### PR TITLE
👷 build(package): publish types on releases of this package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "Gregor Martynus (https://github.com/gr2m)",
   "license": "MIT",
   "files": [
+    "index.d.ts",
     "index.json"
   ]
 }


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
To publish `index.d.ts` on future releases of this package.

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To have types of webhook examples available when consuming this package with TypeScript.
After adding `index.d.ts` file (77c7cd49a08bfb917ed4bd74364de866351e13f6), it was not added to be published.