### PR TITLE
📦 refactor(ping-webhook): replace 'example' for 'examples' for consistency with the resto webhooks

### DIFF
--- a/index.json
+++ b/index.json
@@ -7870,7 +7870,7 @@
   {
     "name": "ping",
     "actions": [],
-    "example": [
+    "examples": [
       {
         "event": "ping",
         "payload": {

--- a/lib/get-ping-webhook.js
+++ b/lib/get-ping-webhook.js
@@ -8,7 +8,7 @@ function getPingWebhook () {
   return {
     name: 'ping',
     actions: [],
-    example: [{
+    examples: [{
       event: 'ping',
       payload: {
         zen: 'Design for failure.',


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Replace `"example"` property for `"examples"` on `ping` webhook

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To have consistency between properties on each webhook for [TypeScript migration](https://github.com/octokit/webhooks.js/pull/113)

## 📚 References:
<!-- Any interesting external link to documentation, article, tweet which can add value to the PR -->
* TypeScript migration: https://github.com/octokit/webhooks.js/pull/113