### PR TITLE
🐛 fix(type-declaration): export WebhookDefinition type for external usage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,8 @@
-type WebhookDefinition = {
-  name: string,
-  actions: string[],
-  examples: object[]
+type WebhookExample = {
+  [key: string]: any
+}
+export type WebhookDefinition = {
+  name: string;
+  actions: string[];
+  examples: WebhookExample[];
 }


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- Export `type WebhookDefinition` for usage on third party projects

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [This migration](https://github.com/octokit/webhooks.js/pull/113) needs WebhookDefinition types exposed.
* Blocked by https://github.com/octokit/webhooks/pull/82 to avoid problems of `examples` 🆚 `example` property on `type WebhookDefinition`
![image](https://user-images.githubusercontent.com/2574275/79022583-9559af80-7b7e-11ea-8efc-489627c72d56.png)

## 📚 References:
<!-- Any interesting external link to documentation, article, tweet which can add value to the PR -->
* TypeScript migration of webhooks.js: https://github.com/octokit/webhooks.js/pull/113