### PR TITLE
feat: `installation.{suspend,unsuspend}`

### DIFF
--- a/cache/event-types-and-payloads.html
+++ b/cache/event-types-and-payloads.html
@@ -3061,7 +3061,15 @@ You cannot create webhooks that listen to these events.</p>
 <h2>
 <a id="installationevent" class="anchor" href="#installationevent" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>InstallationEvent</h2>
 
-<p>Triggered when someone installs (<code>created</code>) , uninstalls (<code>deleted</code>), or accepts new permissions (<code>new_permissions_accepted</code>) for a GitHub App. When a GitHub App owner requests new permissions, the person who installed the GitHub App must accept the new permissions request.</p>
+<p>Triggered when someone installs (<code>created</code>) , uninstalls (<code>deleted</code>), suspends (<code>suspend</code>), unsuspends (<code>unsuspend</code>), or accepts new permissions (<code>new_permissions_accepted</code>) for a GitHub App. When a GitHub App owner requests new permissions, the person who installed the GitHub App must accept the new permissions request.</p>
+
+<div class="alert note">
+
+<p><strong>Note:</strong> 
+Suspending a GitHub App installation is currently in beta and subject to change. Before you can suspend a GitHub App, the app owner must enable suspending installations for the app by opting-in to the beta.
+ For more information, see "<a href="/apps/managing-github-apps/suspending-a-github-app-installation/">Suspending a GitHub App installation</a>."</p>
+
+</div>
 
 <h3>
 <a id="events-api-payload-13" class="anchor" href="#events-api-payload-13" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Events API payload</h3>
@@ -3078,7 +3086,7 @@ You cannot create webhooks that listen to these events.</p>
 <tr>
 <td><code>action</code></td>
 <td><code>string</code></td>
-<td>The action that was performed. Can be one of <code>created</code>, <code>deleted</code>, or <code>new_permissions_accepted</code>.</td>
+<td>The action that was performed. Can be one of <code>created</code>, <code>deleted</code>, <code>suspend</code>, <code>unsuspend</code>, or <code>new_permissions_accepted</code>.</td>
 </tr>
 <tr>
 <td><code>installation</code></td>
@@ -4252,14 +4260,14 @@ You cannot create webhooks that listen to these events.</p>
 </thead>
 <tbody>
 <tr>
-<td><code>member</code></td>
-<td><code>object</code></td>
-<td>The <a href="/v3/users/">user</a> that was added.</td>
-</tr>
-<tr>
 <td><code>action</code></td>
 <td><code>string</code></td>
 <td>The action that was performed. Can be one of <code>added</code>, <code>removed</code>, or <code>edited</code>.</td>
+</tr>
+<tr>
+<td><code>member</code></td>
+<td><code>object</code></td>
+<td>The <a href="/v3/users/">user</a> that was added.</td>
 </tr>
 <tr>
 <td><code>changes</code></td>

--- a/index.json
+++ b/index.json
@@ -4795,7 +4795,9 @@
     "actions": [
       "created",
       "deleted",
-      "new_permissions_accepted"
+      "new_permissions_accepted",
+      "suspend",
+      "unsuspend"
     ],
     "examples": [
       {

--- a/lib/workarounds.js
+++ b/lib/workarounds.js
@@ -15,13 +15,5 @@ function workarounds (webhooks) {
 
       webhook.actions = webhook.actions.concat('synchronize').sort()
     }
-
-    if (webhook.name === 'member') {
-      if (webhook.actions.includes('removed')) {
-        throw new Error('Remove workaround that adds "removed" action to "member" event')
-      }
-
-      webhook.actions = webhook.actions.concat('removed').sort()
-    }
   })
 }


### PR DESCRIPTION
This PR removes a workaround, now that the issue has been resolved on GitHub's side.

```
$ ./bin/octokit-webhooks.js check         
⌛  fetching https://developer.github.com/v3/activity/events/types/
Error: Remove workaround that adds "removed" action to "member" event
    at /Users/z/git/octokit/webhooks/lib/workarounds.js:21:15
    at Array.forEach (<anonymous>)
    at workarounds (/Users/z/git/octokit/webhooks/lib/workarounds.js:10:12)
    at checkOrUpdateWebhooks (/Users/z/git/octokit/webhooks/lib/check-or-update-webhooks.js:40:3)
```