### PR TITLE
fix: remove sample inputs from `workflow_dispatch` webhook

### DIFF
--- a/index.json
+++ b/index.json
@@ -24171,9 +24171,7 @@
     "actions": [],
     "examples": [
       {
-        "inputs": {
-          "name": "Mona the Octocat"
-        },
+        "inputs": {},
         "ref": "refs/heads/master",
         "repository": {
           "id": 17273051,
@@ -24305,9 +24303,7 @@
         "workflow": ".github/workflows/hello-world-workflow.yml"
       },
       {
-        "inputs": {
-          "name": "Mona the Octocat"
-        },
+        "inputs": {},
         "ref": "refs/heads/master",
         "repository": {
           "id": 17273051,

--- a/lib/check-or-update-webhooks.js
+++ b/lib/check-or-update-webhooks.js
@@ -6,6 +6,7 @@ const prettier = require("prettier");
 
 const createPrOnChange = require("./create-pr-on-change");
 const getHtml = require("./get-html");
+const applyWorkarounds = require("./workarounds");
 const getSections = require("./get-sections");
 const toWebhook = require("./section-to-webhook");
 const getActionsAndExamplesFromPayloads = require("./get-actions-and-examples-from-payloads");
@@ -41,6 +42,8 @@ async function checkOrUpdateWebhooks({ cached, checkOnly }) {
       examples: webhook.examples.concat(webhookFromPayloadExamples.examples),
     };
   });
+
+  applyWorkarounds(webhooks);
 
   const currentWebhooks = require("../index.json");
 

--- a/lib/workarounds.js
+++ b/lib/workarounds.js
@@ -1,0 +1,11 @@
+module.exports = workarounds;
+
+function workarounds(webhooks) {
+  webhooks.forEach((webhook) => {
+    if (webhook.name === "workflow_dispatch") {
+      webhook.examples.forEach((example) => {
+        example.inputs = {};
+      });
+    }
+  });
+}


### PR DESCRIPTION
Hey 🙂 

I've added a workaround to clear the `inputs` object in the `workflow_dispatch` event, since it does not have a fixed shape. Sorry I haven't done it [in my previous PR](https://github.com/octokit/webhooks/pull/134), somehow it hasn't caught my eye.