### PR TITLE
fix: add installation object to pull_request_review and pull_request_review_comment events

### DIFF
--- a/index.json
+++ b/index.json
@@ -18535,6 +18535,10 @@
           "received_events_url": "https://api.github.com/users/Codertocat/received_events",
           "type": "User",
           "site_admin": false
+        },
+        "installation": {
+          "id": 1,
+          "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMQ=="
         }
       },
       {

--- a/index.json
+++ b/index.json
@@ -18535,10 +18535,6 @@
           "received_events_url": "https://api.github.com/users/Codertocat/received_events",
           "type": "User",
           "site_admin": false
-        },
-        "installation": {
-          "id": 1,
-          "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMQ=="
         }
       },
       {

--- a/index.json
+++ b/index.json
@@ -19006,6 +19006,10 @@
           "received_events_url": "https://api.github.com/users/Codertocat/received_events",
           "type": "User",
           "site_admin": false
+        },
+        "installation": {
+          "id": 1,
+          "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMQ=="
         }
       }
     ]
@@ -19963,6 +19967,10 @@
           "open_issues": 2,
           "watchers": 0,
           "default_branch": "master"
+        },
+        "installation": {
+          "id": 1,
+          "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMQ=="
         },
         "sender": {
           "login": "Codertocat",

--- a/payload-examples/api.github.com/pull_request_review.submitted.payload.json
+++ b/payload-examples/api.github.com/pull_request_review.submitted.payload.json
@@ -467,5 +467,9 @@
     "received_events_url": "https://api.github.com/users/Codertocat/received_events",
     "type": "User",
     "site_admin": false
+  },
+  "installation": {
+    "id": 1,
+    "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMQ=="
   }
 }

--- a/payload-examples/api.github.com/pull_request_review_comment.created.payload.json
+++ b/payload-examples/api.github.com/pull_request_review_comment.created.payload.json
@@ -458,6 +458,10 @@
     "watchers": 0,
     "default_branch": "master"
   },
+  "installation": {
+    "id": 1,
+    "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMQ=="
+  },
   "sender": {
     "login": "Codertocat",
     "id": 21031067,


### PR DESCRIPTION
The pull request review payloa has an installation object as defined here: https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#pull_request_review

Adding this will end up fixing the typescript definitions