### PR TITLE
fix: add missing example for check_run.requested_action

### DIFF
--- a/index.json
+++ b/index.json
@@ -1592,6 +1592,318 @@
         }
       },
       {
+        "action": "requested_action",
+        "check_run": {
+          "id": 1494503112,
+          "node_id": "MDg6Q2hlY2tSdW4xNDk0NTAzMTEy",
+          "head_sha": "5bd5f196a46b8222fb7484f05faba41a73cf34bd",
+          "external_id": "",
+          "url": "https://api.github.com/repos/electron/electron/check-runs/1494503112",
+          "html_url": "https://github.com/electron/electron/runs/1494503112",
+          "details_url": "https://github.com/electron/cation",
+          "status": "in_progress",
+          "conclusion": null,
+          "started_at": "2020-12-03T18:27:27Z",
+          "completed_at": null,
+          "output": {
+            "title": "Pending",
+            "summary": "<!-- ||  {\"approved\":[\"MarshallOfSound\",\"nornagon\"],\"declined\":[],\"requestedChanges\":[]}  || -->\n#### Approved\n\n* @MarshallOfSound \n ,* @nornagon \n \n",
+            "text": null,
+            "annotations_count": 0,
+            "annotations_url": "https://api.github.com/repos/electron/electron/check-runs/1494503112/annotations"
+          },
+          "name": "API Review",
+          "check_suite": {
+            "id": 1604239627,
+            "node_id": "MDEwOkNoZWNrU3VpdGUxNjA0MjM5NjI3",
+            "head_branch": "miniak/event-process-id",
+            "head_sha": "5bd5f196a46b8222fb7484f05faba41a73cf34bd",
+            "status": "in_progress",
+            "conclusion": null,
+            "url": "https://api.github.com/repos/electron/electron/check-suites/1604239627",
+            "before": "0cac7e27ee4c1d949ae4418899e5d5f206e393f6",
+            "after": "5bd5f196a46b8222fb7484f05faba41a73cf34bd",
+            "pull_requests": [
+              {
+                "url": "https://api.github.com/repos/electron/electron/pulls/26764",
+                "id": 530493071,
+                "number": 26764,
+                "head": {
+                  "ref": "miniak/event-process-id",
+                  "sha": "5bd5f196a46b8222fb7484f05faba41a73cf34bd",
+                  "repo": {
+                    "id": 9384267,
+                    "url": "https://api.github.com/repos/electron/electron",
+                    "name": "electron"
+                  }
+                },
+                "base": {
+                  "ref": "master",
+                  "sha": "45eee468647309e9e6cdb2a88a3b460a59771fef",
+                  "repo": {
+                    "id": 9384267,
+                    "url": "https://api.github.com/repos/electron/electron",
+                    "name": "electron"
+                  }
+                }
+              }
+            ],
+            "app": {
+              "id": 25811,
+              "slug": "electron-cation",
+              "node_id": "MDM6QXBwMjU4MTE=",
+              "owner": {
+                "login": "electron",
+                "id": 13409222,
+                "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+                "avatar_url": "https://avatars1.githubusercontent.com/u/13409222?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/electron",
+                "html_url": "https://github.com/electron",
+                "followers_url": "https://api.github.com/users/electron/followers",
+                "following_url": "https://api.github.com/users/electron/following{/other_user}",
+                "gists_url": "https://api.github.com/users/electron/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/electron/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/electron/subscriptions",
+                "organizations_url": "https://api.github.com/users/electron/orgs",
+                "repos_url": "https://api.github.com/users/electron/repos",
+                "events_url": "https://api.github.com/users/electron/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/electron/received_events",
+                "type": "Organization",
+                "site_admin": false
+              },
+              "name": "Electron Cation",
+              "description": "",
+              "external_url": "https://github.com/electron/cation",
+              "html_url": "https://github.com/apps/electron-cation",
+              "created_at": "2019-02-21T17:22:19Z",
+              "updated_at": "2020-12-03T18:28:52Z",
+              "permissions": {
+                "checks": "write",
+                "members": "read",
+                "metadata": "read",
+                "pull_requests": "write"
+              },
+              "events": [
+                "pull_request",
+                "pull_request_review",
+                "pull_request_review_comment"
+              ]
+            },
+            "created_at": "2020-12-03T17:29:21Z",
+            "updated_at": "2020-12-03T18:27:27Z"
+          },
+          "app": {
+            "id": 25811,
+            "slug": "electron-cation",
+            "node_id": "MDM6QXBwMjU4MTE=",
+            "owner": {
+              "login": "electron",
+              "id": 13409222,
+              "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+              "avatar_url": "https://avatars1.githubusercontent.com/u/13409222?v=4",
+              "gravatar_id": "",
+              "url": "https://api.github.com/users/electron",
+              "html_url": "https://github.com/electron",
+              "followers_url": "https://api.github.com/users/electron/followers",
+              "following_url": "https://api.github.com/users/electron/following{/other_user}",
+              "gists_url": "https://api.github.com/users/electron/gists{/gist_id}",
+              "starred_url": "https://api.github.com/users/electron/starred{/owner}{/repo}",
+              "subscriptions_url": "https://api.github.com/users/electron/subscriptions",
+              "organizations_url": "https://api.github.com/users/electron/orgs",
+              "repos_url": "https://api.github.com/users/electron/repos",
+              "events_url": "https://api.github.com/users/electron/events{/privacy}",
+              "received_events_url": "https://api.github.com/users/electron/received_events",
+              "type": "Organization",
+              "site_admin": false
+            },
+            "name": "Electron Cation",
+            "description": "",
+            "external_url": "https://github.com/electron/cation",
+            "html_url": "https://github.com/apps/electron-cation",
+            "created_at": "2019-02-21T17:22:19Z",
+            "updated_at": "2020-12-03T18:28:52Z",
+            "permissions": {
+              "checks": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "write"
+            },
+            "events": [
+              "pull_request",
+              "pull_request_review",
+              "pull_request_review_comment"
+            ]
+          },
+          "pull_requests": [
+            {
+              "url": "https://api.github.com/repos/electron/electron/pulls/26764",
+              "id": 530493071,
+              "number": 26764,
+              "head": {
+                "ref": "miniak/event-process-id",
+                "sha": "5bd5f196a46b8222fb7484f05faba41a73cf34bd",
+                "repo": {
+                  "id": 9384267,
+                  "url": "https://api.github.com/repos/electron/electron",
+                  "name": "electron"
+                }
+              },
+              "base": {
+                "ref": "master",
+                "sha": "45eee468647309e9e6cdb2a88a3b460a59771fef",
+                "repo": {
+                  "id": 9384267,
+                  "url": "https://api.github.com/repos/electron/electron",
+                  "name": "electron"
+                }
+              }
+            }
+          ]
+        },
+        "requested_action": {
+          "identifier": "lgtm|26764"
+        },
+        "repository": {
+          "id": 9384267,
+          "node_id": "MDEwOlJlcG9zaXRvcnk5Mzg0MjY3",
+          "name": "electron",
+          "full_name": "electron/electron",
+          "private": false,
+          "owner": {
+            "login": "electron",
+            "id": 13409222,
+            "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/13409222?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/electron",
+            "html_url": "https://github.com/electron",
+            "followers_url": "https://api.github.com/users/electron/followers",
+            "following_url": "https://api.github.com/users/electron/following{/other_user}",
+            "gists_url": "https://api.github.com/users/electron/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/electron/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/electron/subscriptions",
+            "organizations_url": "https://api.github.com/users/electron/orgs",
+            "repos_url": "https://api.github.com/users/electron/repos",
+            "events_url": "https://api.github.com/users/electron/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/electron/received_events",
+            "type": "Organization",
+            "site_admin": false
+          },
+          "html_url": "https://github.com/electron/electron",
+          "description": ":electron: Build cross-platform desktop apps with JavaScript, HTML, and CSS",
+          "fork": false,
+          "url": "https://api.github.com/repos/electron/electron",
+          "forks_url": "https://api.github.com/repos/electron/electron/forks",
+          "keys_url": "https://api.github.com/repos/electron/electron/keys{/key_id}",
+          "collaborators_url": "https://api.github.com/repos/electron/electron/collaborators{/collaborator}",
+          "teams_url": "https://api.github.com/repos/electron/electron/teams",
+          "hooks_url": "https://api.github.com/repos/electron/electron/hooks",
+          "issue_events_url": "https://api.github.com/repos/electron/electron/issues/events{/number}",
+          "events_url": "https://api.github.com/repos/electron/electron/events",
+          "assignees_url": "https://api.github.com/repos/electron/electron/assignees{/user}",
+          "branches_url": "https://api.github.com/repos/electron/electron/branches{/branch}",
+          "tags_url": "https://api.github.com/repos/electron/electron/tags",
+          "blobs_url": "https://api.github.com/repos/electron/electron/git/blobs{/sha}",
+          "git_tags_url": "https://api.github.com/repos/electron/electron/git/tags{/sha}",
+          "git_refs_url": "https://api.github.com/repos/electron/electron/git/refs{/sha}",
+          "trees_url": "https://api.github.com/repos/electron/electron/git/trees{/sha}",
+          "statuses_url": "https://api.github.com/repos/electron/electron/statuses/{sha}",
+          "languages_url": "https://api.github.com/repos/electron/electron/languages",
+          "stargazers_url": "https://api.github.com/repos/electron/electron/stargazers",
+          "contributors_url": "https://api.github.com/repos/electron/electron/contributors",
+          "subscribers_url": "https://api.github.com/repos/electron/electron/subscribers",
+          "subscription_url": "https://api.github.com/repos/electron/electron/subscription",
+          "commits_url": "https://api.github.com/repos/electron/electron/commits{/sha}",
+          "git_commits_url": "https://api.github.com/repos/electron/electron/git/commits{/sha}",
+          "comments_url": "https://api.github.com/repos/electron/electron/comments{/number}",
+          "issue_comment_url": "https://api.github.com/repos/electron/electron/issues/comments{/number}",
+          "contents_url": "https://api.github.com/repos/electron/electron/contents/{+path}",
+          "compare_url": "https://api.github.com/repos/electron/electron/compare/{base}...{head}",
+          "merges_url": "https://api.github.com/repos/electron/electron/merges",
+          "archive_url": "https://api.github.com/repos/electron/electron/{archive_format}{/ref}",
+          "downloads_url": "https://api.github.com/repos/electron/electron/downloads",
+          "issues_url": "https://api.github.com/repos/electron/electron/issues{/number}",
+          "pulls_url": "https://api.github.com/repos/electron/electron/pulls{/number}",
+          "milestones_url": "https://api.github.com/repos/electron/electron/milestones{/number}",
+          "notifications_url": "https://api.github.com/repos/electron/electron/notifications{?since,all,participating}",
+          "labels_url": "https://api.github.com/repos/electron/electron/labels{/name}",
+          "releases_url": "https://api.github.com/repos/electron/electron/releases{/id}",
+          "deployments_url": "https://api.github.com/repos/electron/electron/deployments",
+          "created_at": "2013-04-12T01:47:36Z",
+          "updated_at": "2020-12-03T19:29:46Z",
+          "pushed_at": "2020-12-03T18:54:41Z",
+          "git_url": "git://github.com/electron/electron.git",
+          "ssh_url": "git@github.com:electron/electron.git",
+          "clone_url": "https://github.com/electron/electron.git",
+          "svn_url": "https://github.com/electron/electron",
+          "homepage": "https://electronjs.org",
+          "size": 87727,
+          "stargazers_count": 87864,
+          "watchers_count": 87864,
+          "language": "C++",
+          "has_issues": true,
+          "has_projects": true,
+          "has_downloads": true,
+          "has_wiki": false,
+          "has_pages": false,
+          "forks_count": 11745,
+          "mirror_url": null,
+          "archived": false,
+          "disabled": false,
+          "open_issues_count": 1504,
+          "license": {
+            "key": "mit",
+            "name": "MIT License",
+            "spdx_id": "MIT",
+            "url": "https://api.github.com/licenses/mit",
+            "node_id": "MDc6TGljZW5zZTEz"
+          },
+          "forks": 11745,
+          "open_issues": 1504,
+          "watchers": 87864,
+          "default_branch": "master"
+        },
+        "organization": {
+          "login": "electron",
+          "id": 13409222,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+          "url": "https://api.github.com/orgs/electron",
+          "repos_url": "https://api.github.com/orgs/electron/repos",
+          "events_url": "https://api.github.com/orgs/electron/events",
+          "hooks_url": "https://api.github.com/orgs/electron/hooks",
+          "issues_url": "https://api.github.com/orgs/electron/issues",
+          "members_url": "https://api.github.com/orgs/electron/members{/member}",
+          "public_members_url": "https://api.github.com/orgs/electron/public_members{/member}",
+          "avatar_url": "https://avatars1.githubusercontent.com/u/13409222?v=4",
+          "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS"
+        },
+        "sender": {
+          "login": "codebytere",
+          "id": 2036040,
+          "node_id": "MDQ6VXNlcjIwMzYwNDA=",
+          "avatar_url": "https://avatars2.githubusercontent.com/u/2036040?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/codebytere",
+          "html_url": "https://github.com/codebytere",
+          "followers_url": "https://api.github.com/users/codebytere/followers",
+          "following_url": "https://api.github.com/users/codebytere/following{/other_user}",
+          "gists_url": "https://api.github.com/users/codebytere/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/codebytere/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/codebytere/subscriptions",
+          "organizations_url": "https://api.github.com/users/codebytere/orgs",
+          "repos_url": "https://api.github.com/users/codebytere/repos",
+          "events_url": "https://api.github.com/users/codebytere/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/codebytere/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "installation": {
+          "id": 690857,
+          "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uNjkwODU3"
+        }
+      },
+      {
         "action": "rerequested",
         "check_run": {
           "id": 4,

--- a/payload-examples/api.github.com/check_run.requested_action.payload.json
+++ b/payload-examples/api.github.com/check_run.requested_action.payload.json
@@ -1,0 +1,312 @@
+{
+  "action": "requested_action",
+  "check_run": {
+    "id": 1494503112,
+    "node_id": "MDg6Q2hlY2tSdW4xNDk0NTAzMTEy",
+    "head_sha": "5bd5f196a46b8222fb7484f05faba41a73cf34bd",
+    "external_id": "",
+    "url": "https://api.github.com/repos/electron/electron/check-runs/1494503112",
+    "html_url": "https://github.com/electron/electron/runs/1494503112",
+    "details_url": "https://github.com/electron/cation",
+    "status": "in_progress",
+    "conclusion": null,
+    "started_at": "2020-12-03T18:27:27Z",
+    "completed_at": null,
+    "output": {
+      "title": "Pending",
+      "summary": "<!-- ||  {\"approved\":[\"MarshallOfSound\",\"nornagon\"],\"declined\":[],\"requestedChanges\":[]}  || -->\n#### Approved\n\n* @MarshallOfSound \n ,* @nornagon \n \n",
+      "text": null,
+      "annotations_count": 0,
+      "annotations_url": "https://api.github.com/repos/electron/electron/check-runs/1494503112/annotations"
+    },
+    "name": "API Review",
+    "check_suite": {
+      "id": 1604239627,
+      "node_id": "MDEwOkNoZWNrU3VpdGUxNjA0MjM5NjI3",
+      "head_branch": "miniak/event-process-id",
+      "head_sha": "5bd5f196a46b8222fb7484f05faba41a73cf34bd",
+      "status": "in_progress",
+      "conclusion": null,
+      "url": "https://api.github.com/repos/electron/electron/check-suites/1604239627",
+      "before": "0cac7e27ee4c1d949ae4418899e5d5f206e393f6",
+      "after": "5bd5f196a46b8222fb7484f05faba41a73cf34bd",
+      "pull_requests": [
+        {
+          "url": "https://api.github.com/repos/electron/electron/pulls/26764",
+          "id": 530493071,
+          "number": 26764,
+          "head": {
+            "ref": "miniak/event-process-id",
+            "sha": "5bd5f196a46b8222fb7484f05faba41a73cf34bd",
+            "repo": {
+              "id": 9384267,
+              "url": "https://api.github.com/repos/electron/electron",
+              "name": "electron"
+            }
+          },
+          "base": {
+            "ref": "master",
+            "sha": "45eee468647309e9e6cdb2a88a3b460a59771fef",
+            "repo": {
+              "id": 9384267,
+              "url": "https://api.github.com/repos/electron/electron",
+              "name": "electron"
+            }
+          }
+        }
+      ],
+      "app": {
+        "id": 25811,
+        "slug": "electron-cation",
+        "node_id": "MDM6QXBwMjU4MTE=",
+        "owner": {
+          "login": "electron",
+          "id": 13409222,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+          "avatar_url": "https://avatars1.githubusercontent.com/u/13409222?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/electron",
+          "html_url": "https://github.com/electron",
+          "followers_url": "https://api.github.com/users/electron/followers",
+          "following_url": "https://api.github.com/users/electron/following{/other_user}",
+          "gists_url": "https://api.github.com/users/electron/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/electron/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/electron/subscriptions",
+          "organizations_url": "https://api.github.com/users/electron/orgs",
+          "repos_url": "https://api.github.com/users/electron/repos",
+          "events_url": "https://api.github.com/users/electron/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/electron/received_events",
+          "type": "Organization",
+          "site_admin": false
+        },
+        "name": "Electron Cation",
+        "description": "",
+        "external_url": "https://github.com/electron/cation",
+        "html_url": "https://github.com/apps/electron-cation",
+        "created_at": "2019-02-21T17:22:19Z",
+        "updated_at": "2020-12-03T18:28:52Z",
+        "permissions": {
+          "checks": "write",
+          "members": "read",
+          "metadata": "read",
+          "pull_requests": "write"
+        },
+        "events": [
+          "pull_request",
+          "pull_request_review",
+          "pull_request_review_comment"
+        ]
+      },
+      "created_at": "2020-12-03T17:29:21Z",
+      "updated_at": "2020-12-03T18:27:27Z"
+    },
+    "app": {
+      "id": 25811,
+      "slug": "electron-cation",
+      "node_id": "MDM6QXBwMjU4MTE=",
+      "owner": {
+        "login": "electron",
+        "id": 13409222,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+        "avatar_url": "https://avatars1.githubusercontent.com/u/13409222?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/electron",
+        "html_url": "https://github.com/electron",
+        "followers_url": "https://api.github.com/users/electron/followers",
+        "following_url": "https://api.github.com/users/electron/following{/other_user}",
+        "gists_url": "https://api.github.com/users/electron/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/electron/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/electron/subscriptions",
+        "organizations_url": "https://api.github.com/users/electron/orgs",
+        "repos_url": "https://api.github.com/users/electron/repos",
+        "events_url": "https://api.github.com/users/electron/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/electron/received_events",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "name": "Electron Cation",
+      "description": "",
+      "external_url": "https://github.com/electron/cation",
+      "html_url": "https://github.com/apps/electron-cation",
+      "created_at": "2019-02-21T17:22:19Z",
+      "updated_at": "2020-12-03T18:28:52Z",
+      "permissions": {
+        "checks": "write",
+        "members": "read",
+        "metadata": "read",
+        "pull_requests": "write"
+      },
+      "events": [
+        "pull_request",
+        "pull_request_review",
+        "pull_request_review_comment"
+      ]
+    },
+    "pull_requests": [
+      {
+        "url": "https://api.github.com/repos/electron/electron/pulls/26764",
+        "id": 530493071,
+        "number": 26764,
+        "head": {
+          "ref": "miniak/event-process-id",
+          "sha": "5bd5f196a46b8222fb7484f05faba41a73cf34bd",
+          "repo": {
+            "id": 9384267,
+            "url": "https://api.github.com/repos/electron/electron",
+            "name": "electron"
+          }
+        },
+        "base": {
+          "ref": "master",
+          "sha": "45eee468647309e9e6cdb2a88a3b460a59771fef",
+          "repo": {
+            "id": 9384267,
+            "url": "https://api.github.com/repos/electron/electron",
+            "name": "electron"
+          }
+        }
+      }
+    ]
+  },
+  "requested_action": {
+    "identifier": "lgtm|26764"
+  },
+  "repository": {
+    "id": 9384267,
+    "node_id": "MDEwOlJlcG9zaXRvcnk5Mzg0MjY3",
+    "name": "electron",
+    "full_name": "electron/electron",
+    "private": false,
+    "owner": {
+      "login": "electron",
+      "id": 13409222,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/13409222?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/electron",
+      "html_url": "https://github.com/electron",
+      "followers_url": "https://api.github.com/users/electron/followers",
+      "following_url": "https://api.github.com/users/electron/following{/other_user}",
+      "gists_url": "https://api.github.com/users/electron/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/electron/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/electron/subscriptions",
+      "organizations_url": "https://api.github.com/users/electron/orgs",
+      "repos_url": "https://api.github.com/users/electron/repos",
+      "events_url": "https://api.github.com/users/electron/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/electron/received_events",
+      "type": "Organization",
+      "site_admin": false
+    },
+    "html_url": "https://github.com/electron/electron",
+    "description": ":electron: Build cross-platform desktop apps with JavaScript, HTML, and CSS",
+    "fork": false,
+    "url": "https://api.github.com/repos/electron/electron",
+    "forks_url": "https://api.github.com/repos/electron/electron/forks",
+    "keys_url": "https://api.github.com/repos/electron/electron/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/electron/electron/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/electron/electron/teams",
+    "hooks_url": "https://api.github.com/repos/electron/electron/hooks",
+    "issue_events_url": "https://api.github.com/repos/electron/electron/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/electron/electron/events",
+    "assignees_url": "https://api.github.com/repos/electron/electron/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/electron/electron/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/electron/electron/tags",
+    "blobs_url": "https://api.github.com/repos/electron/electron/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/electron/electron/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/electron/electron/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/electron/electron/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/electron/electron/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/electron/electron/languages",
+    "stargazers_url": "https://api.github.com/repos/electron/electron/stargazers",
+    "contributors_url": "https://api.github.com/repos/electron/electron/contributors",
+    "subscribers_url": "https://api.github.com/repos/electron/electron/subscribers",
+    "subscription_url": "https://api.github.com/repos/electron/electron/subscription",
+    "commits_url": "https://api.github.com/repos/electron/electron/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/electron/electron/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/electron/electron/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/electron/electron/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/electron/electron/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/electron/electron/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/electron/electron/merges",
+    "archive_url": "https://api.github.com/repos/electron/electron/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/electron/electron/downloads",
+    "issues_url": "https://api.github.com/repos/electron/electron/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/electron/electron/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/electron/electron/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/electron/electron/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/electron/electron/labels{/name}",
+    "releases_url": "https://api.github.com/repos/electron/electron/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/electron/electron/deployments",
+    "created_at": "2013-04-12T01:47:36Z",
+    "updated_at": "2020-12-03T19:29:46Z",
+    "pushed_at": "2020-12-03T18:54:41Z",
+    "git_url": "git://github.com/electron/electron.git",
+    "ssh_url": "git@github.com:electron/electron.git",
+    "clone_url": "https://github.com/electron/electron.git",
+    "svn_url": "https://github.com/electron/electron",
+    "homepage": "https://electronjs.org",
+    "size": 87727,
+    "stargazers_count": 87864,
+    "watchers_count": 87864,
+    "language": "C++",
+    "has_issues": true,
+    "has_projects": true,
+    "has_downloads": true,
+    "has_wiki": false,
+    "has_pages": false,
+    "forks_count": 11745,
+    "mirror_url": null,
+    "archived": false,
+    "disabled": false,
+    "open_issues_count": 1504,
+    "license": {
+      "key": "mit",
+      "name": "MIT License",
+      "spdx_id": "MIT",
+      "url": "https://api.github.com/licenses/mit",
+      "node_id": "MDc6TGljZW5zZTEz"
+    },
+    "forks": 11745,
+    "open_issues": 1504,
+    "watchers": 87864,
+    "default_branch": "master"
+  },
+  "organization": {
+    "login": "electron",
+    "id": 13409222,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjEzNDA5MjIy",
+    "url": "https://api.github.com/orgs/electron",
+    "repos_url": "https://api.github.com/orgs/electron/repos",
+    "events_url": "https://api.github.com/orgs/electron/events",
+    "hooks_url": "https://api.github.com/orgs/electron/hooks",
+    "issues_url": "https://api.github.com/orgs/electron/issues",
+    "members_url": "https://api.github.com/orgs/electron/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/electron/public_members{/member}",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/13409222?v=4",
+    "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS"
+  },
+  "sender": {
+    "login": "codebytere",
+    "id": 2036040,
+    "node_id": "MDQ6VXNlcjIwMzYwNDA=",
+    "avatar_url": "https://avatars2.githubusercontent.com/u/2036040?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/codebytere",
+    "html_url": "https://github.com/codebytere",
+    "followers_url": "https://api.github.com/users/codebytere/followers",
+    "following_url": "https://api.github.com/users/codebytere/following{/other_user}",
+    "gists_url": "https://api.github.com/users/codebytere/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/codebytere/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/codebytere/subscriptions",
+    "organizations_url": "https://api.github.com/users/codebytere/orgs",
+    "repos_url": "https://api.github.com/users/codebytere/repos",
+    "events_url": "https://api.github.com/users/codebytere/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/codebytere/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "installation": {
+    "id": 690857,
+    "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uNjkwODU3"
+  }
+}


### PR DESCRIPTION
This PR adds a missing payload example for [check_run.requested_action](https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#check_run). I copied existing approaches from the repo but please let me know if i'm missing anything!

cc @gr2m