### PR TITLE
chore: add prettier config

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "prettier --check '{bin,lib}/*.js' '*.{js,md}' 'payload-examples/**/*.json' *.md package.json index.json",
     "lint:fix": "prettier --write '{bin,lib}/*.js' '*.{js,md}' 'payload-examples/**/*.json' *.md package.json index.json"
   },
+  "prettier": {},
   "repository": "https://github.com/octokit/webhooks",
   "keywords": [],
   "author": "Gregor Martynus (https://github.com/gr2m)",


### PR DESCRIPTION
This ensures that the default prettier settings are used for this repo - i.e I've got [my default `.prettierrc`](https://github.com/ackama/prettier-config-ackama) in my home directory, which means without this in the repo running prettier uses that.