### PR TITLE
fix(deps): move `prettier` to `devDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5777,7 +5777,8 @@
     "prettier": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q=="
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "execa": "^5.0.0",
     "fs-extra": "^9.0.0",
     "json-diff": "^0.5.3",
+    "prettier": "^2.0.5",
     "semantic-release": "^17.0.0",
     "turndown": "^7.0.0",
     "yargs": "^16.0.0"
@@ -31,8 +32,5 @@
   "files": [
     "index.d.ts",
     "index.json"
-  ],
-  "dependencies": {
-    "prettier": "^2.0.5"
-  }
+  ]
 }


### PR DESCRIPTION
Prettier is not used by this project at "runtime", so it's only needed for deving.