### PR TITLE
fix: use `oneOf` for nullable types

### DIFF
--- a/payload-schemas/schemas/check_run.schema.json
+++ b/payload-schemas/schemas/check_run.schema.json
@@ -722,7 +722,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/check_run.schema.json
+++ b/payload-schemas/schemas/check_run.schema.json
@@ -716,7 +716,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/check_suite.schema.json
+++ b/payload-schemas/schemas/check_suite.schema.json
@@ -444,7 +444,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/check_suite.schema.json
+++ b/payload-schemas/schemas/check_suite.schema.json
@@ -438,7 +438,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/code_scanning_alert.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert.schema.json
@@ -135,7 +135,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/code_scanning_alert.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert.schema.json
@@ -129,7 +129,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/commit_comment.schema.json
+++ b/payload-schemas/schemas/commit_comment.schema.json
@@ -154,7 +154,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/commit_comment.schema.json
+++ b/payload-schemas/schemas/commit_comment.schema.json
@@ -148,7 +148,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/common/installation.schema.json
+++ b/payload-schemas/schemas/common/installation.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "common/installation.schema.json",
-  "type": ["object", "null"],
+  "type": "object",
   "required": ["id", "node_id"],
   "properties": {
     "id": {

--- a/payload-schemas/schemas/common/organization.schema.json
+++ b/payload-schemas/schemas/common/organization.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "common/organization.schema.json",
-  "type": ["object", "null"],
+  "type": "object",
   "required": [
     "login",
     "id",

--- a/payload-schemas/schemas/content_reference.schema.json
+++ b/payload-schemas/schemas/content_reference.schema.json
@@ -33,7 +33,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/content_reference.schema.json
+++ b/payload-schemas/schemas/content_reference.schema.json
@@ -39,7 +39,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/create.schema.json
+++ b/payload-schemas/schemas/create.schema.json
@@ -36,7 +36,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/create.schema.json
+++ b/payload-schemas/schemas/create.schema.json
@@ -30,7 +30,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/delete.schema.json
+++ b/payload-schemas/schemas/delete.schema.json
@@ -16,7 +16,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/delete.schema.json
+++ b/payload-schemas/schemas/delete.schema.json
@@ -22,7 +22,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/deploy_key.schema.json
+++ b/payload-schemas/schemas/deploy_key.schema.json
@@ -53,7 +53,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/deploy_key.schema.json
+++ b/payload-schemas/schemas/deploy_key.schema.json
@@ -47,7 +47,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/deployment.schema.json
+++ b/payload-schemas/schemas/deployment.schema.json
@@ -164,7 +164,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/deployment.schema.json
+++ b/payload-schemas/schemas/deployment.schema.json
@@ -158,7 +158,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/deployment_status.schema.json
+++ b/payload-schemas/schemas/deployment_status.schema.json
@@ -297,7 +297,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/deployment_status.schema.json
+++ b/payload-schemas/schemas/deployment_status.schema.json
@@ -303,7 +303,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/fork.schema.json
+++ b/payload-schemas/schemas/fork.schema.json
@@ -394,7 +394,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/fork.schema.json
+++ b/payload-schemas/schemas/fork.schema.json
@@ -388,7 +388,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/gollum.schema.json
+++ b/payload-schemas/schemas/gollum.schema.json
@@ -54,7 +54,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/gollum.schema.json
+++ b/payload-schemas/schemas/gollum.schema.json
@@ -48,7 +48,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/issue_comment.schema.json
+++ b/payload-schemas/schemas/issue_comment.schema.json
@@ -675,7 +675,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/issue_comment.schema.json
+++ b/payload-schemas/schemas/issue_comment.schema.json
@@ -669,7 +669,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/issues.schema.json
+++ b/payload-schemas/schemas/issues.schema.json
@@ -627,7 +627,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/issues.schema.json
+++ b/payload-schemas/schemas/issues.schema.json
@@ -633,7 +633,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/label.schema.json
+++ b/payload-schemas/schemas/label.schema.json
@@ -49,7 +49,12 @@
         { "type": "null" }
       ]
     },
-    "organization": { "$ref": "common/organization.schema.json" }
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/label.schema.json
+++ b/payload-schemas/schemas/label.schema.json
@@ -43,7 +43,12 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/member.schema.json
+++ b/payload-schemas/schemas/member.schema.json
@@ -93,7 +93,12 @@
       "type": "object"
     },
     "repository": { "$ref": "common/repository.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" },
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/membership.schema.json
+++ b/payload-schemas/schemas/membership.schema.json
@@ -146,7 +146,12 @@
       "additionalProperties": false
     },
     "organization": { "$ref": "common/organization.schema.json" },
-    "installation": { "$ref": "common/installation.schema.json" }
+    "installation": {
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
+    }
   },
   "additionalProperties": false
 }

--- a/payload-schemas/schemas/membership.schema.json
+++ b/payload-schemas/schemas/membership.schema.json
@@ -145,7 +145,12 @@
       },
       "additionalProperties": false
     },
-    "organization": { "$ref": "common/organization.schema.json" },
+    "organization": {
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
+    },
     "installation": {
       "oneOf": [
         { "$ref": "common/installation.schema.json" },

--- a/payload-schemas/schemas/milestone.schema.json
+++ b/payload-schemas/schemas/milestone.schema.json
@@ -171,7 +171,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/milestone.schema.json
+++ b/payload-schemas/schemas/milestone.schema.json
@@ -165,7 +165,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/org_block.schema.json
+++ b/payload-schemas/schemas/org_block.schema.json
@@ -99,7 +99,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/org_block.schema.json
+++ b/payload-schemas/schemas/org_block.schema.json
@@ -93,7 +93,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/organization.schema.json
+++ b/payload-schemas/schemas/organization.schema.json
@@ -124,7 +124,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/organization.schema.json
+++ b/payload-schemas/schemas/organization.schema.json
@@ -118,7 +118,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/package.schema.json
+++ b/payload-schemas/schemas/package.schema.json
@@ -499,7 +499,10 @@
       "$ref": "common/user.schema.json"
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/page_build.schema.json
+++ b/payload-schemas/schemas/page_build.schema.json
@@ -145,7 +145,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/page_build.schema.json
+++ b/payload-schemas/schemas/page_build.schema.json
@@ -139,7 +139,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/ping.schema.json
+++ b/payload-schemas/schemas/ping.schema.json
@@ -108,7 +108,10 @@
       "$ref": "common/user.schema.json"
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/project.schema.json
+++ b/payload-schemas/schemas/project.schema.json
@@ -159,7 +159,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/project.schema.json
+++ b/payload-schemas/schemas/project.schema.json
@@ -153,7 +153,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/project_card.schema.json
+++ b/payload-schemas/schemas/project_card.schema.json
@@ -145,7 +145,10 @@
       "$ref": "common/user.schema.json"
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     },
     "installation": {
       "oneOf": [

--- a/payload-schemas/schemas/project_card.schema.json
+++ b/payload-schemas/schemas/project_card.schema.json
@@ -148,7 +148,10 @@
       "$ref": "common/organization.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/project_column.schema.json
+++ b/payload-schemas/schemas/project_column.schema.json
@@ -56,7 +56,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/project_column.schema.json
+++ b/payload-schemas/schemas/project_column.schema.json
@@ -62,7 +62,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/public.schema.json
+++ b/payload-schemas/schemas/public.schema.json
@@ -18,7 +18,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/public.schema.json
+++ b/payload-schemas/schemas/public.schema.json
@@ -12,7 +12,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/pull_request.schema.json
+++ b/payload-schemas/schemas/pull_request.schema.json
@@ -1769,7 +1769,10 @@
       "$ref": "common/repository.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/pull_request.schema.json
+++ b/payload-schemas/schemas/pull_request.schema.json
@@ -1775,7 +1775,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     },
     "sender": {
       "$ref": "common/user.schema.json"

--- a/payload-schemas/schemas/pull_request_review.schema.json
+++ b/payload-schemas/schemas/pull_request_review.schema.json
@@ -1426,7 +1426,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     },
     "sender": {
       "$ref": "common/user.schema.json"

--- a/payload-schemas/schemas/pull_request_review.schema.json
+++ b/payload-schemas/schemas/pull_request_review.schema.json
@@ -1420,7 +1420,10 @@
       "$ref": "common/repository.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/pull_request_review_comment.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment.schema.json
@@ -1463,7 +1463,10 @@
     },
 
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/pull_request_review_comment.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment.schema.json
@@ -1469,7 +1469,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     },
     "sender": {
       "$ref": "common/user.schema.json"

--- a/payload-schemas/schemas/push.schema.json
+++ b/payload-schemas/schemas/push.schema.json
@@ -71,7 +71,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/push.schema.json
+++ b/payload-schemas/schemas/push.schema.json
@@ -77,7 +77,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/release.schema.json
+++ b/payload-schemas/schemas/release.schema.json
@@ -182,7 +182,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/release.schema.json
+++ b/payload-schemas/schemas/release.schema.json
@@ -188,7 +188,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/repository.schema.json
+++ b/payload-schemas/schemas/repository.schema.json
@@ -31,7 +31,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/repository.schema.json
+++ b/payload-schemas/schemas/repository.schema.json
@@ -37,7 +37,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/repository_dispatch.schema.json
+++ b/payload-schemas/schemas/repository_dispatch.schema.json
@@ -31,7 +31,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/repository_dispatch.schema.json
+++ b/payload-schemas/schemas/repository_dispatch.schema.json
@@ -37,7 +37,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/repository_import.schema.json
+++ b/payload-schemas/schemas/repository_import.schema.json
@@ -22,7 +22,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/repository_import.schema.json
+++ b/payload-schemas/schemas/repository_import.schema.json
@@ -16,7 +16,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/repository_vulnerability_alert.schema.json
+++ b/payload-schemas/schemas/repository_vulnerability_alert.schema.json
@@ -63,7 +63,10 @@
       "$ref": "common/user.schema.json"
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/star.schema.json
+++ b/payload-schemas/schemas/star.schema.json
@@ -19,7 +19,10 @@
       "$ref": "common/user.schema.json"
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/status.schema.json
+++ b/payload-schemas/schemas/status.schema.json
@@ -375,7 +375,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/status.schema.json
+++ b/payload-schemas/schemas/status.schema.json
@@ -381,7 +381,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/team.schema.json
+++ b/payload-schemas/schemas/team.schema.json
@@ -80,7 +80,10 @@
       "$ref": "common/user.schema.json"
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/team_add.schema.json
+++ b/payload-schemas/schemas/team_add.schema.json
@@ -64,7 +64,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/team_add.schema.json
+++ b/payload-schemas/schemas/team_add.schema.json
@@ -70,7 +70,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/watch.schema.json
+++ b/payload-schemas/schemas/watch.schema.json
@@ -22,7 +22,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     }
   },
   "additionalProperties": false

--- a/payload-schemas/schemas/watch.schema.json
+++ b/payload-schemas/schemas/watch.schema.json
@@ -16,7 +16,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/workflow_dispatch.schema.json
+++ b/payload-schemas/schemas/workflow_dispatch.schema.json
@@ -27,7 +27,10 @@
       "$ref": "common/user.schema.json"
     },
     "installation": {
-      "$ref": "common/installation.schema.json"
+      "oneOf": [
+        { "$ref": "common/installation.schema.json" },
+        { "type": "null" }
+      ]
     },
     "organization": {
       "$ref": "common/organization.schema.json"

--- a/payload-schemas/schemas/workflow_dispatch.schema.json
+++ b/payload-schemas/schemas/workflow_dispatch.schema.json
@@ -33,7 +33,10 @@
       ]
     },
     "organization": {
-      "$ref": "common/organization.schema.json"
+      "oneOf": [
+        { "$ref": "common/organization.schema.json" },
+        { "type": "null" }
+      ]
     },
     "workflow": {
       "type": "string"


### PR DESCRIPTION
Resolves https://github.com/G-Rath/compare-gh-webhook-to-schema-function/issues/9

Currently some of the common interfaces will come out weird due to being of type `object | null`:

```ts
export type Installation = {
  id: number;
  node_id: string;
} & ({
  id: number;
  node_id: string;
} | null);
```

This resolves that by marking them as just `object`, and replacing all references to them with a `oneOf` with the reference and `null`.

The result is types like this:

```
export interface Installation {
  id: number;
  node_id: string;
}

export interface EventType {
  installation: Installation  | null;
}
```