### PR TITLE
chore: format payload and schema jsons with prettier consistently

### DIFF
--- a/payload-examples/api.github.com/code_scanning_alert/reopened.payload.json
+++ b/payload-examples/api.github.com/code_scanning_alert/reopened.payload.json
@@ -22,10 +22,7 @@
       "severity": "note",
       "description": "Add the frozen_string_literal comment to the top of files to help transition to frozen string literals by default."
     },
-    "tool": {
-      "name": "Rubocop",
-      "version": null
-    }
+    "tool": { "name": "Rubocop", "version": null }
   },
   "ref": "refs/heads/master",
   "commit_oid": "d6e4c75c141dbacecc279b721b8b9393d5405795",

--- a/payload-examples/api.github.com/code_scanning_alert/reopened.with-organization.payload.json
+++ b/payload-examples/api.github.com/code_scanning_alert/reopened.with-organization.payload.json
@@ -22,10 +22,7 @@
       "severity": "note",
       "description": "Add the frozen_string_literal comment to the top of files to help transition to frozen string literals by default."
     },
-    "tool": {
-      "name": "Rubocop",
-      "version": null
-    }
+    "tool": { "name": "Rubocop", "version": null }
   },
   "ref": "refs/heads/master",
   "commit_oid": "d6e4c75c141dbacecc279b721b8b9393d5405795",

--- a/payload-examples/api.github.com/issue_comment/edited.payload.json
+++ b/payload-examples/api.github.com/issue_comment/edited.payload.json
@@ -1,9 +1,7 @@
 {
   "action": "edited",
   "changes": {
-    "body": {
-      "from": "You are totally right! I'll get this fixed right away."
-    }
+    "body": { "from": "You are totally right! I'll get this fixed right away." }
   },
   "issue": {
     "url": "https://api.github.com/repos/Codertocat/Hello-World/issues/1",

--- a/payload-examples/api.github.com/issue_comment/edited.with-organization.payload.json
+++ b/payload-examples/api.github.com/issue_comment/edited.with-organization.payload.json
@@ -1,9 +1,7 @@
 {
   "action": "edited",
   "changes": {
-    "body": {
-      "from": "You are totally right! I'll get this fixed right away."
-    }
+    "body": { "from": "You are totally right! I'll get this fixed right away." }
   },
   "issue": {
     "url": "https://api.github.com/repos/Codertocat/Hello-World/issues/1",

--- a/payload-examples/api.github.com/label/edited.payload.json
+++ b/payload-examples/api.github.com/label/edited.payload.json
@@ -9,11 +9,7 @@
     "color": "cceeaa",
     "default": false
   },
-  "changes": {
-    "color": {
-      "from": "cb1f00"
-    }
-  },
+  "changes": { "color": { "from": "cb1f00" } },
   "repository": {
     "id": 186853002,
     "node_id": "MDEwOlJlcG9zaXRvcnkxODY4NTMwMDI=",

--- a/payload-examples/api.github.com/member/edited.payload.json
+++ b/payload-examples/api.github.com/member/edited.payload.json
@@ -20,11 +20,7 @@
     "type": "User",
     "site_admin": false
   },
-  "changes": {
-    "permission": {
-      "from": "write"
-    }
-  },
+  "changes": { "permission": { "from": "write" } },
   "repository": {
     "id": 135493233,
     "node_id": "MDEwOlJlcG9zaXRvcnkxMzU0OTMyMzM=",

--- a/payload-examples/api.github.com/page_build/payload.json
+++ b/payload-examples/api.github.com/page_build/payload.json
@@ -3,9 +3,7 @@
   "build": {
     "url": "https://api.github.com/repos/Codertocat/Hello-World/pages/builds/130514899",
     "status": "built",
-    "error": {
-      "message": null
-    },
+    "error": { "message": null },
     "pusher": {
       "login": "Codertocat",
       "id": 21031067,

--- a/payload-examples/api.github.com/page_build/with-installation.payload.json
+++ b/payload-examples/api.github.com/page_build/with-installation.payload.json
@@ -3,9 +3,7 @@
   "build": {
     "url": "https://api.github.com/repos/Codertocat/Hello-World/pages/builds/130514899",
     "status": "built",
-    "error": {
-      "message": null
-    },
+    "error": { "message": null },
     "pusher": {
       "login": "Codertocat",
       "id": 21031067,

--- a/payload-examples/api.github.com/ping/payload.json
+++ b/payload-examples/api.github.com/ping/payload.json
@@ -17,11 +17,7 @@
     "url": "https://api.github.com/repos/Octocoders/Hello-World/hooks/109948940",
     "test_url": "https://api.github.com/repos/Octocoders/Hello-World/hooks/109948940/test",
     "ping_url": "https://api.github.com/repos/Octocoders/Hello-World/hooks/109948940/pings",
-    "last_response": {
-      "code": null,
-      "status": "unused",
-      "message": null
-    }
+    "last_response": { "code": null, "status": "unused", "message": null }
   },
   "repository": {
     "id": 186853261,

--- a/payload-examples/api.github.com/pull_request/assigned.payload.json
+++ b/payload-examples/api.github.com/pull_request/assigned.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/assigned.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/assigned.with-organization.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/closed.payload.json
+++ b/payload-examples/api.github.com/pull_request/closed.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/closed.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/closed.with-organization.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/converted_to_draft.payload.json
+++ b/payload-examples/api.github.com/pull_request/converted_to_draft.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/converted_to_draft.with-installation.payload.json
+++ b/payload-examples/api.github.com/pull_request/converted_to_draft.with-installation.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/converted_to_draft.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/converted_to_draft.with-organization.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/labeled.payload.json
+++ b/payload-examples/api.github.com/pull_request/labeled.payload.json
@@ -398,9 +398,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/labeled.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/labeled.with-organization.payload.json
@@ -398,9 +398,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/locked.payload.json
+++ b/payload-examples/api.github.com/pull_request/locked.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/locked.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/locked.with-organization.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/opened.payload.json
+++ b/payload-examples/api.github.com/pull_request/opened.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/opened.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/opened.with-organization.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/ready_for_review.payload.json
+++ b/payload-examples/api.github.com/pull_request/ready_for_review.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/ready_for_review.with-installation.payload.json
+++ b/payload-examples/api.github.com/pull_request/ready_for_review.with-installation.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/ready_for_review.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/ready_for_review.with-organization.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/reopened.payload.json
+++ b/payload-examples/api.github.com/pull_request/reopened.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/reopened.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/reopened.with-organization.payload.json
@@ -343,9 +343,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/unassigned.payload.json
+++ b/payload-examples/api.github.com/pull_request/unassigned.payload.json
@@ -377,9 +377,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/unassigned.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/unassigned.with-organization.payload.json
@@ -377,9 +377,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/unlabeled.payload.json
+++ b/payload-examples/api.github.com/pull_request/unlabeled.payload.json
@@ -322,9 +322,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/unlabeled.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/unlabeled.with-organization.payload.json
@@ -322,9 +322,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/unlocked.payload.json
+++ b/payload-examples/api.github.com/pull_request/unlocked.payload.json
@@ -322,9 +322,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request/unlocked.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request/unlocked.with-organization.payload.json
@@ -322,9 +322,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request_review/submitted.payload.json
+++ b/payload-examples/api.github.com/pull_request_review/submitted.payload.json
@@ -381,9 +381,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request_review/submitted.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request_review/submitted.with-organization.payload.json
@@ -381,9 +381,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request_review_comment/created.payload.json
+++ b/payload-examples/api.github.com/pull_request_review_comment/created.payload.json
@@ -391,9 +391,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/pull_request_review_comment/created.with-organization.payload.json
+++ b/payload-examples/api.github.com/pull_request_review_comment/created.with-organization.payload.json
@@ -391,9 +391,7 @@
       "self": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/pulls/2"
       },
-      "html": {
-        "href": "https://github.com/Codertocat/Hello-World/pull/2"
-      },
+      "html": { "href": "https://github.com/Codertocat/Hello-World/pull/2" },
       "issue": {
         "href": "https://api.github.com/repos/Codertocat/Hello-World/issues/2"
       },

--- a/payload-examples/api.github.com/repository/edited.payload.json
+++ b/payload-examples/api.github.com/repository/edited.payload.json
@@ -1,10 +1,6 @@
 {
   "action": "edited",
-  "changes": {
-    "description": {
-      "from": "My Repo"
-    }
-  },
+  "changes": { "description": { "from": "My Repo" } },
   "repository": {
     "id": 186853261,
     "node_id": "MDEwOlJlcG9zaXRvcnkxODY4NTMyNjE=",

--- a/payload-examples/api.github.com/repository/edited.with-default_branch-edit.payload.json
+++ b/payload-examples/api.github.com/repository/edited.with-default_branch-edit.payload.json
@@ -1,10 +1,6 @@
 {
   "action": "edited",
-  "changes": {
-    "default_branch": {
-      "from": "main"
-    }
-  },
+  "changes": { "default_branch": { "from": "main" } },
   "repository": {
     "id": 186853261,
     "node_id": "MDEwOlJlcG9zaXRvcnkxODY4NTMyNjE=",

--- a/payload-examples/api.github.com/repository_dispatch/payload.json
+++ b/payload-examples/api.github.com/repository_dispatch/payload.json
@@ -1,10 +1,7 @@
 {
   "action": "on-demand-test",
   "branch": "master",
-  "client_payload": {
-    "unit": false,
-    "integration": true
-  },
+  "client_payload": { "unit": false, "integration": true },
   "repository": {
     "id": 17273051,
     "node_id": "MDEwOlJlcG9zaXRvcnkxNzI3MzA1MQ==",

--- a/payload-examples/api.github.com/security_advisory/published.payload.json
+++ b/payload-examples/api.github.com/security_advisory/published.payload.json
@@ -6,45 +6,25 @@
     "description": "django.contrib.auth.forms.AuthenticationForm in Django 2.0 before 2.0.2, and 1.11.8 and 1.11.9, allows remote attackers to obtain potentially sensitive information by leveraging data exposure from the confirm_login_allowed() method, as demonstrated by discovering whether a user account is inactive.",
     "severity": "moderate",
     "identifiers": [
-      {
-        "value": "GHSA-rf4j-j272-fj86",
-        "type": "GHSA"
-      },
-      {
-        "value": "CVE-2018-6188",
-        "type": "CVE"
-      }
+      { "value": "GHSA-rf4j-j272-fj86", "type": "GHSA" },
+      { "value": "CVE-2018-6188", "type": "CVE" }
     ],
-    "references": [
-      {
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-6188"
-      }
-    ],
+    "references": [{ "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-6188" }],
     "published_at": "2018-10-03T21:13:54Z",
     "updated_at": "2018-10-03T21:13:54Z",
     "withdrawn_at": null,
     "vulnerabilities": [
       {
-        "package": {
-          "ecosystem": "pip",
-          "name": "django"
-        },
+        "package": { "ecosystem": "pip", "name": "django" },
         "severity": "moderate",
         "vulnerable_version_range": ">= 2.0.0, < 2.0.2",
-        "first_patched_version": {
-          "identifier": "2.0.2"
-        }
+        "first_patched_version": { "identifier": "2.0.2" }
       },
       {
-        "package": {
-          "ecosystem": "pip",
-          "name": "django"
-        },
+        "package": { "ecosystem": "pip", "name": "django" },
         "severity": "moderate",
         "vulnerable_version_range": ">= 1.11.8, < 1.11.10",
-        "first_patched_version": {
-          "identifier": "1.11.10"
-        }
+        "first_patched_version": { "identifier": "1.11.10" }
       }
     ]
   }

--- a/payload-examples/api.github.com/security_advisory/updated.payload.json
+++ b/payload-examples/api.github.com/security_advisory/updated.payload.json
@@ -6,32 +6,19 @@
     "description": "All versions of `harp` are vulnerable to Unauthorized File Access. If a symlink in the project's base directory points to a file outside of the directory, the file is served. This could allow an attacker to access sensitive files on the server.\n\n\n## Recommendation\n\nNo fix is currently available. Consider using an alternative module until a fix is made available.",
     "severity": "moderate",
     "identifiers": [
-      {
-        "value": "GHSA-6fmm-47qc-p4m4",
-        "type": "GHSA"
-      },
-      {
-        "value": "CVE-2019-5438",
-        "type": "CVE"
-      }
+      { "value": "GHSA-6fmm-47qc-p4m4", "type": "GHSA" },
+      { "value": "CVE-2019-5438", "type": "CVE" }
     ],
     "references": [
-      {
-        "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-5438"
-      },
-      {
-        "url": "https://github.com/advisories/GHSA-6fmm-47qc-p4m4"
-      }
+      { "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-5438" },
+      { "url": "https://github.com/advisories/GHSA-6fmm-47qc-p4m4" }
     ],
     "published_at": "2019-06-13T16:12:26Z",
     "updated_at": "2021-01-08T21:27:28Z",
     "withdrawn_at": null,
     "vulnerabilities": [
       {
-        "package": {
-          "ecosystem": "npm",
-          "name": "harp"
-        },
+        "package": { "ecosystem": "npm", "name": "harp" },
         "severity": "moderate",
         "vulnerable_version_range": "<= 0.29.0",
         "first_patched_version": null

--- a/payload-examples/api.github.com/team/added_to_repository.payload.json
+++ b/payload-examples/api.github.com/team/added_to_repository.payload.json
@@ -106,11 +106,7 @@
     "open_issues": 0,
     "watchers": 0,
     "default_branch": "master",
-    "permissions": {
-      "pull": true,
-      "push": false,
-      "admin": false
-    }
+    "permissions": { "pull": true, "push": false, "admin": false }
   },
   "organization": {
     "login": "Octocoders",

--- a/payload-examples/api.github.com/workflow_dispatch/payload.json
+++ b/payload-examples/api.github.com/workflow_dispatch/payload.json
@@ -1,7 +1,5 @@
 {
-  "inputs": {
-    "name": "Mona the Octocat"
-  },
+  "inputs": { "name": "Mona the Octocat" },
   "ref": "refs/heads/master",
   "repository": {
     "id": 17273051,

--- a/payload-examples/api.github.com/workflow_run/completed.payload.json
+++ b/payload-examples/api.github.com/workflow_run/completed.payload.json
@@ -159,10 +159,7 @@
         "email": "matfax@users.noreply.github.com",
         "name": "Matthias Fax"
       },
-      "committer": {
-        "email": "noreply@github.com",
-        "name": "GitHub"
-      },
+      "committer": { "email": "noreply@github.com", "name": "GitHub" },
       "id": "3484a3fb816e0859fd6e1cea078d76385ff50625",
       "message": "build(test): check workflow run event payload",
       "timestamp": "2020-10-05T16:32:07Z",

--- a/payload-examples/api.github.com/workflow_run/requested.payload.json
+++ b/payload-examples/api.github.com/workflow_run/requested.payload.json
@@ -159,10 +159,7 @@
         "email": "matfax@users.noreply.github.com",
         "name": "Matthias Fax"
       },
-      "committer": {
-        "email": "noreply@github.com",
-        "name": "GitHub"
-      },
+      "committer": { "email": "noreply@github.com", "name": "GitHub" },
       "id": "3484a3fb816e0859fd6e1cea078d76385ff50625",
       "message": "build(test): check workflow run event payload",
       "timestamp": "2020-10-05T16:32:07Z",

--- a/payload-schemas/schemas/check_run/completed.schema.json
+++ b/payload-schemas/schemas/check_run/completed.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "check_run", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["completed"]
-    },
+    "action": { "type": "string", "enum": ["completed"] },
     "check_run": {
       "type": "object",
       "required": [
@@ -27,36 +24,20 @@
         "pull_requests"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "head_sha": {
-          "type": "string"
-        },
-        "external_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "details_url": {
-          "type": "string"
-        },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "head_sha": { "type": "string" },
+        "external_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "details_url": { "type": "string" },
         "status": {
           "type": "string",
           "enum": ["queued", "in_progress", "completed"]
         },
         "conclusion": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -71,19 +52,8 @@
             }
           ]
         },
-        "started_at": {
-          "type": "string"
-        },
-        "completed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "started_at": { "type": "string" },
+        "completed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "output": {
           "type": "object",
           "required": [
@@ -93,48 +63,15 @@
             "annotations_url"
           ],
           "properties": {
-            "title": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "summary": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "text": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "annotations_count": {
-              "type": "integer"
-            },
-            "annotations_url": {
-              "type": "string"
-            }
+            "title": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "summary": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "text": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "annotations_count": { "type": "integer" },
+            "annotations_url": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "name": {
-          "type": "string"
-        },
+        "name": { "type": "string" },
         "check_suite": {
           "type": "object",
           "required": [
@@ -152,40 +89,17 @@
             "updated_at"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "head_branch": {
-              "type": "string"
-            },
-            "head_sha": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "head_branch": { "type": "string" },
+            "head_sha": { "type": "string" },
+            "status": { "type": "string" },
             "conclusion": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "url": {
-              "type": "string"
-            },
-            "before": {
-              "type": "string"
-            },
-            "after": {
-              "type": "string"
-            },
+            "url": { "type": "string" },
+            "before": { "type": "string" },
+            "after": { "type": "string" },
             "pull_requests": {
               "type": "array",
               "items": {
@@ -194,38 +108,22 @@
                     "type": "object",
                     "required": ["url", "id", "number", "head", "base"],
                     "properties": {
-                      "url": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "integer"
-                      },
-                      "number": {
-                        "type": "integer"
-                      },
+                      "url": { "type": "string" },
+                      "id": { "type": "integer" },
+                      "number": { "type": "integer" },
                       "head": {
                         "type": "object",
                         "required": ["ref", "sha", "repo"],
                         "properties": {
-                          "ref": {
-                            "type": "string"
-                          },
-                          "sha": {
-                            "type": "string"
-                          },
+                          "ref": { "type": "string" },
+                          "sha": { "type": "string" },
                           "repo": {
                             "type": "object",
                             "required": ["id", "url", "name"],
                             "properties": {
-                              "id": {
-                                "type": "integer"
-                              },
-                              "url": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
+                              "id": { "type": "integer" },
+                              "url": { "type": "string" },
+                              "name": { "type": "string" }
                             },
                             "additionalProperties": false
                           }
@@ -236,25 +134,15 @@
                         "type": "object",
                         "required": ["ref", "sha", "repo"],
                         "properties": {
-                          "ref": {
-                            "type": "string"
-                          },
-                          "sha": {
-                            "type": "string"
-                          },
+                          "ref": { "type": "string" },
+                          "sha": { "type": "string" },
                           "repo": {
                             "type": "object",
                             "required": ["id", "url", "name"],
                             "properties": {
-                              "id": {
-                                "type": "integer"
-                              },
-                              "url": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
+                              "id": { "type": "integer" },
+                              "url": { "type": "string" },
+                              "name": { "type": "string" }
                             },
                             "additionalProperties": false
                           }
@@ -281,43 +169,18 @@
                 "updated_at"
               ],
               "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "slug": {
-                  "type": "string"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "owner": {
-                  "$ref": "common/user.schema.json"
-                },
-                "name": {
-                  "type": "string"
-                },
+                "id": { "type": "integer" },
+                "slug": { "type": "string" },
+                "node_id": { "type": "string" },
+                "owner": { "$ref": "common/user.schema.json" },
+                "name": { "type": "string" },
                 "description": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 },
-                "external_url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
+                "external_url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
                 "permissions": {
                   "type": "object",
                   "properties": {
@@ -325,34 +188,16 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "actions": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "checks": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "contents": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "actions": { "type": "string", "enum": ["read", "write"] },
+                    "checks": { "type": "string", "enum": ["read", "write"] },
+                    "contents": { "type": "string", "enum": ["read", "write"] },
                     "deployments": {
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "issues": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "members": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "metadata": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "issues": { "type": "string", "enum": ["read", "write"] },
+                    "members": { "type": "string", "enum": ["read", "write"] },
+                    "metadata": { "type": "string", "enum": ["read", "write"] },
                     "organization_administration": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -373,10 +218,7 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "pages": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "pages": { "type": "string", "enum": ["read", "write"] },
                     "pull_requests": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -389,10 +231,7 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "statuses": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "statuses": { "type": "string", "enum": ["read", "write"] },
                     "team_discussions": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -404,19 +243,12 @@
                   },
                   "additionalProperties": false
                 },
-                "events": {
-                  "type": "array",
-                  "items": {}
-                }
+                "events": { "type": "array", "items": {} }
               },
               "additionalProperties": false
             },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            }
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -434,43 +266,18 @@
             "updated_at"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "slug": {
-              "type": "string"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "owner": {
-              "$ref": "common/user.schema.json"
-            },
-            "name": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "slug": { "type": "string" },
+            "node_id": { "type": "string" },
+            "owner": { "$ref": "common/user.schema.json" },
+            "name": { "type": "string" },
             "description": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "external_url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
+            "external_url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
             "permissions": {
               "type": "object",
               "properties": {
@@ -478,30 +285,12 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "checks": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "contents": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "deployments": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "issues": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "members": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "metadata": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "checks": { "type": "string", "enum": ["read", "write"] },
+                "contents": { "type": "string", "enum": ["read", "write"] },
+                "deployments": { "type": "string", "enum": ["read", "write"] },
+                "issues": { "type": "string", "enum": ["read", "write"] },
+                "members": { "type": "string", "enum": ["read", "write"] },
+                "metadata": { "type": "string", "enum": ["read", "write"] },
                 "organization_administration": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -522,10 +311,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "pages": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "pages": { "type": "string", "enum": ["read", "write"] },
                 "pull_requests": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -538,10 +324,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "statuses": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "statuses": { "type": "string", "enum": ["read", "write"] },
                 "team_discussions": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -553,10 +336,7 @@
               },
               "additionalProperties": false
             },
-            "events": {
-              "type": "array",
-              "items": {}
-            }
+            "events": { "type": "array", "items": {} }
           },
           "additionalProperties": false
         },
@@ -568,38 +348,22 @@
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],
                 "properties": {
-                  "url": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "integer"
-                  },
-                  "number": {
-                    "type": "integer"
-                  },
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
                   "head": {
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -610,25 +374,15 @@
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -646,31 +400,17 @@
     },
     "requested_action": {
       "oneOf": [
-        {
-          "type": "null"
-        },
+        { "type": "null" },
         {
           "type": "object",
-          "properties": {
-            "identifier": {
-              "type": "string"
-            }
-          }
+          "properties": { "identifier": { "type": "string" } }
         }
       ]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "check_run completed event"

--- a/payload-schemas/schemas/check_run/created.schema.json
+++ b/payload-schemas/schemas/check_run/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "check_run", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "check_run": {
       "type": "object",
       "required": [
@@ -27,36 +24,20 @@
         "pull_requests"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "head_sha": {
-          "type": "string"
-        },
-        "external_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "details_url": {
-          "type": "string"
-        },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "head_sha": { "type": "string" },
+        "external_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "details_url": { "type": "string" },
         "status": {
           "type": "string",
           "enum": ["queued", "in_progress", "completed"]
         },
         "conclusion": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -71,19 +52,8 @@
             }
           ]
         },
-        "started_at": {
-          "type": "string"
-        },
-        "completed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "started_at": { "type": "string" },
+        "completed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "output": {
           "type": "object",
           "required": [
@@ -93,48 +63,15 @@
             "annotations_url"
           ],
           "properties": {
-            "title": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "summary": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "text": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "annotations_count": {
-              "type": "integer"
-            },
-            "annotations_url": {
-              "type": "string"
-            }
+            "title": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "summary": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "text": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "annotations_count": { "type": "integer" },
+            "annotations_url": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "name": {
-          "type": "string"
-        },
+        "name": { "type": "string" },
         "check_suite": {
           "type": "object",
           "required": [
@@ -152,40 +89,17 @@
             "updated_at"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "head_branch": {
-              "type": "string"
-            },
-            "head_sha": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "head_branch": { "type": "string" },
+            "head_sha": { "type": "string" },
+            "status": { "type": "string" },
             "conclusion": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "url": {
-              "type": "string"
-            },
-            "before": {
-              "type": "string"
-            },
-            "after": {
-              "type": "string"
-            },
+            "url": { "type": "string" },
+            "before": { "type": "string" },
+            "after": { "type": "string" },
             "pull_requests": {
               "type": "array",
               "items": {
@@ -194,38 +108,22 @@
                     "type": "object",
                     "required": ["url", "id", "number", "head", "base"],
                     "properties": {
-                      "url": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "integer"
-                      },
-                      "number": {
-                        "type": "integer"
-                      },
+                      "url": { "type": "string" },
+                      "id": { "type": "integer" },
+                      "number": { "type": "integer" },
                       "head": {
                         "type": "object",
                         "required": ["ref", "sha", "repo"],
                         "properties": {
-                          "ref": {
-                            "type": "string"
-                          },
-                          "sha": {
-                            "type": "string"
-                          },
+                          "ref": { "type": "string" },
+                          "sha": { "type": "string" },
                           "repo": {
                             "type": "object",
                             "required": ["id", "url", "name"],
                             "properties": {
-                              "id": {
-                                "type": "integer"
-                              },
-                              "url": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
+                              "id": { "type": "integer" },
+                              "url": { "type": "string" },
+                              "name": { "type": "string" }
                             },
                             "additionalProperties": false
                           }
@@ -236,25 +134,15 @@
                         "type": "object",
                         "required": ["ref", "sha", "repo"],
                         "properties": {
-                          "ref": {
-                            "type": "string"
-                          },
-                          "sha": {
-                            "type": "string"
-                          },
+                          "ref": { "type": "string" },
+                          "sha": { "type": "string" },
                           "repo": {
                             "type": "object",
                             "required": ["id", "url", "name"],
                             "properties": {
-                              "id": {
-                                "type": "integer"
-                              },
-                              "url": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
+                              "id": { "type": "integer" },
+                              "url": { "type": "string" },
+                              "name": { "type": "string" }
                             },
                             "additionalProperties": false
                           }
@@ -281,43 +169,18 @@
                 "updated_at"
               ],
               "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "slug": {
-                  "type": "string"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "owner": {
-                  "$ref": "common/user.schema.json"
-                },
-                "name": {
-                  "type": "string"
-                },
+                "id": { "type": "integer" },
+                "slug": { "type": "string" },
+                "node_id": { "type": "string" },
+                "owner": { "$ref": "common/user.schema.json" },
+                "name": { "type": "string" },
                 "description": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 },
-                "external_url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
+                "external_url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
                 "permissions": {
                   "type": "object",
                   "properties": {
@@ -325,34 +188,16 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "actions": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "checks": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "contents": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "actions": { "type": "string", "enum": ["read", "write"] },
+                    "checks": { "type": "string", "enum": ["read", "write"] },
+                    "contents": { "type": "string", "enum": ["read", "write"] },
                     "deployments": {
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "issues": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "members": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "metadata": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "issues": { "type": "string", "enum": ["read", "write"] },
+                    "members": { "type": "string", "enum": ["read", "write"] },
+                    "metadata": { "type": "string", "enum": ["read", "write"] },
                     "organization_administration": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -373,10 +218,7 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "pages": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "pages": { "type": "string", "enum": ["read", "write"] },
                     "pull_requests": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -389,10 +231,7 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "statuses": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "statuses": { "type": "string", "enum": ["read", "write"] },
                     "team_discussions": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -404,19 +243,12 @@
                   },
                   "additionalProperties": false
                 },
-                "events": {
-                  "type": "array",
-                  "items": {}
-                }
+                "events": { "type": "array", "items": {} }
               },
               "additionalProperties": false
             },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            }
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -434,43 +266,18 @@
             "updated_at"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "slug": {
-              "type": "string"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "owner": {
-              "$ref": "common/user.schema.json"
-            },
-            "name": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "slug": { "type": "string" },
+            "node_id": { "type": "string" },
+            "owner": { "$ref": "common/user.schema.json" },
+            "name": { "type": "string" },
             "description": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "external_url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
+            "external_url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
             "permissions": {
               "type": "object",
               "properties": {
@@ -478,30 +285,12 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "checks": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "contents": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "deployments": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "issues": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "members": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "metadata": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "checks": { "type": "string", "enum": ["read", "write"] },
+                "contents": { "type": "string", "enum": ["read", "write"] },
+                "deployments": { "type": "string", "enum": ["read", "write"] },
+                "issues": { "type": "string", "enum": ["read", "write"] },
+                "members": { "type": "string", "enum": ["read", "write"] },
+                "metadata": { "type": "string", "enum": ["read", "write"] },
                 "organization_administration": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -522,10 +311,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "pages": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "pages": { "type": "string", "enum": ["read", "write"] },
                 "pull_requests": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -538,10 +324,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "statuses": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "statuses": { "type": "string", "enum": ["read", "write"] },
                 "team_discussions": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -553,10 +336,7 @@
               },
               "additionalProperties": false
             },
-            "events": {
-              "type": "array",
-              "items": {}
-            }
+            "events": { "type": "array", "items": {} }
           },
           "additionalProperties": false
         },
@@ -568,38 +348,22 @@
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],
                 "properties": {
-                  "url": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "integer"
-                  },
-                  "number": {
-                    "type": "integer"
-                  },
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
                   "head": {
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -610,25 +374,15 @@
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -646,31 +400,17 @@
     },
     "requested_action": {
       "oneOf": [
-        {
-          "type": "null"
-        },
+        { "type": "null" },
         {
           "type": "object",
-          "properties": {
-            "identifier": {
-              "type": "string"
-            }
-          }
+          "properties": { "identifier": { "type": "string" } }
         }
       ]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "check_run created event"

--- a/payload-schemas/schemas/check_run/requested_action.schema.json
+++ b/payload-schemas/schemas/check_run/requested_action.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "check_run", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["requested_action"]
-    },
+    "action": { "type": "string", "enum": ["requested_action"] },
     "check_run": {
       "type": "object",
       "required": [
@@ -27,36 +24,20 @@
         "pull_requests"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "head_sha": {
-          "type": "string"
-        },
-        "external_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "details_url": {
-          "type": "string"
-        },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "head_sha": { "type": "string" },
+        "external_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "details_url": { "type": "string" },
         "status": {
           "type": "string",
           "enum": ["queued", "in_progress", "completed"]
         },
         "conclusion": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -71,19 +52,8 @@
             }
           ]
         },
-        "started_at": {
-          "type": "string"
-        },
-        "completed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "started_at": { "type": "string" },
+        "completed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "output": {
           "type": "object",
           "required": [
@@ -93,48 +63,15 @@
             "annotations_url"
           ],
           "properties": {
-            "title": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "summary": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "text": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "annotations_count": {
-              "type": "integer"
-            },
-            "annotations_url": {
-              "type": "string"
-            }
+            "title": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "summary": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "text": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "annotations_count": { "type": "integer" },
+            "annotations_url": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "name": {
-          "type": "string"
-        },
+        "name": { "type": "string" },
         "check_suite": {
           "type": "object",
           "required": [
@@ -152,40 +89,17 @@
             "updated_at"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "head_branch": {
-              "type": "string"
-            },
-            "head_sha": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "head_branch": { "type": "string" },
+            "head_sha": { "type": "string" },
+            "status": { "type": "string" },
             "conclusion": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "url": {
-              "type": "string"
-            },
-            "before": {
-              "type": "string"
-            },
-            "after": {
-              "type": "string"
-            },
+            "url": { "type": "string" },
+            "before": { "type": "string" },
+            "after": { "type": "string" },
             "pull_requests": {
               "type": "array",
               "items": {
@@ -194,38 +108,22 @@
                     "type": "object",
                     "required": ["url", "id", "number", "head", "base"],
                     "properties": {
-                      "url": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "integer"
-                      },
-                      "number": {
-                        "type": "integer"
-                      },
+                      "url": { "type": "string" },
+                      "id": { "type": "integer" },
+                      "number": { "type": "integer" },
                       "head": {
                         "type": "object",
                         "required": ["ref", "sha", "repo"],
                         "properties": {
-                          "ref": {
-                            "type": "string"
-                          },
-                          "sha": {
-                            "type": "string"
-                          },
+                          "ref": { "type": "string" },
+                          "sha": { "type": "string" },
                           "repo": {
                             "type": "object",
                             "required": ["id", "url", "name"],
                             "properties": {
-                              "id": {
-                                "type": "integer"
-                              },
-                              "url": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
+                              "id": { "type": "integer" },
+                              "url": { "type": "string" },
+                              "name": { "type": "string" }
                             },
                             "additionalProperties": false
                           }
@@ -236,25 +134,15 @@
                         "type": "object",
                         "required": ["ref", "sha", "repo"],
                         "properties": {
-                          "ref": {
-                            "type": "string"
-                          },
-                          "sha": {
-                            "type": "string"
-                          },
+                          "ref": { "type": "string" },
+                          "sha": { "type": "string" },
                           "repo": {
                             "type": "object",
                             "required": ["id", "url", "name"],
                             "properties": {
-                              "id": {
-                                "type": "integer"
-                              },
-                              "url": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
+                              "id": { "type": "integer" },
+                              "url": { "type": "string" },
+                              "name": { "type": "string" }
                             },
                             "additionalProperties": false
                           }
@@ -281,43 +169,18 @@
                 "updated_at"
               ],
               "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "slug": {
-                  "type": "string"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "owner": {
-                  "$ref": "common/user.schema.json"
-                },
-                "name": {
-                  "type": "string"
-                },
+                "id": { "type": "integer" },
+                "slug": { "type": "string" },
+                "node_id": { "type": "string" },
+                "owner": { "$ref": "common/user.schema.json" },
+                "name": { "type": "string" },
                 "description": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 },
-                "external_url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
+                "external_url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
                 "permissions": {
                   "type": "object",
                   "properties": {
@@ -325,34 +188,16 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "actions": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "checks": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "contents": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "actions": { "type": "string", "enum": ["read", "write"] },
+                    "checks": { "type": "string", "enum": ["read", "write"] },
+                    "contents": { "type": "string", "enum": ["read", "write"] },
                     "deployments": {
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "issues": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "members": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "metadata": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "issues": { "type": "string", "enum": ["read", "write"] },
+                    "members": { "type": "string", "enum": ["read", "write"] },
+                    "metadata": { "type": "string", "enum": ["read", "write"] },
                     "organization_administration": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -373,10 +218,7 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "pages": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "pages": { "type": "string", "enum": ["read", "write"] },
                     "pull_requests": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -389,10 +231,7 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "statuses": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "statuses": { "type": "string", "enum": ["read", "write"] },
                     "team_discussions": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -404,19 +243,12 @@
                   },
                   "additionalProperties": false
                 },
-                "events": {
-                  "type": "array",
-                  "items": {}
-                }
+                "events": { "type": "array", "items": {} }
               },
               "additionalProperties": false
             },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            }
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -434,43 +266,18 @@
             "updated_at"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "slug": {
-              "type": "string"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "owner": {
-              "$ref": "common/user.schema.json"
-            },
-            "name": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "slug": { "type": "string" },
+            "node_id": { "type": "string" },
+            "owner": { "$ref": "common/user.schema.json" },
+            "name": { "type": "string" },
             "description": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "external_url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
+            "external_url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
             "permissions": {
               "type": "object",
               "properties": {
@@ -478,30 +285,12 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "checks": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "contents": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "deployments": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "issues": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "members": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "metadata": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "checks": { "type": "string", "enum": ["read", "write"] },
+                "contents": { "type": "string", "enum": ["read", "write"] },
+                "deployments": { "type": "string", "enum": ["read", "write"] },
+                "issues": { "type": "string", "enum": ["read", "write"] },
+                "members": { "type": "string", "enum": ["read", "write"] },
+                "metadata": { "type": "string", "enum": ["read", "write"] },
                 "organization_administration": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -522,10 +311,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "pages": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "pages": { "type": "string", "enum": ["read", "write"] },
                 "pull_requests": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -538,10 +324,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "statuses": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "statuses": { "type": "string", "enum": ["read", "write"] },
                 "team_discussions": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -553,10 +336,7 @@
               },
               "additionalProperties": false
             },
-            "events": {
-              "type": "array",
-              "items": {}
-            }
+            "events": { "type": "array", "items": {} }
           },
           "additionalProperties": false
         },
@@ -568,38 +348,22 @@
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],
                 "properties": {
-                  "url": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "integer"
-                  },
-                  "number": {
-                    "type": "integer"
-                  },
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
                   "head": {
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -610,25 +374,15 @@
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -646,31 +400,17 @@
     },
     "requested_action": {
       "oneOf": [
-        {
-          "type": "null"
-        },
+        { "type": "null" },
         {
           "type": "object",
-          "properties": {
-            "identifier": {
-              "type": "string"
-            }
-          }
+          "properties": { "identifier": { "type": "string" } }
         }
       ]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "check_run requested_action event"

--- a/payload-schemas/schemas/check_run/rerequested.schema.json
+++ b/payload-schemas/schemas/check_run/rerequested.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "check_run", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["rerequested"]
-    },
+    "action": { "type": "string", "enum": ["rerequested"] },
     "check_run": {
       "type": "object",
       "required": [
@@ -27,36 +24,20 @@
         "pull_requests"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "head_sha": {
-          "type": "string"
-        },
-        "external_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "details_url": {
-          "type": "string"
-        },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "head_sha": { "type": "string" },
+        "external_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "details_url": { "type": "string" },
         "status": {
           "type": "string",
           "enum": ["queued", "in_progress", "completed"]
         },
         "conclusion": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -71,19 +52,8 @@
             }
           ]
         },
-        "started_at": {
-          "type": "string"
-        },
-        "completed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "started_at": { "type": "string" },
+        "completed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "output": {
           "type": "object",
           "required": [
@@ -93,48 +63,15 @@
             "annotations_url"
           ],
           "properties": {
-            "title": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "summary": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "text": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "annotations_count": {
-              "type": "integer"
-            },
-            "annotations_url": {
-              "type": "string"
-            }
+            "title": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "summary": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "text": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "annotations_count": { "type": "integer" },
+            "annotations_url": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "name": {
-          "type": "string"
-        },
+        "name": { "type": "string" },
         "check_suite": {
           "type": "object",
           "required": [
@@ -152,40 +89,17 @@
             "updated_at"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "head_branch": {
-              "type": "string"
-            },
-            "head_sha": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "head_branch": { "type": "string" },
+            "head_sha": { "type": "string" },
+            "status": { "type": "string" },
             "conclusion": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "url": {
-              "type": "string"
-            },
-            "before": {
-              "type": "string"
-            },
-            "after": {
-              "type": "string"
-            },
+            "url": { "type": "string" },
+            "before": { "type": "string" },
+            "after": { "type": "string" },
             "pull_requests": {
               "type": "array",
               "items": {
@@ -194,38 +108,22 @@
                     "type": "object",
                     "required": ["url", "id", "number", "head", "base"],
                     "properties": {
-                      "url": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "integer"
-                      },
-                      "number": {
-                        "type": "integer"
-                      },
+                      "url": { "type": "string" },
+                      "id": { "type": "integer" },
+                      "number": { "type": "integer" },
                       "head": {
                         "type": "object",
                         "required": ["ref", "sha", "repo"],
                         "properties": {
-                          "ref": {
-                            "type": "string"
-                          },
-                          "sha": {
-                            "type": "string"
-                          },
+                          "ref": { "type": "string" },
+                          "sha": { "type": "string" },
                           "repo": {
                             "type": "object",
                             "required": ["id", "url", "name"],
                             "properties": {
-                              "id": {
-                                "type": "integer"
-                              },
-                              "url": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
+                              "id": { "type": "integer" },
+                              "url": { "type": "string" },
+                              "name": { "type": "string" }
                             },
                             "additionalProperties": false
                           }
@@ -236,25 +134,15 @@
                         "type": "object",
                         "required": ["ref", "sha", "repo"],
                         "properties": {
-                          "ref": {
-                            "type": "string"
-                          },
-                          "sha": {
-                            "type": "string"
-                          },
+                          "ref": { "type": "string" },
+                          "sha": { "type": "string" },
                           "repo": {
                             "type": "object",
                             "required": ["id", "url", "name"],
                             "properties": {
-                              "id": {
-                                "type": "integer"
-                              },
-                              "url": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
+                              "id": { "type": "integer" },
+                              "url": { "type": "string" },
+                              "name": { "type": "string" }
                             },
                             "additionalProperties": false
                           }
@@ -281,43 +169,18 @@
                 "updated_at"
               ],
               "properties": {
-                "id": {
-                  "type": "integer"
-                },
-                "slug": {
-                  "type": "string"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "owner": {
-                  "$ref": "common/user.schema.json"
-                },
-                "name": {
-                  "type": "string"
-                },
+                "id": { "type": "integer" },
+                "slug": { "type": "string" },
+                "node_id": { "type": "string" },
+                "owner": { "$ref": "common/user.schema.json" },
+                "name": { "type": "string" },
                 "description": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 },
-                "external_url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
+                "external_url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
                 "permissions": {
                   "type": "object",
                   "properties": {
@@ -325,34 +188,16 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "actions": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "checks": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "contents": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "actions": { "type": "string", "enum": ["read", "write"] },
+                    "checks": { "type": "string", "enum": ["read", "write"] },
+                    "contents": { "type": "string", "enum": ["read", "write"] },
                     "deployments": {
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "issues": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "members": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
-                    "metadata": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "issues": { "type": "string", "enum": ["read", "write"] },
+                    "members": { "type": "string", "enum": ["read", "write"] },
+                    "metadata": { "type": "string", "enum": ["read", "write"] },
                     "organization_administration": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -373,10 +218,7 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "pages": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "pages": { "type": "string", "enum": ["read", "write"] },
                     "pull_requests": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -389,10 +231,7 @@
                       "type": "string",
                       "enum": ["read", "write"]
                     },
-                    "statuses": {
-                      "type": "string",
-                      "enum": ["read", "write"]
-                    },
+                    "statuses": { "type": "string", "enum": ["read", "write"] },
                     "team_discussions": {
                       "type": "string",
                       "enum": ["read", "write"]
@@ -404,19 +243,12 @@
                   },
                   "additionalProperties": false
                 },
-                "events": {
-                  "type": "array",
-                  "items": {}
-                }
+                "events": { "type": "array", "items": {} }
               },
               "additionalProperties": false
             },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            }
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -434,43 +266,18 @@
             "updated_at"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "slug": {
-              "type": "string"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "owner": {
-              "$ref": "common/user.schema.json"
-            },
-            "name": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "slug": { "type": "string" },
+            "node_id": { "type": "string" },
+            "owner": { "$ref": "common/user.schema.json" },
+            "name": { "type": "string" },
             "description": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "external_url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
+            "external_url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
             "permissions": {
               "type": "object",
               "properties": {
@@ -478,30 +285,12 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "checks": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "contents": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "deployments": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "issues": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "members": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "metadata": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "checks": { "type": "string", "enum": ["read", "write"] },
+                "contents": { "type": "string", "enum": ["read", "write"] },
+                "deployments": { "type": "string", "enum": ["read", "write"] },
+                "issues": { "type": "string", "enum": ["read", "write"] },
+                "members": { "type": "string", "enum": ["read", "write"] },
+                "metadata": { "type": "string", "enum": ["read", "write"] },
                 "organization_administration": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -522,10 +311,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "pages": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "pages": { "type": "string", "enum": ["read", "write"] },
                 "pull_requests": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -538,10 +324,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "statuses": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "statuses": { "type": "string", "enum": ["read", "write"] },
                 "team_discussions": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -553,10 +336,7 @@
               },
               "additionalProperties": false
             },
-            "events": {
-              "type": "array",
-              "items": {}
-            }
+            "events": { "type": "array", "items": {} }
           },
           "additionalProperties": false
         },
@@ -568,38 +348,22 @@
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],
                 "properties": {
-                  "url": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "integer"
-                  },
-                  "number": {
-                    "type": "integer"
-                  },
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
                   "head": {
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -610,25 +374,15 @@
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -646,31 +400,17 @@
     },
     "requested_action": {
       "oneOf": [
-        {
-          "type": "null"
-        },
+        { "type": "null" },
         {
           "type": "object",
-          "properties": {
-            "identifier": {
-              "type": "string"
-            }
-          }
+          "properties": { "identifier": { "type": "string" } }
         }
       ]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "check_run rerequested event"

--- a/payload-schemas/schemas/check_suite/completed.schema.json
+++ b/payload-schemas/schemas/check_suite/completed.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "check_suite", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["completed"]
-    },
+    "action": { "type": "string", "enum": ["completed"] },
     "check_suite": {
       "type": "object",
       "required": [
@@ -29,30 +26,13 @@
         "head_commit"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "head_branch": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "head_sha": {
-          "type": "string"
-        },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "head_branch": { "oneOf": [{ "type": "string" }, { "type": "null" }] },
+        "head_sha": { "type": "string" },
         "status": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["requested", "in_progress", "completed", "queued"]
@@ -61,9 +41,7 @@
         },
         "conclusion": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -78,15 +56,9 @@
             }
           ]
         },
-        "url": {
-          "type": "string"
-        },
-        "before": {
-          "type": "string"
-        },
-        "after": {
-          "type": "string"
-        },
+        "url": { "type": "string" },
+        "before": { "type": "string" },
+        "after": { "type": "string" },
         "pull_requests": {
           "type": "array",
           "items": {
@@ -95,38 +67,22 @@
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],
                 "properties": {
-                  "url": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "integer"
-                  },
-                  "number": {
-                    "type": "integer"
-                  },
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
                   "head": {
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -137,25 +93,15 @@
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -184,36 +130,16 @@
             "events"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "slug": {
-              "type": "string"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "owner": {
-              "$ref": "common/user.schema.json"
-            },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "external_url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "slug": { "type": "string" },
+            "node_id": { "type": "string" },
+            "owner": { "$ref": "common/user.schema.json" },
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "external_url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
             "permissions": {
               "type": "object",
               "required": [
@@ -242,34 +168,13 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "actions": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "checks": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "contents": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "deployments": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "issues": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "members": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "metadata": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "actions": { "type": "string", "enum": ["read", "write"] },
+                "checks": { "type": "string", "enum": ["read", "write"] },
+                "contents": { "type": "string", "enum": ["read", "write"] },
+                "deployments": { "type": "string", "enum": ["read", "write"] },
+                "issues": { "type": "string", "enum": ["read", "write"] },
+                "members": { "type": "string", "enum": ["read", "write"] },
+                "metadata": { "type": "string", "enum": ["read", "write"] },
                 "organization_administration": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -290,10 +195,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "pages": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "pages": { "type": "string", "enum": ["read", "write"] },
                 "pull_requests": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -306,10 +208,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "statuses": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "statuses": { "type": "string", "enum": ["read", "write"] },
                 "team_discussions": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -321,27 +220,14 @@
               },
               "additionalProperties": false
             },
-            "events": {
-              "type": "array",
-              "items": {
-                "type": "object"
-              }
-            }
+            "events": { "type": "array", "items": { "type": "object" } }
           },
           "additionalProperties": false
         },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "latest_check_runs_count": {
-          "type": "integer"
-        },
-        "check_runs_url": {
-          "type": "string"
-        },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "latest_check_runs_count": { "type": "integer" },
+        "check_runs_url": { "type": "string" },
         "head_commit": {
           "type": "object",
           "required": [
@@ -353,28 +239,16 @@
             "committer"
           ],
           "properties": {
-            "id": {
-              "type": "string"
-            },
-            "tree_id": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "timestamp": {
-              "type": "string"
-            },
+            "id": { "type": "string" },
+            "tree_id": { "type": "string" },
+            "message": { "type": "string" },
+            "timestamp": { "type": "string" },
             "author": {
               "type": "object",
               "required": ["name", "email"],
               "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                }
+                "name": { "type": "string" },
+                "email": { "type": "string" }
               },
               "additionalProperties": false
             },
@@ -382,12 +256,8 @@
               "type": "object",
               "required": ["name", "email"],
               "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                }
+                "name": { "type": "string" },
+                "email": { "type": "string" }
               },
               "additionalProperties": false
             }
@@ -397,18 +267,10 @@
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "check_suite completed event"

--- a/payload-schemas/schemas/check_suite/requested.schema.json
+++ b/payload-schemas/schemas/check_suite/requested.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "check_suite", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["requested"]
-    },
+    "action": { "type": "string", "enum": ["requested"] },
     "check_suite": {
       "type": "object",
       "required": [
@@ -29,30 +26,13 @@
         "head_commit"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "head_branch": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "head_sha": {
-          "type": "string"
-        },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "head_branch": { "oneOf": [{ "type": "string" }, { "type": "null" }] },
+        "head_sha": { "type": "string" },
         "status": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["requested", "in_progress", "completed", "queued"]
@@ -61,9 +41,7 @@
         },
         "conclusion": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -78,15 +56,9 @@
             }
           ]
         },
-        "url": {
-          "type": "string"
-        },
-        "before": {
-          "type": "string"
-        },
-        "after": {
-          "type": "string"
-        },
+        "url": { "type": "string" },
+        "before": { "type": "string" },
+        "after": { "type": "string" },
         "pull_requests": {
           "type": "array",
           "items": {
@@ -95,38 +67,22 @@
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],
                 "properties": {
-                  "url": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "integer"
-                  },
-                  "number": {
-                    "type": "integer"
-                  },
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
                   "head": {
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -137,25 +93,15 @@
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -184,36 +130,16 @@
             "events"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "slug": {
-              "type": "string"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "owner": {
-              "$ref": "common/user.schema.json"
-            },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "external_url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "slug": { "type": "string" },
+            "node_id": { "type": "string" },
+            "owner": { "$ref": "common/user.schema.json" },
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "external_url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
             "permissions": {
               "type": "object",
               "required": [
@@ -242,34 +168,13 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "actions": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "checks": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "contents": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "deployments": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "issues": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "members": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "metadata": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "actions": { "type": "string", "enum": ["read", "write"] },
+                "checks": { "type": "string", "enum": ["read", "write"] },
+                "contents": { "type": "string", "enum": ["read", "write"] },
+                "deployments": { "type": "string", "enum": ["read", "write"] },
+                "issues": { "type": "string", "enum": ["read", "write"] },
+                "members": { "type": "string", "enum": ["read", "write"] },
+                "metadata": { "type": "string", "enum": ["read", "write"] },
                 "organization_administration": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -290,10 +195,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "pages": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "pages": { "type": "string", "enum": ["read", "write"] },
                 "pull_requests": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -306,10 +208,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "statuses": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "statuses": { "type": "string", "enum": ["read", "write"] },
                 "team_discussions": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -321,27 +220,14 @@
               },
               "additionalProperties": false
             },
-            "events": {
-              "type": "array",
-              "items": {
-                "type": "object"
-              }
-            }
+            "events": { "type": "array", "items": { "type": "object" } }
           },
           "additionalProperties": false
         },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "latest_check_runs_count": {
-          "type": "integer"
-        },
-        "check_runs_url": {
-          "type": "string"
-        },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "latest_check_runs_count": { "type": "integer" },
+        "check_runs_url": { "type": "string" },
         "head_commit": {
           "type": "object",
           "required": [
@@ -353,28 +239,16 @@
             "committer"
           ],
           "properties": {
-            "id": {
-              "type": "string"
-            },
-            "tree_id": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "timestamp": {
-              "type": "string"
-            },
+            "id": { "type": "string" },
+            "tree_id": { "type": "string" },
+            "message": { "type": "string" },
+            "timestamp": { "type": "string" },
             "author": {
               "type": "object",
               "required": ["name", "email"],
               "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                }
+                "name": { "type": "string" },
+                "email": { "type": "string" }
               },
               "additionalProperties": false
             },
@@ -382,12 +256,8 @@
               "type": "object",
               "required": ["name", "email"],
               "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                }
+                "name": { "type": "string" },
+                "email": { "type": "string" }
               },
               "additionalProperties": false
             }
@@ -397,18 +267,10 @@
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "check_suite requested event"

--- a/payload-schemas/schemas/check_suite/rerequested.schema.json
+++ b/payload-schemas/schemas/check_suite/rerequested.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "check_suite", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["rerequested"]
-    },
+    "action": { "type": "string", "enum": ["rerequested"] },
     "check_suite": {
       "type": "object",
       "required": [
@@ -29,30 +26,13 @@
         "head_commit"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "head_branch": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "head_sha": {
-          "type": "string"
-        },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "head_branch": { "oneOf": [{ "type": "string" }, { "type": "null" }] },
+        "head_sha": { "type": "string" },
         "status": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["requested", "in_progress", "completed", "queued"]
@@ -61,9 +41,7 @@
         },
         "conclusion": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -78,15 +56,9 @@
             }
           ]
         },
-        "url": {
-          "type": "string"
-        },
-        "before": {
-          "type": "string"
-        },
-        "after": {
-          "type": "string"
-        },
+        "url": { "type": "string" },
+        "before": { "type": "string" },
+        "after": { "type": "string" },
         "pull_requests": {
           "type": "array",
           "items": {
@@ -95,38 +67,22 @@
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],
                 "properties": {
-                  "url": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "integer"
-                  },
-                  "number": {
-                    "type": "integer"
-                  },
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
                   "head": {
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -137,25 +93,15 @@
                     "type": "object",
                     "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "ref": {
-                        "type": "string"
-                      },
-                      "sha": {
-                        "type": "string"
-                      },
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
                       "repo": {
                         "type": "object",
                         "required": ["id", "url", "name"],
                         "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "url": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
@@ -184,36 +130,16 @@
             "events"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "slug": {
-              "type": "string"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "owner": {
-              "$ref": "common/user.schema.json"
-            },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "external_url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "slug": { "type": "string" },
+            "node_id": { "type": "string" },
+            "owner": { "$ref": "common/user.schema.json" },
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "external_url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
             "permissions": {
               "type": "object",
               "required": [
@@ -242,34 +168,13 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "actions": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "checks": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "contents": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "deployments": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "issues": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "members": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
-                "metadata": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "actions": { "type": "string", "enum": ["read", "write"] },
+                "checks": { "type": "string", "enum": ["read", "write"] },
+                "contents": { "type": "string", "enum": ["read", "write"] },
+                "deployments": { "type": "string", "enum": ["read", "write"] },
+                "issues": { "type": "string", "enum": ["read", "write"] },
+                "members": { "type": "string", "enum": ["read", "write"] },
+                "metadata": { "type": "string", "enum": ["read", "write"] },
                 "organization_administration": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -290,10 +195,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "pages": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "pages": { "type": "string", "enum": ["read", "write"] },
                 "pull_requests": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -306,10 +208,7 @@
                   "type": "string",
                   "enum": ["read", "write"]
                 },
-                "statuses": {
-                  "type": "string",
-                  "enum": ["read", "write"]
-                },
+                "statuses": { "type": "string", "enum": ["read", "write"] },
                 "team_discussions": {
                   "type": "string",
                   "enum": ["read", "write"]
@@ -321,27 +220,14 @@
               },
               "additionalProperties": false
             },
-            "events": {
-              "type": "array",
-              "items": {
-                "type": "object"
-              }
-            }
+            "events": { "type": "array", "items": { "type": "object" } }
           },
           "additionalProperties": false
         },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "latest_check_runs_count": {
-          "type": "integer"
-        },
-        "check_runs_url": {
-          "type": "string"
-        },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "latest_check_runs_count": { "type": "integer" },
+        "check_runs_url": { "type": "string" },
         "head_commit": {
           "type": "object",
           "required": [
@@ -353,28 +239,16 @@
             "committer"
           ],
           "properties": {
-            "id": {
-              "type": "string"
-            },
-            "tree_id": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "timestamp": {
-              "type": "string"
-            },
+            "id": { "type": "string" },
+            "tree_id": { "type": "string" },
+            "message": { "type": "string" },
+            "timestamp": { "type": "string" },
             "author": {
               "type": "object",
               "required": ["name", "email"],
               "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                }
+                "name": { "type": "string" },
+                "email": { "type": "string" }
               },
               "additionalProperties": false
             },
@@ -382,12 +256,8 @@
               "type": "object",
               "required": ["name", "email"],
               "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                }
+                "name": { "type": "string" },
+                "email": { "type": "string" }
               },
               "additionalProperties": false
             }
@@ -397,18 +267,10 @@
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "check_suite rerequested event"

--- a/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
@@ -11,10 +11,7 @@
     "organization"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["appeared_in_branch"]
-    },
+    "action": { "type": "string", "enum": ["appeared_in_branch"] },
     "alert": {
       "type": "object",
       "required": [
@@ -31,18 +28,10 @@
         "tool"
       ],
       "properties": {
-        "number": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
+        "number": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
         "instances": {
           "type": "array",
           "items": {
@@ -51,63 +40,29 @@
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],
                 "properties": {
-                  "ref": {
-                    "type": "string"
-                  },
-                  "analysis_key": {
-                    "type": "string"
-                  },
-                  "environment": {
-                    "type": "string"
-                  },
-                  "state": {
-                    "type": "string"
-                  }
+                  "ref": { "type": "string" },
+                  "analysis_key": { "type": "string" },
+                  "environment": { "type": "string" },
+                  "state": { "type": "string" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "dismissed_by": {
-          "type": "null"
-        },
-        "dismissed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "state": { "type": "string" },
+        "dismissed_by": { "type": "null" },
+        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "dismissed_reason": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],
           "properties": {
-            "id": {
-              "type": "string"
-            },
-            "severity": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            }
+            "id": { "type": "string" },
+            "severity": { "type": "string" },
+            "description": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -115,36 +70,20 @@
           "type": "object",
           "required": ["name", "version"],
           "properties": {
-            "name": {
-              "type": "string"
-            },
-            "version": {
-              "type": "null"
-            }
+            "name": { "type": "string" },
+            "version": { "type": "null" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "ref": {
-      "type": "string"
-    },
-    "commit_oid": {
-      "type": "string"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "ref": { "type": "string" },
+    "commit_oid": { "type": "string" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "code_scanning_alert appeared_in_branch event"

--- a/payload-schemas/schemas/code_scanning_alert/closed_by_user.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/closed_by_user.schema.json
@@ -11,10 +11,7 @@
     "organization"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["closed_by_user"]
-    },
+    "action": { "type": "string", "enum": ["closed_by_user"] },
     "alert": {
       "type": "object",
       "required": [
@@ -31,18 +28,10 @@
         "tool"
       ],
       "properties": {
-        "number": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
+        "number": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
         "instances": {
           "type": "array",
           "items": {
@@ -51,63 +40,29 @@
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],
                 "properties": {
-                  "ref": {
-                    "type": "string"
-                  },
-                  "analysis_key": {
-                    "type": "string"
-                  },
-                  "environment": {
-                    "type": "string"
-                  },
-                  "state": {
-                    "type": "string"
-                  }
+                  "ref": { "type": "string" },
+                  "analysis_key": { "type": "string" },
+                  "environment": { "type": "string" },
+                  "state": { "type": "string" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "dismissed_by": {
-          "type": "null"
-        },
-        "dismissed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "state": { "type": "string" },
+        "dismissed_by": { "type": "null" },
+        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "dismissed_reason": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],
           "properties": {
-            "id": {
-              "type": "string"
-            },
-            "severity": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            }
+            "id": { "type": "string" },
+            "severity": { "type": "string" },
+            "description": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -115,36 +70,20 @@
           "type": "object",
           "required": ["name", "version"],
           "properties": {
-            "name": {
-              "type": "string"
-            },
-            "version": {
-              "type": "null"
-            }
+            "name": { "type": "string" },
+            "version": { "type": "null" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "ref": {
-      "type": "string"
-    },
-    "commit_oid": {
-      "type": "string"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "ref": { "type": "string" },
+    "commit_oid": { "type": "string" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "code_scanning_alert closed_by_user event"

--- a/payload-schemas/schemas/code_scanning_alert/created.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/created.schema.json
@@ -11,10 +11,7 @@
     "organization"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "alert": {
       "type": "object",
       "required": [
@@ -31,18 +28,10 @@
         "tool"
       ],
       "properties": {
-        "number": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
+        "number": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
         "instances": {
           "type": "array",
           "items": {
@@ -51,63 +40,29 @@
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],
                 "properties": {
-                  "ref": {
-                    "type": "string"
-                  },
-                  "analysis_key": {
-                    "type": "string"
-                  },
-                  "environment": {
-                    "type": "string"
-                  },
-                  "state": {
-                    "type": "string"
-                  }
+                  "ref": { "type": "string" },
+                  "analysis_key": { "type": "string" },
+                  "environment": { "type": "string" },
+                  "state": { "type": "string" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "dismissed_by": {
-          "type": "null"
-        },
-        "dismissed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "state": { "type": "string" },
+        "dismissed_by": { "type": "null" },
+        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "dismissed_reason": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],
           "properties": {
-            "id": {
-              "type": "string"
-            },
-            "severity": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            }
+            "id": { "type": "string" },
+            "severity": { "type": "string" },
+            "description": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -115,36 +70,20 @@
           "type": "object",
           "required": ["name", "version"],
           "properties": {
-            "name": {
-              "type": "string"
-            },
-            "version": {
-              "type": "null"
-            }
+            "name": { "type": "string" },
+            "version": { "type": "null" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "ref": {
-      "type": "string"
-    },
-    "commit_oid": {
-      "type": "string"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "ref": { "type": "string" },
+    "commit_oid": { "type": "string" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "code_scanning_alert created event"

--- a/payload-schemas/schemas/code_scanning_alert/fixed.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/fixed.schema.json
@@ -11,10 +11,7 @@
     "organization"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["fixed"]
-    },
+    "action": { "type": "string", "enum": ["fixed"] },
     "alert": {
       "type": "object",
       "required": [
@@ -31,18 +28,10 @@
         "tool"
       ],
       "properties": {
-        "number": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
+        "number": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
         "instances": {
           "type": "array",
           "items": {
@@ -51,63 +40,29 @@
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],
                 "properties": {
-                  "ref": {
-                    "type": "string"
-                  },
-                  "analysis_key": {
-                    "type": "string"
-                  },
-                  "environment": {
-                    "type": "string"
-                  },
-                  "state": {
-                    "type": "string"
-                  }
+                  "ref": { "type": "string" },
+                  "analysis_key": { "type": "string" },
+                  "environment": { "type": "string" },
+                  "state": { "type": "string" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "dismissed_by": {
-          "type": "null"
-        },
-        "dismissed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "state": { "type": "string" },
+        "dismissed_by": { "type": "null" },
+        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "dismissed_reason": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],
           "properties": {
-            "id": {
-              "type": "string"
-            },
-            "severity": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            }
+            "id": { "type": "string" },
+            "severity": { "type": "string" },
+            "description": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -115,36 +70,20 @@
           "type": "object",
           "required": ["name", "version"],
           "properties": {
-            "name": {
-              "type": "string"
-            },
-            "version": {
-              "type": "null"
-            }
+            "name": { "type": "string" },
+            "version": { "type": "null" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "ref": {
-      "type": "string"
-    },
-    "commit_oid": {
-      "type": "string"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "ref": { "type": "string" },
+    "commit_oid": { "type": "string" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "code_scanning_alert fixed event"

--- a/payload-schemas/schemas/code_scanning_alert/reopened.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/reopened.schema.json
@@ -11,10 +11,7 @@
     "organization"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["reopened"]
-    },
+    "action": { "type": "string", "enum": ["reopened"] },
     "alert": {
       "type": "object",
       "required": [
@@ -31,18 +28,10 @@
         "tool"
       ],
       "properties": {
-        "number": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
+        "number": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
         "instances": {
           "type": "array",
           "items": {
@@ -51,63 +40,29 @@
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],
                 "properties": {
-                  "ref": {
-                    "type": "string"
-                  },
-                  "analysis_key": {
-                    "type": "string"
-                  },
-                  "environment": {
-                    "type": "string"
-                  },
-                  "state": {
-                    "type": "string"
-                  }
+                  "ref": { "type": "string" },
+                  "analysis_key": { "type": "string" },
+                  "environment": { "type": "string" },
+                  "state": { "type": "string" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "dismissed_by": {
-          "type": "null"
-        },
-        "dismissed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "state": { "type": "string" },
+        "dismissed_by": { "type": "null" },
+        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "dismissed_reason": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],
           "properties": {
-            "id": {
-              "type": "string"
-            },
-            "severity": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            }
+            "id": { "type": "string" },
+            "severity": { "type": "string" },
+            "description": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -115,36 +70,20 @@
           "type": "object",
           "required": ["name", "version"],
           "properties": {
-            "name": {
-              "type": "string"
-            },
-            "version": {
-              "type": "null"
-            }
+            "name": { "type": "string" },
+            "version": { "type": "null" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "ref": {
-      "type": "string"
-    },
-    "commit_oid": {
-      "type": "string"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "ref": { "type": "string" },
+    "commit_oid": { "type": "string" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "code_scanning_alert reopened event"

--- a/payload-schemas/schemas/code_scanning_alert/reopened_by_user.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/reopened_by_user.schema.json
@@ -11,10 +11,7 @@
     "organization"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["reopened_by_user"]
-    },
+    "action": { "type": "string", "enum": ["reopened_by_user"] },
     "alert": {
       "type": "object",
       "required": [
@@ -31,18 +28,10 @@
         "tool"
       ],
       "properties": {
-        "number": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
+        "number": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
         "instances": {
           "type": "array",
           "items": {
@@ -51,63 +40,29 @@
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],
                 "properties": {
-                  "ref": {
-                    "type": "string"
-                  },
-                  "analysis_key": {
-                    "type": "string"
-                  },
-                  "environment": {
-                    "type": "string"
-                  },
-                  "state": {
-                    "type": "string"
-                  }
+                  "ref": { "type": "string" },
+                  "analysis_key": { "type": "string" },
+                  "environment": { "type": "string" },
+                  "state": { "type": "string" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "dismissed_by": {
-          "type": "null"
-        },
-        "dismissed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "state": { "type": "string" },
+        "dismissed_by": { "type": "null" },
+        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "dismissed_reason": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],
           "properties": {
-            "id": {
-              "type": "string"
-            },
-            "severity": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            }
+            "id": { "type": "string" },
+            "severity": { "type": "string" },
+            "description": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -115,36 +70,20 @@
           "type": "object",
           "required": ["name", "version"],
           "properties": {
-            "name": {
-              "type": "string"
-            },
-            "version": {
-              "type": "null"
-            }
+            "name": { "type": "string" },
+            "version": { "type": "null" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "ref": {
-      "type": "string"
-    },
-    "commit_oid": {
-      "type": "string"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "ref": { "type": "string" },
+    "commit_oid": { "type": "string" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "code_scanning_alert reopened_by_user event"

--- a/payload-schemas/schemas/commit_comment/created.schema.json
+++ b/payload-schemas/schemas/commit_comment/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "comment", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "comment": {
       "type": "object",
       "required": [
@@ -26,60 +23,26 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "position": {
-          "type": "null"
-        },
-        "line": {
-          "type": "null"
-        },
-        "path": {
-          "type": "null"
-        },
-        "commit_id": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "author_association": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "position": { "type": "null" },
+        "line": { "type": "null" },
+        "path": { "type": "null" },
+        "commit_id": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "author_association": { "type": "string" },
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "commit_comment created event"

--- a/payload-schemas/schemas/common/installation.schema.json
+++ b/payload-schemas/schemas/common/installation.schema.json
@@ -4,12 +4,8 @@
   "type": "object",
   "required": ["id", "node_id"],
   "properties": {
-    "id": {
-      "type": "integer"
-    },
-    "node_id": {
-      "type": "string"
-    }
+    "id": { "type": "integer" },
+    "node_id": { "type": "string" }
   },
   "additionalProperties": false,
   "title": "Installation"

--- a/payload-schemas/schemas/common/organization.schema.json
+++ b/payload-schemas/schemas/common/organization.schema.json
@@ -17,45 +17,19 @@
     "description"
   ],
   "properties": {
-    "login": {
-      "type": "string"
-    },
-    "id": {
-      "type": "integer"
-    },
-    "node_id": {
-      "type": "string"
-    },
-    "url": {
-      "type": "string"
-    },
-    "html_url": {
-      "type": "string"
-    },
-    "repos_url": {
-      "type": "string"
-    },
-    "events_url": {
-      "type": "string"
-    },
-    "hooks_url": {
-      "type": "string"
-    },
-    "issues_url": {
-      "type": "string"
-    },
-    "members_url": {
-      "type": "string"
-    },
-    "public_members_url": {
-      "type": "string"
-    },
-    "avatar_url": {
-      "type": "string"
-    },
-    "description": {
-      "type": "string"
-    }
+    "login": { "type": "string" },
+    "id": { "type": "integer" },
+    "node_id": { "type": "string" },
+    "url": { "type": "string" },
+    "html_url": { "type": "string" },
+    "repos_url": { "type": "string" },
+    "events_url": { "type": "string" },
+    "hooks_url": { "type": "string" },
+    "issues_url": { "type": "string" },
+    "members_url": { "type": "string" },
+    "public_members_url": { "type": "string" },
+    "avatar_url": { "type": "string" },
+    "description": { "type": "string" }
   },
   "additionalProperties": false,
   "title": "Organization"

--- a/payload-schemas/schemas/common/repository.schema.json
+++ b/payload-schemas/schemas/common/repository.schema.json
@@ -77,21 +77,11 @@
     "default_branch"
   ],
   "properties": {
-    "id": {
-      "type": "integer"
-    },
-    "node_id": {
-      "type": "string"
-    },
-    "name": {
-      "type": "string"
-    },
-    "full_name": {
-      "type": "string"
-    },
-    "private": {
-      "type": "boolean"
-    },
+    "id": { "type": "integer" },
+    "node_id": { "type": "string" },
+    "name": { "type": "string" },
+    "full_name": { "type": "string" },
+    "private": { "type": "boolean" },
     "owner": {
       "type": "object",
       "required": [
@@ -115,396 +105,130 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "name": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "email": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "name": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "email": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "html_url": {
-      "type": "string"
-    },
-    "description": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "fork": {
-      "type": "boolean"
-    },
-    "url": {
-      "type": "string"
-    },
-    "forks_url": {
-      "type": "string"
-    },
-    "keys_url": {
-      "type": "string"
-    },
-    "collaborators_url": {
-      "type": "string"
-    },
-    "teams_url": {
-      "type": "string"
-    },
-    "hooks_url": {
-      "type": "string"
-    },
-    "issue_events_url": {
-      "type": "string"
-    },
-    "events_url": {
-      "type": "string"
-    },
-    "assignees_url": {
-      "type": "string"
-    },
-    "branches_url": {
-      "type": "string"
-    },
-    "tags_url": {
-      "type": "string"
-    },
-    "blobs_url": {
-      "type": "string"
-    },
-    "git_tags_url": {
-      "type": "string"
-    },
-    "git_refs_url": {
-      "type": "string"
-    },
-    "trees_url": {
-      "type": "string"
-    },
-    "statuses_url": {
-      "type": "string"
-    },
-    "languages_url": {
-      "type": "string"
-    },
-    "stargazers_url": {
-      "type": "string"
-    },
-    "contributors_url": {
-      "type": "string"
-    },
-    "subscribers_url": {
-      "type": "string"
-    },
-    "subscription_url": {
-      "type": "string"
-    },
-    "commits_url": {
-      "type": "string"
-    },
-    "git_commits_url": {
-      "type": "string"
-    },
-    "comments_url": {
-      "type": "string"
-    },
-    "issue_comment_url": {
-      "type": "string"
-    },
-    "contents_url": {
-      "type": "string"
-    },
-    "compare_url": {
-      "type": "string"
-    },
-    "merges_url": {
-      "type": "string"
-    },
-    "archive_url": {
-      "type": "string"
-    },
-    "downloads_url": {
-      "type": "string"
-    },
-    "issues_url": {
-      "type": "string"
-    },
-    "pulls_url": {
-      "type": "string"
-    },
-    "milestones_url": {
-      "type": "string"
-    },
-    "notifications_url": {
-      "type": "string"
-    },
-    "labels_url": {
-      "type": "string"
-    },
-    "releases_url": {
-      "type": "string"
-    },
-    "deployments_url": {
-      "type": "string"
-    },
-    "created_at": {
-      "oneOf": [
-        {
-          "type": "integer"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "updated_at": {
-      "type": "string"
-    },
-    "pushed_at": {
-      "oneOf": [
-        {
-          "type": "integer"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "git_url": {
-      "type": "string"
-    },
-    "ssh_url": {
-      "type": "string"
-    },
-    "clone_url": {
-      "type": "string"
-    },
-    "svn_url": {
-      "type": "string"
-    },
-    "homepage": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "size": {
-      "type": "integer"
-    },
-    "stargazers_count": {
-      "type": "integer"
-    },
-    "watchers_count": {
-      "type": "integer"
-    },
-    "language": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "has_issues": {
-      "type": "boolean"
-    },
-    "has_projects": {
-      "type": "boolean"
-    },
-    "has_downloads": {
-      "type": "boolean"
-    },
-    "has_wiki": {
-      "type": "boolean"
-    },
-    "has_pages": {
-      "type": "boolean"
-    },
-    "forks_count": {
-      "type": "integer"
-    },
-    "mirror_url": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "archived": {
-      "type": "boolean"
-    },
-    "disabled": {
-      "type": "boolean"
-    },
-    "open_issues_count": {
-      "type": "integer"
-    },
+    "html_url": { "type": "string" },
+    "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "fork": { "type": "boolean" },
+    "url": { "type": "string" },
+    "forks_url": { "type": "string" },
+    "keys_url": { "type": "string" },
+    "collaborators_url": { "type": "string" },
+    "teams_url": { "type": "string" },
+    "hooks_url": { "type": "string" },
+    "issue_events_url": { "type": "string" },
+    "events_url": { "type": "string" },
+    "assignees_url": { "type": "string" },
+    "branches_url": { "type": "string" },
+    "tags_url": { "type": "string" },
+    "blobs_url": { "type": "string" },
+    "git_tags_url": { "type": "string" },
+    "git_refs_url": { "type": "string" },
+    "trees_url": { "type": "string" },
+    "statuses_url": { "type": "string" },
+    "languages_url": { "type": "string" },
+    "stargazers_url": { "type": "string" },
+    "contributors_url": { "type": "string" },
+    "subscribers_url": { "type": "string" },
+    "subscription_url": { "type": "string" },
+    "commits_url": { "type": "string" },
+    "git_commits_url": { "type": "string" },
+    "comments_url": { "type": "string" },
+    "issue_comment_url": { "type": "string" },
+    "contents_url": { "type": "string" },
+    "compare_url": { "type": "string" },
+    "merges_url": { "type": "string" },
+    "archive_url": { "type": "string" },
+    "downloads_url": { "type": "string" },
+    "issues_url": { "type": "string" },
+    "pulls_url": { "type": "string" },
+    "milestones_url": { "type": "string" },
+    "notifications_url": { "type": "string" },
+    "labels_url": { "type": "string" },
+    "releases_url": { "type": "string" },
+    "deployments_url": { "type": "string" },
+    "created_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+    "updated_at": { "type": "string" },
+    "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+    "git_url": { "type": "string" },
+    "ssh_url": { "type": "string" },
+    "clone_url": { "type": "string" },
+    "svn_url": { "type": "string" },
+    "homepage": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "size": { "type": "integer" },
+    "stargazers_count": { "type": "integer" },
+    "watchers_count": { "type": "integer" },
+    "language": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "has_issues": { "type": "boolean" },
+    "has_projects": { "type": "boolean" },
+    "has_downloads": { "type": "boolean" },
+    "has_wiki": { "type": "boolean" },
+    "has_pages": { "type": "boolean" },
+    "forks_count": { "type": "integer" },
+    "mirror_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "archived": { "type": "boolean" },
+    "disabled": { "type": "boolean" },
+    "open_issues_count": { "type": "integer" },
     "license": {
       "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        },
+        { "type": "null" },
+        { "type": "string" },
         {
           "type": "object",
           "properties": {
-            "key": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "spdx_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "node_id": {
-              "type": "string"
-            }
+            "key": { "type": "string" },
+            "name": { "type": "string" },
+            "spdx_id": { "type": "string" },
+            "url": { "type": "string" },
+            "node_id": { "type": "string" }
           }
         }
       ]
     },
-    "forks": {
-      "type": "integer"
-    },
-    "open_issues": {
-      "type": "integer"
-    },
-    "watchers": {
-      "type": "integer"
-    },
-    "stargazers": {
-      "type": "integer"
-    },
-    "default_branch": {
-      "type": "string"
-    },
-    "allow_squash_merge": {
-      "type": "boolean"
-    },
-    "allow_merge_commit": {
-      "type": "boolean"
-    },
-    "allow_rebase_merge": {
-      "type": "boolean"
-    },
-    "delete_branch_on_merge": {
-      "type": "boolean"
-    },
-    "master_branch": {
-      "type": "string"
-    },
+    "forks": { "type": "integer" },
+    "open_issues": { "type": "integer" },
+    "watchers": { "type": "integer" },
+    "stargazers": { "type": "integer" },
+    "default_branch": { "type": "string" },
+    "allow_squash_merge": { "type": "boolean" },
+    "allow_merge_commit": { "type": "boolean" },
+    "allow_rebase_merge": { "type": "boolean" },
+    "delete_branch_on_merge": { "type": "boolean" },
+    "master_branch": { "type": "string" },
     "permissions": {
       "type": "object",
       "required": ["pull", "push", "admin"],
       "properties": {
-        "pull": {
-          "type": "boolean"
-        },
-        "push": {
-          "type": "boolean"
-        },
-        "admin": {
-          "type": "boolean"
-        },
-        "maintain": {
-          "type": "boolean"
-        },
-        "triage": {
-          "type": "boolean"
-        }
+        "pull": { "type": "boolean" },
+        "push": { "type": "boolean" },
+        "admin": { "type": "boolean" },
+        "maintain": { "type": "boolean" },
+        "triage": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "public": {
-      "type": "boolean"
-    }
+    "public": { "type": "boolean" }
   },
   "additionalProperties": false,
   "title": "Repository"

--- a/payload-schemas/schemas/common/user.schema.json
+++ b/payload-schemas/schemas/common/user.schema.json
@@ -23,61 +23,24 @@
     "site_admin"
   ],
   "properties": {
-    "login": {
-      "type": "string"
-    },
-    "id": {
-      "type": "integer"
-    },
-    "node_id": {
-      "type": "string"
-    },
-    "avatar_url": {
-      "type": "string"
-    },
-    "gravatar_id": {
-      "type": "string"
-    },
-    "url": {
-      "type": "string"
-    },
-    "html_url": {
-      "type": "string"
-    },
-    "followers_url": {
-      "type": "string"
-    },
-    "following_url": {
-      "type": "string"
-    },
-    "gists_url": {
-      "type": "string"
-    },
-    "starred_url": {
-      "type": "string"
-    },
-    "subscriptions_url": {
-      "type": "string"
-    },
-    "organizations_url": {
-      "type": "string"
-    },
-    "repos_url": {
-      "type": "string"
-    },
-    "events_url": {
-      "type": "string"
-    },
-    "received_events_url": {
-      "type": "string"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["Bot", "User", "Organization"]
-    },
-    "site_admin": {
-      "type": "boolean"
-    }
+    "login": { "type": "string" },
+    "id": { "type": "integer" },
+    "node_id": { "type": "string" },
+    "avatar_url": { "type": "string" },
+    "gravatar_id": { "type": "string" },
+    "url": { "type": "string" },
+    "html_url": { "type": "string" },
+    "followers_url": { "type": "string" },
+    "following_url": { "type": "string" },
+    "gists_url": { "type": "string" },
+    "starred_url": { "type": "string" },
+    "subscriptions_url": { "type": "string" },
+    "organizations_url": { "type": "string" },
+    "repos_url": { "type": "string" },
+    "events_url": { "type": "string" },
+    "received_events_url": { "type": "string" },
+    "type": { "type": "string", "enum": ["Bot", "User", "Organization"] },
+    "site_admin": { "type": "boolean" }
   },
   "additionalProperties": false,
   "title": "User"

--- a/payload-schemas/schemas/content_reference/created.schema.json
+++ b/payload-schemas/schemas/content_reference/created.schema.json
@@ -10,38 +10,21 @@
     "installation"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "content_reference": {
       "type": "object",
       "required": ["id", "node_id", "reference"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "reference": {
-          "type": "string"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "reference": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "content_reference created event"

--- a/payload-schemas/schemas/create/event.schema.json
+++ b/payload-schemas/schemas/create/event.schema.json
@@ -12,40 +12,15 @@
     "sender"
   ],
   "properties": {
-    "ref": {
-      "type": "string"
-    },
-    "ref_type": {
-      "type": "string"
-    },
-    "master_branch": {
-      "type": "string"
-    },
-    "description": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "pusher_type": {
-      "type": "string"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "ref": { "type": "string" },
+    "ref_type": { "type": "string" },
+    "master_branch": { "type": "string" },
+    "description": { "oneOf": [{ "type": "string" }, { "type": "null" }] },
+    "pusher_type": { "type": "string" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "create event"

--- a/payload-schemas/schemas/delete/event.schema.json
+++ b/payload-schemas/schemas/delete/event.schema.json
@@ -4,27 +4,13 @@
   "type": "object",
   "required": ["ref", "ref_type", "pusher_type", "repository", "sender"],
   "properties": {
-    "ref": {
-      "type": "string"
-    },
-    "ref_type": {
-      "type": "string"
-    },
-    "pusher_type": {
-      "type": "string"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "ref": { "type": "string" },
+    "ref_type": { "type": "string" },
+    "pusher_type": { "type": "string" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "delete event"

--- a/payload-schemas/schemas/deploy_key/created.schema.json
+++ b/payload-schemas/schemas/deploy_key/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "key", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "key": {
       "type": "object",
       "required": [
@@ -20,42 +17,20 @@
         "read_only"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "key": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "verified": {
-          "type": "boolean"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "read_only": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "key": { "type": "string" },
+        "url": { "type": "string" },
+        "title": { "type": "string" },
+        "verified": { "type": "boolean" },
+        "created_at": { "type": "string" },
+        "read_only": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "deploy_key created event"

--- a/payload-schemas/schemas/deploy_key/deleted.schema.json
+++ b/payload-schemas/schemas/deploy_key/deleted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "key", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "key": {
       "type": "object",
       "required": [
@@ -20,42 +17,20 @@
         "read_only"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "key": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "verified": {
-          "type": "boolean"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "read_only": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "key": { "type": "string" },
+        "url": { "type": "string" },
+        "title": { "type": "string" },
+        "verified": { "type": "boolean" },
+        "created_at": { "type": "string" },
+        "read_only": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "deploy_key deleted event"

--- a/payload-schemas/schemas/deployment/created.schema.json
+++ b/payload-schemas/schemas/deployment/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "deployment", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "deployment": {
       "type": "object",
       "required": [
@@ -28,71 +25,33 @@
         "repository_url"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "sha": {
-          "type": "string"
-        },
-        "ref": {
-          "type": "string"
-        },
-        "task": {
-          "type": "string"
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "sha": { "type": "string" },
+        "ref": { "type": "string" },
+        "task": { "type": "string" },
         "payload": {
           "type": "object",
           "required": [],
           "additionalProperties": false
         },
-        "original_environment": {
-          "type": "string"
-        },
-        "environment": {
-          "type": "string"
-        },
-        "description": {
-          "type": "null"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "performed_via_github_app": {
-          "type": "null"
-        }
+        "original_environment": { "type": "string" },
+        "environment": { "type": "string" },
+        "description": { "type": "null" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "statuses_url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "performed_via_github_app": { "type": "null" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "deployment created event"

--- a/payload-schemas/schemas/deployment_status/created.schema.json
+++ b/payload-schemas/schemas/deployment_status/created.schema.json
@@ -10,10 +10,7 @@
     "sender"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "deployment_status": {
       "type": "object",
       "required": [
@@ -31,45 +28,19 @@
         "repository_url"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "description": {
-          "type": "string"
-        },
-        "environment": {
-          "type": "string"
-        },
-        "target_url": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "deployment_url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "performed_via_github_app": {
-          "type": "null"
-        }
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "state": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "description": { "type": "string" },
+        "environment": { "type": "string" },
+        "target_url": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "deployment_url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "performed_via_github_app": { "type": "null" }
       },
       "additionalProperties": false
     },
@@ -93,38 +64,20 @@
         "repository_url"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "sha": {
-          "type": "string"
-        },
-        "ref": {
-          "type": "string"
-        },
-        "task": {
-          "type": "string"
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "sha": { "type": "string" },
+        "ref": { "type": "string" },
+        "task": { "type": "string" },
         "payload": {
           "type": "object",
           "required": [],
           "additionalProperties": false
         },
-        "original_environment": {
-          "type": "string"
-        },
-        "environment": {
-          "type": "string"
-        },
-        "description": {
-          "type": "null"
-        },
+        "original_environment": { "type": "string" },
+        "environment": { "type": "string" },
+        "description": { "type": "null" },
         "creator": {
           "type": "object",
           "required": [
@@ -148,90 +101,38 @@
             "site_admin"
           ],
           "properties": {
-            "login": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "avatar_url": {
-              "type": "string"
-            },
-            "gravatar_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "followers_url": {
-              "type": "string"
-            },
-            "following_url": {
-              "type": "string"
-            },
-            "gists_url": {
-              "type": "string"
-            },
-            "starred_url": {
-              "type": "string"
-            },
-            "subscriptions_url": {
-              "type": "string"
-            },
-            "organizations_url": {
-              "type": "string"
-            },
-            "repos_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "received_events_url": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "site_admin": {
-              "type": "boolean"
-            }
+            "login": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "avatar_url": { "type": "string" },
+            "gravatar_id": { "type": "string" },
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "followers_url": { "type": "string" },
+            "following_url": { "type": "string" },
+            "gists_url": { "type": "string" },
+            "starred_url": { "type": "string" },
+            "subscriptions_url": { "type": "string" },
+            "organizations_url": { "type": "string" },
+            "repos_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "received_events_url": { "type": "string" },
+            "type": { "type": "string" },
+            "site_admin": { "type": "boolean" }
           },
           "additionalProperties": false
         },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        }
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "statuses_url": { "type": "string" },
+        "repository_url": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "deployment_status created event"

--- a/payload-schemas/schemas/fork/event.schema.json
+++ b/payload-schemas/schemas/fork/event.schema.json
@@ -4,21 +4,11 @@
   "type": "object",
   "required": ["forkee", "repository", "sender"],
   "properties": {
-    "forkee": {
-      "$ref": "common/repository.schema.json"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "forkee": { "$ref": "common/repository.schema.json" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "fork event"

--- a/payload-schemas/schemas/github_app_authorization/revoked.schema.json
+++ b/payload-schemas/schemas/github_app_authorization/revoked.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["revoked"]
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "action": { "type": "string", "enum": ["revoked"] },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "github_app_authorization revoked event"

--- a/payload-schemas/schemas/gollum/event.schema.json
+++ b/payload-schemas/schemas/gollum/event.schema.json
@@ -19,43 +19,22 @@
               "html_url"
             ],
             "properties": {
-              "page_name": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              },
-              "summary": {
-                "type": "null"
-              },
-              "action": {
-                "type": "string",
-                "enum": ["created", "edited"]
-              },
-              "sha": {
-                "type": "string"
-              },
-              "html_url": {
-                "type": "string"
-              }
+              "page_name": { "type": "string" },
+              "title": { "type": "string" },
+              "summary": { "type": "null" },
+              "action": { "type": "string", "enum": ["created", "edited"] },
+              "sha": { "type": "string" },
+              "html_url": { "type": "string" }
             },
             "additionalProperties": false
           }
         ]
       }
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "gollum event"

--- a/payload-schemas/schemas/installation/created.schema.json
+++ b/payload-schemas/schemas/installation/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "installation", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "installation": {
       "type": "object",
       "required": [
@@ -27,9 +24,7 @@
         "single_file_name"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
+        "id": { "type": "integer" },
         "account": {
           "type": "object",
           "required": [
@@ -53,60 +48,24 @@
             "site_admin"
           ],
           "properties": {
-            "login": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "avatar_url": {
-              "type": "string"
-            },
-            "gravatar_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "followers_url": {
-              "type": "string"
-            },
-            "following_url": {
-              "type": "string"
-            },
-            "gists_url": {
-              "type": "string"
-            },
-            "starred_url": {
-              "type": "string"
-            },
-            "subscriptions_url": {
-              "type": "string"
-            },
-            "organizations_url": {
-              "type": "string"
-            },
-            "repos_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "received_events_url": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "site_admin": {
-              "type": "boolean"
-            }
+            "login": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "avatar_url": { "type": "string" },
+            "gravatar_id": { "type": "string" },
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "followers_url": { "type": "string" },
+            "following_url": { "type": "string" },
+            "gists_url": { "type": "string" },
+            "starred_url": { "type": "string" },
+            "subscriptions_url": { "type": "string" },
+            "organizations_url": { "type": "string" },
+            "repos_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "received_events_url": { "type": "string" },
+            "type": { "type": "string" },
+            "site_admin": { "type": "boolean" }
           },
           "additionalProperties": false
         },
@@ -114,75 +73,31 @@
           "type": "string",
           "enum": ["all", "selected"]
         },
-        "access_tokens_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "app_id": {
-          "type": "integer"
-        },
-        "app_slug": {
-          "type": "string"
-        },
-        "target_id": {
-          "type": "integer"
-        },
-        "target_type": {
-          "type": "string",
-          "enum": ["User", "Organization"]
-        },
+        "access_tokens_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "app_id": { "type": "integer" },
+        "app_slug": { "type": "string" },
+        "target_id": { "type": "integer" },
+        "target_type": { "type": "string", "enum": ["User", "Organization"] },
         "permissions": {
           "type": "object",
           "required": [],
           "properties": {
-            "administration": {
-              "type": "string"
-            },
-            "checks": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "contents": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "deployments": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "issues": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "pages": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "pull_requests": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "repository_hooks": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
+            "administration": { "type": "string" },
+            "checks": { "type": "string", "enum": ["read", "write"] },
+            "contents": { "type": "string", "enum": ["read", "write"] },
+            "deployments": { "type": "string", "enum": ["read", "write"] },
+            "issues": { "type": "string", "enum": ["read", "write"] },
+            "pages": { "type": "string", "enum": ["read", "write"] },
+            "pull_requests": { "type": "string", "enum": ["read", "write"] },
+            "repository_hooks": { "type": "string", "enum": ["read", "write"] },
             "repository_projects": {
               "type": "string",
               "enum": ["read", "write"]
             },
-            "statuses": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "metadata": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
+            "statuses": { "type": "string", "enum": ["read", "write"] },
+            "metadata": { "type": "string", "enum": ["read", "write"] },
             "vulnerability_alerts": {
               "type": "string",
               "enum": ["read", "write"]
@@ -190,55 +105,16 @@
           },
           "additionalProperties": false
         },
-        "events": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "integer"
-        },
-        "updated_at": {
-          "type": "integer"
-        },
+        "events": { "type": "array", "items": { "type": "string" } },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" },
         "single_file_name": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
-        "has_multiple_single_files": {
-          "type": "boolean"
-        },
-        "single_file_paths": {
-          "type": "array",
-          "items": {}
-        },
-        "suspended_by": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "suspended_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
+        "has_multiple_single_files": { "type": "boolean" },
+        "single_file_paths": { "type": "array", "items": {} },
+        "suspended_by": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "suspended_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
       },
       "additionalProperties": false
     },
@@ -250,33 +126,19 @@
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],
             "properties": {
-              "id": {
-                "type": "integer"
-              },
-              "node_id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "full_name": {
-                "type": "string"
-              },
-              "private": {
-                "type": "boolean"
-              }
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "full_name": { "type": "string" },
+              "private": { "type": "boolean" }
             },
             "additionalProperties": false
           }
         ]
       }
     },
-    "requester": {
-      "type": "null"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "requester": { "type": "null" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "installation created event"

--- a/payload-schemas/schemas/installation/deleted.schema.json
+++ b/payload-schemas/schemas/installation/deleted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "installation", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "installation": {
       "type": "object",
       "required": [
@@ -27,9 +24,7 @@
         "single_file_name"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
+        "id": { "type": "integer" },
         "account": {
           "type": "object",
           "required": [
@@ -53,60 +48,24 @@
             "site_admin"
           ],
           "properties": {
-            "login": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "avatar_url": {
-              "type": "string"
-            },
-            "gravatar_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "followers_url": {
-              "type": "string"
-            },
-            "following_url": {
-              "type": "string"
-            },
-            "gists_url": {
-              "type": "string"
-            },
-            "starred_url": {
-              "type": "string"
-            },
-            "subscriptions_url": {
-              "type": "string"
-            },
-            "organizations_url": {
-              "type": "string"
-            },
-            "repos_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "received_events_url": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "site_admin": {
-              "type": "boolean"
-            }
+            "login": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "avatar_url": { "type": "string" },
+            "gravatar_id": { "type": "string" },
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "followers_url": { "type": "string" },
+            "following_url": { "type": "string" },
+            "gists_url": { "type": "string" },
+            "starred_url": { "type": "string" },
+            "subscriptions_url": { "type": "string" },
+            "organizations_url": { "type": "string" },
+            "repos_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "received_events_url": { "type": "string" },
+            "type": { "type": "string" },
+            "site_admin": { "type": "boolean" }
           },
           "additionalProperties": false
         },
@@ -114,75 +73,31 @@
           "type": "string",
           "enum": ["all", "selected"]
         },
-        "access_tokens_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "app_id": {
-          "type": "integer"
-        },
-        "app_slug": {
-          "type": "string"
-        },
-        "target_id": {
-          "type": "integer"
-        },
-        "target_type": {
-          "type": "string",
-          "enum": ["User", "Organization"]
-        },
+        "access_tokens_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "app_id": { "type": "integer" },
+        "app_slug": { "type": "string" },
+        "target_id": { "type": "integer" },
+        "target_type": { "type": "string", "enum": ["User", "Organization"] },
         "permissions": {
           "type": "object",
           "required": [],
           "properties": {
-            "administration": {
-              "type": "string"
-            },
-            "checks": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "contents": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "deployments": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "issues": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "pages": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "pull_requests": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "repository_hooks": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
+            "administration": { "type": "string" },
+            "checks": { "type": "string", "enum": ["read", "write"] },
+            "contents": { "type": "string", "enum": ["read", "write"] },
+            "deployments": { "type": "string", "enum": ["read", "write"] },
+            "issues": { "type": "string", "enum": ["read", "write"] },
+            "pages": { "type": "string", "enum": ["read", "write"] },
+            "pull_requests": { "type": "string", "enum": ["read", "write"] },
+            "repository_hooks": { "type": "string", "enum": ["read", "write"] },
             "repository_projects": {
               "type": "string",
               "enum": ["read", "write"]
             },
-            "statuses": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "metadata": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
+            "statuses": { "type": "string", "enum": ["read", "write"] },
+            "metadata": { "type": "string", "enum": ["read", "write"] },
             "vulnerability_alerts": {
               "type": "string",
               "enum": ["read", "write"]
@@ -190,55 +105,16 @@
           },
           "additionalProperties": false
         },
-        "events": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "integer"
-        },
-        "updated_at": {
-          "type": "integer"
-        },
+        "events": { "type": "array", "items": { "type": "string" } },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" },
         "single_file_name": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
-        "has_multiple_single_files": {
-          "type": "boolean"
-        },
-        "single_file_paths": {
-          "type": "array",
-          "items": {}
-        },
-        "suspended_by": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "suspended_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
+        "has_multiple_single_files": { "type": "boolean" },
+        "single_file_paths": { "type": "array", "items": {} },
+        "suspended_by": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "suspended_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
       },
       "additionalProperties": false
     },
@@ -250,33 +126,19 @@
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],
             "properties": {
-              "id": {
-                "type": "integer"
-              },
-              "node_id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "full_name": {
-                "type": "string"
-              },
-              "private": {
-                "type": "boolean"
-              }
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "full_name": { "type": "string" },
+              "private": { "type": "boolean" }
             },
             "additionalProperties": false
           }
         ]
       }
     },
-    "requester": {
-      "type": "null"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "requester": { "type": "null" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "installation deleted event"

--- a/payload-schemas/schemas/installation/new_permissions_accepted.schema.json
+++ b/payload-schemas/schemas/installation/new_permissions_accepted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "installation", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["new_permissions_accepted"]
-    },
+    "action": { "type": "string", "enum": ["new_permissions_accepted"] },
     "installation": {
       "type": "object",
       "required": [
@@ -27,9 +24,7 @@
         "single_file_name"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
+        "id": { "type": "integer" },
         "account": {
           "type": "object",
           "required": [
@@ -53,60 +48,24 @@
             "site_admin"
           ],
           "properties": {
-            "login": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "avatar_url": {
-              "type": "string"
-            },
-            "gravatar_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "followers_url": {
-              "type": "string"
-            },
-            "following_url": {
-              "type": "string"
-            },
-            "gists_url": {
-              "type": "string"
-            },
-            "starred_url": {
-              "type": "string"
-            },
-            "subscriptions_url": {
-              "type": "string"
-            },
-            "organizations_url": {
-              "type": "string"
-            },
-            "repos_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "received_events_url": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "site_admin": {
-              "type": "boolean"
-            }
+            "login": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "avatar_url": { "type": "string" },
+            "gravatar_id": { "type": "string" },
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "followers_url": { "type": "string" },
+            "following_url": { "type": "string" },
+            "gists_url": { "type": "string" },
+            "starred_url": { "type": "string" },
+            "subscriptions_url": { "type": "string" },
+            "organizations_url": { "type": "string" },
+            "repos_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "received_events_url": { "type": "string" },
+            "type": { "type": "string" },
+            "site_admin": { "type": "boolean" }
           },
           "additionalProperties": false
         },
@@ -114,75 +73,31 @@
           "type": "string",
           "enum": ["all", "selected"]
         },
-        "access_tokens_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "app_id": {
-          "type": "integer"
-        },
-        "app_slug": {
-          "type": "string"
-        },
-        "target_id": {
-          "type": "integer"
-        },
-        "target_type": {
-          "type": "string",
-          "enum": ["User", "Organization"]
-        },
+        "access_tokens_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "app_id": { "type": "integer" },
+        "app_slug": { "type": "string" },
+        "target_id": { "type": "integer" },
+        "target_type": { "type": "string", "enum": ["User", "Organization"] },
         "permissions": {
           "type": "object",
           "required": [],
           "properties": {
-            "administration": {
-              "type": "string"
-            },
-            "checks": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "contents": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "deployments": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "issues": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "pages": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "pull_requests": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "repository_hooks": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
+            "administration": { "type": "string" },
+            "checks": { "type": "string", "enum": ["read", "write"] },
+            "contents": { "type": "string", "enum": ["read", "write"] },
+            "deployments": { "type": "string", "enum": ["read", "write"] },
+            "issues": { "type": "string", "enum": ["read", "write"] },
+            "pages": { "type": "string", "enum": ["read", "write"] },
+            "pull_requests": { "type": "string", "enum": ["read", "write"] },
+            "repository_hooks": { "type": "string", "enum": ["read", "write"] },
             "repository_projects": {
               "type": "string",
               "enum": ["read", "write"]
             },
-            "statuses": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
-            "metadata": {
-              "type": "string",
-              "enum": ["read", "write"]
-            },
+            "statuses": { "type": "string", "enum": ["read", "write"] },
+            "metadata": { "type": "string", "enum": ["read", "write"] },
             "vulnerability_alerts": {
               "type": "string",
               "enum": ["read", "write"]
@@ -190,55 +105,16 @@
           },
           "additionalProperties": false
         },
-        "events": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "created_at": {
-          "type": "integer"
-        },
-        "updated_at": {
-          "type": "integer"
-        },
+        "events": { "type": "array", "items": { "type": "string" } },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" },
         "single_file_name": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
-        "has_multiple_single_files": {
-          "type": "boolean"
-        },
-        "single_file_paths": {
-          "type": "array",
-          "items": {}
-        },
-        "suspended_by": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "suspended_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
+        "has_multiple_single_files": { "type": "boolean" },
+        "single_file_paths": { "type": "array", "items": {} },
+        "suspended_by": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "suspended_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
       },
       "additionalProperties": false
     },
@@ -250,33 +126,19 @@
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],
             "properties": {
-              "id": {
-                "type": "integer"
-              },
-              "node_id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "full_name": {
-                "type": "string"
-              },
-              "private": {
-                "type": "boolean"
-              }
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "full_name": { "type": "string" },
+              "private": { "type": "boolean" }
             },
             "additionalProperties": false
           }
         ]
       }
     },
-    "requester": {
-      "type": "null"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "requester": { "type": "null" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "installation new_permissions_accepted event"

--- a/payload-schemas/schemas/installation_repositories/added.schema.json
+++ b/payload-schemas/schemas/installation_repositories/added.schema.json
@@ -11,10 +11,7 @@
     "sender"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["added"]
-    },
+    "action": { "type": "string", "enum": ["added"] },
     "installation": {
       "type": "object",
       "required": [
@@ -34,9 +31,7 @@
         "single_file_name"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
+        "id": { "type": "integer" },
         "account": {
           "type": "object",
           "required": [
@@ -60,153 +55,63 @@
             "site_admin"
           ],
           "properties": {
-            "login": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "avatar_url": {
-              "type": "string"
-            },
-            "gravatar_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "followers_url": {
-              "type": "string"
-            },
-            "following_url": {
-              "type": "string"
-            },
-            "gists_url": {
-              "type": "string"
-            },
-            "starred_url": {
-              "type": "string"
-            },
-            "subscriptions_url": {
-              "type": "string"
-            },
-            "organizations_url": {
-              "type": "string"
-            },
-            "repos_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "received_events_url": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "site_admin": {
-              "type": "boolean"
-            }
+            "login": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "avatar_url": { "type": "string" },
+            "gravatar_id": { "type": "string" },
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "followers_url": { "type": "string" },
+            "following_url": { "type": "string" },
+            "gists_url": { "type": "string" },
+            "starred_url": { "type": "string" },
+            "subscriptions_url": { "type": "string" },
+            "organizations_url": { "type": "string" },
+            "repos_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "received_events_url": { "type": "string" },
+            "type": { "type": "string" },
+            "site_admin": { "type": "boolean" }
           },
           "additionalProperties": false
         },
-        "repository_selection": {
-          "type": "string"
-        },
-        "access_tokens_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "app_id": {
-          "type": "integer"
-        },
-        "target_id": {
-          "type": "integer"
-        },
-        "target_type": {
-          "type": "string"
-        },
+        "repository_selection": { "type": "string" },
+        "access_tokens_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "app_id": { "type": "integer" },
+        "target_id": { "type": "integer" },
+        "target_type": { "type": "string" },
         "permissions": {
           "type": "object",
           "required": [],
           "properties": {
-            "administration": {
-              "type": "string"
-            },
-            "statuses": {
-              "type": "string"
-            },
-            "repository_projects": {
-              "type": "string"
-            },
-            "repository_hooks": {
-              "type": "string"
-            },
-            "pull_requests": {
-              "type": "string"
-            },
-            "pages": {
-              "type": "string"
-            },
-            "issues": {
-              "type": "string"
-            },
-            "deployments": {
-              "type": "string"
-            },
-            "contents": {
-              "type": "string"
-            },
-            "checks": {
-              "type": "string"
-            },
-            "metadata": {
-              "type": "string"
-            },
-            "vulnerability_alerts": {
-              "type": "string"
-            }
+            "administration": { "type": "string" },
+            "statuses": { "type": "string" },
+            "repository_projects": { "type": "string" },
+            "repository_hooks": { "type": "string" },
+            "pull_requests": { "type": "string" },
+            "pages": { "type": "string" },
+            "issues": { "type": "string" },
+            "deployments": { "type": "string" },
+            "contents": { "type": "string" },
+            "checks": { "type": "string" },
+            "metadata": { "type": "string" },
+            "vulnerability_alerts": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "events": {
-          "type": "array",
-          "items": {}
-        },
-        "created_at": {
-          "type": "integer"
-        },
-        "updated_at": {
-          "type": "integer"
-        },
+        "events": { "type": "array", "items": {} },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" },
         "single_file_name": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "oneOf": [{ "type": "string" }, { "type": "null" }]
         }
       },
       "additionalProperties": false
     },
-    "repository_selection": {
-      "type": "string"
-    },
+    "repository_selection": { "type": "string" },
     "repositories_added": {
       "type": "array",
       "items": {
@@ -215,34 +120,19 @@
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],
             "properties": {
-              "id": {
-                "type": "integer"
-              },
-              "node_id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "full_name": {
-                "type": "string"
-              },
-              "private": {
-                "type": "boolean"
-              }
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "full_name": { "type": "string" },
+              "private": { "type": "boolean" }
             },
             "additionalProperties": false
           }
         ]
       }
     },
-    "repositories_removed": {
-      "type": "array",
-      "items": {}
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repositories_removed": { "type": "array", "items": {} },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "installation_repositories added event"

--- a/payload-schemas/schemas/installation_repositories/removed.schema.json
+++ b/payload-schemas/schemas/installation_repositories/removed.schema.json
@@ -11,10 +11,7 @@
     "sender"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["removed"]
-    },
+    "action": { "type": "string", "enum": ["removed"] },
     "installation": {
       "type": "object",
       "required": [
@@ -34,9 +31,7 @@
         "single_file_name"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
+        "id": { "type": "integer" },
         "account": {
           "type": "object",
           "required": [
@@ -60,153 +55,63 @@
             "site_admin"
           ],
           "properties": {
-            "login": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "avatar_url": {
-              "type": "string"
-            },
-            "gravatar_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "followers_url": {
-              "type": "string"
-            },
-            "following_url": {
-              "type": "string"
-            },
-            "gists_url": {
-              "type": "string"
-            },
-            "starred_url": {
-              "type": "string"
-            },
-            "subscriptions_url": {
-              "type": "string"
-            },
-            "organizations_url": {
-              "type": "string"
-            },
-            "repos_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "received_events_url": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "site_admin": {
-              "type": "boolean"
-            }
+            "login": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "avatar_url": { "type": "string" },
+            "gravatar_id": { "type": "string" },
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "followers_url": { "type": "string" },
+            "following_url": { "type": "string" },
+            "gists_url": { "type": "string" },
+            "starred_url": { "type": "string" },
+            "subscriptions_url": { "type": "string" },
+            "organizations_url": { "type": "string" },
+            "repos_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "received_events_url": { "type": "string" },
+            "type": { "type": "string" },
+            "site_admin": { "type": "boolean" }
           },
           "additionalProperties": false
         },
-        "repository_selection": {
-          "type": "string"
-        },
-        "access_tokens_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "app_id": {
-          "type": "integer"
-        },
-        "target_id": {
-          "type": "integer"
-        },
-        "target_type": {
-          "type": "string"
-        },
+        "repository_selection": { "type": "string" },
+        "access_tokens_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "app_id": { "type": "integer" },
+        "target_id": { "type": "integer" },
+        "target_type": { "type": "string" },
         "permissions": {
           "type": "object",
           "required": [],
           "properties": {
-            "administration": {
-              "type": "string"
-            },
-            "statuses": {
-              "type": "string"
-            },
-            "repository_projects": {
-              "type": "string"
-            },
-            "repository_hooks": {
-              "type": "string"
-            },
-            "pull_requests": {
-              "type": "string"
-            },
-            "pages": {
-              "type": "string"
-            },
-            "issues": {
-              "type": "string"
-            },
-            "deployments": {
-              "type": "string"
-            },
-            "contents": {
-              "type": "string"
-            },
-            "checks": {
-              "type": "string"
-            },
-            "metadata": {
-              "type": "string"
-            },
-            "vulnerability_alerts": {
-              "type": "string"
-            }
+            "administration": { "type": "string" },
+            "statuses": { "type": "string" },
+            "repository_projects": { "type": "string" },
+            "repository_hooks": { "type": "string" },
+            "pull_requests": { "type": "string" },
+            "pages": { "type": "string" },
+            "issues": { "type": "string" },
+            "deployments": { "type": "string" },
+            "contents": { "type": "string" },
+            "checks": { "type": "string" },
+            "metadata": { "type": "string" },
+            "vulnerability_alerts": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "events": {
-          "type": "array",
-          "items": {}
-        },
-        "created_at": {
-          "type": "integer"
-        },
-        "updated_at": {
-          "type": "integer"
-        },
+        "events": { "type": "array", "items": {} },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" },
         "single_file_name": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "oneOf": [{ "type": "string" }, { "type": "null" }]
         }
       },
       "additionalProperties": false
     },
-    "repository_selection": {
-      "type": "string"
-    },
+    "repository_selection": { "type": "string" },
     "repositories_added": {
       "type": "array",
       "items": {
@@ -215,34 +120,19 @@
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],
             "properties": {
-              "id": {
-                "type": "integer"
-              },
-              "node_id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "full_name": {
-                "type": "string"
-              },
-              "private": {
-                "type": "boolean"
-              }
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "full_name": { "type": "string" },
+              "private": { "type": "boolean" }
             },
             "additionalProperties": false
           }
         ]
       }
     },
-    "repositories_removed": {
-      "type": "array",
-      "items": {}
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repositories_removed": { "type": "array", "items": {} },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "installation_repositories removed event"

--- a/payload-schemas/schemas/integration_installation/created.schema.json
+++ b/payload-schemas/schemas/integration_installation/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "installation", "repositories", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "installation": {
       "type": "object",
       "required": [
@@ -27,9 +24,7 @@
         "single_file_name"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
+        "id": { "type": "integer" },
         "account": {
           "type": "object",
           "required": [
@@ -53,84 +48,34 @@
             "site_admin"
           ],
           "properties": {
-            "login": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "avatar_url": {
-              "type": "string"
-            },
-            "gravatar_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "followers_url": {
-              "type": "string"
-            },
-            "following_url": {
-              "type": "string"
-            },
-            "gists_url": {
-              "type": "string"
-            },
-            "starred_url": {
-              "type": "string"
-            },
-            "subscriptions_url": {
-              "type": "string"
-            },
-            "organizations_url": {
-              "type": "string"
-            },
-            "repos_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "received_events_url": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "site_admin": {
-              "type": "boolean"
-            }
+            "login": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "avatar_url": { "type": "string" },
+            "gravatar_id": { "type": "string" },
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "followers_url": { "type": "string" },
+            "following_url": { "type": "string" },
+            "gists_url": { "type": "string" },
+            "starred_url": { "type": "string" },
+            "subscriptions_url": { "type": "string" },
+            "organizations_url": { "type": "string" },
+            "repos_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "received_events_url": { "type": "string" },
+            "type": { "type": "string" },
+            "site_admin": { "type": "boolean" }
           },
           "additionalProperties": false
         },
-        "repository_selection": {
-          "type": "string"
-        },
-        "access_tokens_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "app_id": {
-          "type": "integer"
-        },
-        "target_id": {
-          "type": "integer"
-        },
-        "target_type": {
-          "type": "string"
-        },
+        "repository_selection": { "type": "string" },
+        "access_tokens_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "app_id": { "type": "integer" },
+        "target_id": { "type": "integer" },
+        "target_type": { "type": "string" },
         "permissions": {
           "type": "object",
           "required": [
@@ -148,58 +93,25 @@
             "vulnerability_alerts"
           ],
           "properties": {
-            "administration": {
-              "type": "string"
-            },
-            "checks": {
-              "type": "string"
-            },
-            "contents": {
-              "type": "string"
-            },
-            "deployments": {
-              "type": "string"
-            },
-            "issues": {
-              "type": "string"
-            },
-            "pages": {
-              "type": "string"
-            },
-            "pull_requests": {
-              "type": "string"
-            },
-            "repository_hooks": {
-              "type": "string"
-            },
-            "repository_projects": {
-              "type": "string"
-            },
-            "statuses": {
-              "type": "string"
-            },
-            "metadata": {
-              "type": "string"
-            },
-            "vulnerability_alerts": {
-              "type": "string"
-            }
+            "administration": { "type": "string" },
+            "checks": { "type": "string" },
+            "contents": { "type": "string" },
+            "deployments": { "type": "string" },
+            "issues": { "type": "string" },
+            "pages": { "type": "string" },
+            "pull_requests": { "type": "string" },
+            "repository_hooks": { "type": "string" },
+            "repository_projects": { "type": "string" },
+            "statuses": { "type": "string" },
+            "metadata": { "type": "string" },
+            "vulnerability_alerts": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "events": {
-          "type": "array",
-          "items": {}
-        },
-        "created_at": {
-          "type": "integer"
-        },
-        "updated_at": {
-          "type": "integer"
-        },
-        "single_file_name": {
-          "type": "null"
-        }
+        "events": { "type": "array", "items": {} },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" },
+        "single_file_name": { "type": "null" }
       },
       "additionalProperties": false
     },
@@ -211,30 +123,18 @@
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],
             "properties": {
-              "id": {
-                "type": "integer"
-              },
-              "node_id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "full_name": {
-                "type": "string"
-              },
-              "private": {
-                "type": "boolean"
-              }
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "full_name": { "type": "string" },
+              "private": { "type": "boolean" }
             },
             "additionalProperties": false
           }
         ]
       }
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "integration_installation created event"

--- a/payload-schemas/schemas/integration_installation_repositories/added.schema.json
+++ b/payload-schemas/schemas/integration_installation_repositories/added.schema.json
@@ -11,10 +11,7 @@
     "sender"
   ],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["added"]
-    },
+    "action": { "type": "string", "enum": ["added"] },
     "installation": {
       "type": "object",
       "required": [
@@ -34,9 +31,7 @@
         "single_file_name"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
+        "id": { "type": "integer" },
         "account": {
           "type": "object",
           "required": [
@@ -60,84 +55,34 @@
             "site_admin"
           ],
           "properties": {
-            "login": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "avatar_url": {
-              "type": "string"
-            },
-            "gravatar_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "followers_url": {
-              "type": "string"
-            },
-            "following_url": {
-              "type": "string"
-            },
-            "gists_url": {
-              "type": "string"
-            },
-            "starred_url": {
-              "type": "string"
-            },
-            "subscriptions_url": {
-              "type": "string"
-            },
-            "organizations_url": {
-              "type": "string"
-            },
-            "repos_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "received_events_url": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "site_admin": {
-              "type": "boolean"
-            }
+            "login": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "avatar_url": { "type": "string" },
+            "gravatar_id": { "type": "string" },
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "followers_url": { "type": "string" },
+            "following_url": { "type": "string" },
+            "gists_url": { "type": "string" },
+            "starred_url": { "type": "string" },
+            "subscriptions_url": { "type": "string" },
+            "organizations_url": { "type": "string" },
+            "repos_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "received_events_url": { "type": "string" },
+            "type": { "type": "string" },
+            "site_admin": { "type": "boolean" }
           },
           "additionalProperties": false
         },
-        "repository_selection": {
-          "type": "string"
-        },
-        "access_tokens_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "app_id": {
-          "type": "integer"
-        },
-        "target_id": {
-          "type": "integer"
-        },
-        "target_type": {
-          "type": "string"
-        },
+        "repository_selection": { "type": "string" },
+        "access_tokens_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "app_id": { "type": "integer" },
+        "target_id": { "type": "integer" },
+        "target_type": { "type": "string" },
         "permissions": {
           "type": "object",
           "required": [
@@ -155,64 +100,29 @@
             "vulnerability_alerts"
           ],
           "properties": {
-            "administration": {
-              "type": "string"
-            },
-            "statuses": {
-              "type": "string"
-            },
-            "repository_projects": {
-              "type": "string"
-            },
-            "repository_hooks": {
-              "type": "string"
-            },
-            "pull_requests": {
-              "type": "string"
-            },
-            "pages": {
-              "type": "string"
-            },
-            "issues": {
-              "type": "string"
-            },
-            "deployments": {
-              "type": "string"
-            },
-            "contents": {
-              "type": "string"
-            },
-            "checks": {
-              "type": "string"
-            },
-            "metadata": {
-              "type": "string"
-            },
-            "vulnerability_alerts": {
-              "type": "string"
-            }
+            "administration": { "type": "string" },
+            "statuses": { "type": "string" },
+            "repository_projects": { "type": "string" },
+            "repository_hooks": { "type": "string" },
+            "pull_requests": { "type": "string" },
+            "pages": { "type": "string" },
+            "issues": { "type": "string" },
+            "deployments": { "type": "string" },
+            "contents": { "type": "string" },
+            "checks": { "type": "string" },
+            "metadata": { "type": "string" },
+            "vulnerability_alerts": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "events": {
-          "type": "array",
-          "items": {}
-        },
-        "created_at": {
-          "type": "integer"
-        },
-        "updated_at": {
-          "type": "integer"
-        },
-        "single_file_name": {
-          "type": "null"
-        }
+        "events": { "type": "array", "items": {} },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" },
+        "single_file_name": { "type": "null" }
       },
       "additionalProperties": false
     },
-    "repository_selection": {
-      "type": "string"
-    },
+    "repository_selection": { "type": "string" },
     "repositories_added": {
       "type": "array",
       "items": {
@@ -221,34 +131,19 @@
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],
             "properties": {
-              "id": {
-                "type": "integer"
-              },
-              "node_id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "full_name": {
-                "type": "string"
-              },
-              "private": {
-                "type": "boolean"
-              }
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "full_name": { "type": "string" },
+              "private": { "type": "boolean" }
             },
             "additionalProperties": false
           }
         ]
       }
     },
-    "repositories_removed": {
-      "type": "array",
-      "items": {}
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repositories_removed": { "type": "array", "items": {} },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "integration_installation_repositories added event"

--- a/payload-schemas/schemas/issue_comment/created.schema.json
+++ b/payload-schemas/schemas/issue_comment/created.schema.json
@@ -4,20 +4,13 @@
   "type": "object",
   "required": ["action", "issue", "comment", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "changes": {
       "type": "object",
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
@@ -49,39 +42,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -97,55 +68,26 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "type": "object",
@@ -168,75 +110,31 @@
             "closed_at"
           ],
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "labels_url": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "number": {
-              "type": "integer"
-            },
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "creator": {
-              "$ref": "common/user.schema.json"
-            },
-            "open_issues": {
-              "type": "integer"
-            },
-            "closed_issues": {
-              "type": "integer"
-            },
-            "state": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
-            "due_on": {
-              "type": "string"
-            },
-            "closed_at": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "type": "null"
-        },
-        "author_association": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        }
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "type": "null" },
+        "author_association": { "type": "string" },
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
@@ -255,51 +153,23 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "author_association": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "author_association": { "type": "string" },
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issue_comment created event"

--- a/payload-schemas/schemas/issue_comment/deleted.schema.json
+++ b/payload-schemas/schemas/issue_comment/deleted.schema.json
@@ -4,20 +4,13 @@
   "type": "object",
   "required": ["action", "issue", "comment", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "changes": {
       "type": "object",
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
@@ -49,39 +42,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -97,55 +68,26 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "type": "object",
@@ -168,75 +110,31 @@
             "closed_at"
           ],
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "labels_url": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "number": {
-              "type": "integer"
-            },
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "creator": {
-              "$ref": "common/user.schema.json"
-            },
-            "open_issues": {
-              "type": "integer"
-            },
-            "closed_issues": {
-              "type": "integer"
-            },
-            "state": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
-            "due_on": {
-              "type": "string"
-            },
-            "closed_at": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "type": "null"
-        },
-        "author_association": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        }
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "type": "null" },
+        "author_association": { "type": "string" },
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
@@ -255,51 +153,23 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "author_association": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "author_association": { "type": "string" },
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issue_comment deleted event"

--- a/payload-schemas/schemas/issue_comment/edited.schema.json
+++ b/payload-schemas/schemas/issue_comment/edited.schema.json
@@ -4,20 +4,13 @@
   "type": "object",
   "required": ["action", "issue", "comment", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "changes": {
       "type": "object",
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
@@ -49,39 +42,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -97,55 +68,26 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "type": "object",
@@ -168,75 +110,31 @@
             "closed_at"
           ],
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "labels_url": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "number": {
-              "type": "integer"
-            },
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "creator": {
-              "$ref": "common/user.schema.json"
-            },
-            "open_issues": {
-              "type": "integer"
-            },
-            "closed_issues": {
-              "type": "integer"
-            },
-            "state": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
-            "due_on": {
-              "type": "string"
-            },
-            "closed_at": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "type": "null"
-        },
-        "author_association": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        }
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "type": "null" },
+        "author_association": { "type": "string" },
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
@@ -255,51 +153,23 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "author_association": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "author_association": { "type": "string" },
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issue_comment edited event"

--- a/payload-schemas/schemas/issues/assigned.schema.json
+++ b/payload-schemas/schemas/issues/assigned.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["assigned"]
-    },
+    "action": { "type": "string", "enum": ["assigned"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues assigned event"

--- a/payload-schemas/schemas/issues/closed.schema.json
+++ b/payload-schemas/schemas/issues/closed.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["closed"]
-    },
+    "action": { "type": "string", "enum": ["closed"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues closed event"

--- a/payload-schemas/schemas/issues/deleted.schema.json
+++ b/payload-schemas/schemas/issues/deleted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues deleted event"

--- a/payload-schemas/schemas/issues/demilestoned.schema.json
+++ b/payload-schemas/schemas/issues/demilestoned.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["demilestoned"]
-    },
+    "action": { "type": "string", "enum": ["demilestoned"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues demilestoned event"

--- a/payload-schemas/schemas/issues/edited.schema.json
+++ b/payload-schemas/schemas/issues/edited.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues edited event"

--- a/payload-schemas/schemas/issues/labeled.schema.json
+++ b/payload-schemas/schemas/issues/labeled.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["labeled"]
-    },
+    "action": { "type": "string", "enum": ["labeled"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues labeled event"

--- a/payload-schemas/schemas/issues/locked.schema.json
+++ b/payload-schemas/schemas/issues/locked.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["locked"]
-    },
+    "action": { "type": "string", "enum": ["locked"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues locked event"

--- a/payload-schemas/schemas/issues/milestoned.schema.json
+++ b/payload-schemas/schemas/issues/milestoned.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["milestoned"]
-    },
+    "action": { "type": "string", "enum": ["milestoned"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues milestoned event"

--- a/payload-schemas/schemas/issues/opened.schema.json
+++ b/payload-schemas/schemas/issues/opened.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["opened"]
-    },
+    "action": { "type": "string", "enum": ["opened"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues opened event"

--- a/payload-schemas/schemas/issues/pinned.schema.json
+++ b/payload-schemas/schemas/issues/pinned.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["pinned"]
-    },
+    "action": { "type": "string", "enum": ["pinned"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues pinned event"

--- a/payload-schemas/schemas/issues/reopened.schema.json
+++ b/payload-schemas/schemas/issues/reopened.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["reopened"]
-    },
+    "action": { "type": "string", "enum": ["reopened"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues reopened event"

--- a/payload-schemas/schemas/issues/transferred.schema.json
+++ b/payload-schemas/schemas/issues/transferred.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["transferred"]
-    },
+    "action": { "type": "string", "enum": ["transferred"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues transferred event"

--- a/payload-schemas/schemas/issues/unassigned.schema.json
+++ b/payload-schemas/schemas/issues/unassigned.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["unassigned"]
-    },
+    "action": { "type": "string", "enum": ["unassigned"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues unassigned event"

--- a/payload-schemas/schemas/issues/unlabeled.schema.json
+++ b/payload-schemas/schemas/issues/unlabeled.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["unlabeled"]
-    },
+    "action": { "type": "string", "enum": ["unlabeled"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues unlabeled event"

--- a/payload-schemas/schemas/issues/unlocked.schema.json
+++ b/payload-schemas/schemas/issues/unlocked.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["unlocked"]
-    },
+    "action": { "type": "string", "enum": ["unlocked"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues unlocked event"

--- a/payload-schemas/schemas/issues/unpinned.schema.json
+++ b/payload-schemas/schemas/issues/unpinned.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "issue", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["unpinned"]
-    },
+    "action": { "type": "string", "enum": ["unpinned"] },
     "issue": {
       "type": "object",
       "required": [
@@ -33,39 +30,17 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "repository_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
+        "url": { "type": "string" },
+        "repository_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
         "labels": {
           "type": "array",
           "items": {
@@ -81,61 +56,30 @@
                   "default"
                 ],
                 "properties": {
-                  "id": {
-                    "type": "integer"
-                  },
-                  "node_id": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  },
-                  "default": {
-                    "type": "boolean"
-                  }
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "url": { "type": "string" },
+                  "name": { "type": "string" },
+                  "color": { "type": "string" },
+                  "default": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -157,139 +101,64 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
-                "closed_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
               },
               "additionalProperties": false
             }
           ]
         },
-        "comments": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "comments": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "performed_via_github_app": {
-          "type": "null"
-        },
+        "performed_via_github_app": { "type": "null" },
         "pull_request": {
           "type": "object",
           "properties": {
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "diff_url": {
-              "type": "string"
-            },
-            "patch_url": {
-              "type": "string"
-            }
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "diff_url": { "type": "string" },
+            "patch_url": { "type": "string" }
           }
         },
-        "body": {
-          "type": "string"
-        }
+        "body": { "type": "string" }
       },
       "additionalProperties": false
     },
     "label": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       }
     },
     "changes": {
@@ -297,44 +166,21 @@
       "properties": {
         "body": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         }
       }
     },
     "assignee": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
     },
     "assignees": {
       "type": "array",
-      "items": [
-        {
-          "$ref": "common/user.schema.json"
-        }
-      ]
+      "items": [{ "$ref": "common/user.schema.json" }]
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "issues unpinned event"

--- a/payload-schemas/schemas/label/created.schema.json
+++ b/payload-schemas/schemas/label/created.schema.json
@@ -4,61 +4,26 @@
   "type": "object",
   "required": ["action", "label", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "label": {
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        },
-        "description": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" },
+        "description": { "oneOf": [{ "type": "string" }, { "type": "null" }] }
       },
       "additionalProperties": false
     },
-    "changes": {
-      "type": "object",
-      "properties": {}
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "changes": { "type": "object", "properties": {} },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "label created event"

--- a/payload-schemas/schemas/label/deleted.schema.json
+++ b/payload-schemas/schemas/label/deleted.schema.json
@@ -4,61 +4,26 @@
   "type": "object",
   "required": ["action", "label", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "label": {
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        },
-        "description": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" },
+        "description": { "oneOf": [{ "type": "string" }, { "type": "null" }] }
       },
       "additionalProperties": false
     },
-    "changes": {
-      "type": "object",
-      "properties": {}
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "changes": { "type": "object", "properties": {} },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "label deleted event"

--- a/payload-schemas/schemas/label/edited.schema.json
+++ b/payload-schemas/schemas/label/edited.schema.json
@@ -4,61 +4,26 @@
   "type": "object",
   "required": ["action", "label", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "label": {
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        },
-        "description": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" },
+        "description": { "oneOf": [{ "type": "string" }, { "type": "null" }] }
       },
       "additionalProperties": false
     },
-    "changes": {
-      "type": "object",
-      "properties": {}
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "changes": { "type": "object", "properties": {} },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "label edited event"

--- a/payload-schemas/schemas/marketplace_purchase/cancelled.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/cancelled.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "effective_date", "sender", "marketplace_purchase"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["cancelled"]
-    },
-    "effective_date": {
-      "type": "string"
-    },
+    "action": { "type": "string", "enum": ["cancelled"] },
+    "effective_date": { "type": "string" },
     "sender": {
       "type": "object",
       "required": [
@@ -34,60 +29,24 @@
         "email"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        },
-        "email": {
-          "type": "string"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" },
+        "email": { "type": "string" }
       },
       "additionalProperties": false
     },
@@ -107,36 +66,18 @@
           "type": "object",
           "required": ["type", "id", "login", "organization_billing_email"],
           "properties": {
-            "type": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "login": {
-              "type": "string"
-            },
-            "organization_billing_email": {
-              "type": "string"
-            }
+            "type": { "type": "string" },
+            "id": { "type": "integer" },
+            "login": { "type": "string" },
+            "organization_billing_email": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "billing_cycle": {
-          "type": "string"
-        },
-        "unit_count": {
-          "type": "integer"
-        },
-        "on_free_trial": {
-          "type": "boolean"
-        },
-        "free_trial_ends_on": {
-          "type": "null"
-        },
-        "next_billing_date": {
-          "type": "string"
-        },
+        "billing_cycle": { "type": "string" },
+        "unit_count": { "type": "integer" },
+        "on_free_trial": { "type": "boolean" },
+        "free_trial_ends_on": { "type": "null" },
+        "next_billing_date": { "type": "string" },
         "plan": {
           "type": "object",
           "required": [
@@ -151,46 +92,19 @@
             "bullets"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "yearly_price_in_cents": {
-              "type": "integer"
-            },
-            "price_model": {
-              "type": "string"
-            },
-            "has_free_trial": {
-              "type": "boolean"
-            },
+            "id": { "type": "integer" },
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "yearly_price_in_cents": { "type": "integer" },
+            "price_model": { "type": "string" },
+            "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "anyOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
+              "items": { "anyOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false
@@ -213,36 +127,18 @@
           "type": "object",
           "required": ["type", "id", "login", "organization_billing_email"],
           "properties": {
-            "type": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "login": {
-              "type": "string"
-            },
-            "organization_billing_email": {
-              "type": "string"
-            }
+            "type": { "type": "string" },
+            "id": { "type": "integer" },
+            "login": { "type": "string" },
+            "organization_billing_email": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "billing_cycle": {
-          "type": "string"
-        },
-        "unit_count": {
-          "type": "integer"
-        },
-        "on_free_trial": {
-          "type": "boolean"
-        },
-        "free_trial_ends_on": {
-          "type": "null"
-        },
-        "next_billing_date": {
-          "type": "string"
-        },
+        "billing_cycle": { "type": "string" },
+        "unit_count": { "type": "integer" },
+        "on_free_trial": { "type": "boolean" },
+        "free_trial_ends_on": { "type": "null" },
+        "next_billing_date": { "type": "string" },
         "plan": {
           "type": "object",
           "required": [
@@ -257,46 +153,19 @@
             "bullets"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "yearly_price_in_cents": {
-              "type": "integer"
-            },
-            "price_model": {
-              "type": "string"
-            },
-            "has_free_trial": {
-              "type": "boolean"
-            },
+            "id": { "type": "integer" },
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "yearly_price_in_cents": { "type": "integer" },
+            "price_model": { "type": "string" },
+            "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "anyOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
+              "items": { "anyOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false

--- a/payload-schemas/schemas/marketplace_purchase/changed.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/changed.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "effective_date", "sender", "marketplace_purchase"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["changed"]
-    },
-    "effective_date": {
-      "type": "string"
-    },
+    "action": { "type": "string", "enum": ["changed"] },
+    "effective_date": { "type": "string" },
     "sender": {
       "type": "object",
       "required": [
@@ -34,60 +29,24 @@
         "email"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        },
-        "email": {
-          "type": "string"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" },
+        "email": { "type": "string" }
       },
       "additionalProperties": false
     },
@@ -107,36 +66,18 @@
           "type": "object",
           "required": ["type", "id", "login", "organization_billing_email"],
           "properties": {
-            "type": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "login": {
-              "type": "string"
-            },
-            "organization_billing_email": {
-              "type": "string"
-            }
+            "type": { "type": "string" },
+            "id": { "type": "integer" },
+            "login": { "type": "string" },
+            "organization_billing_email": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "billing_cycle": {
-          "type": "string"
-        },
-        "unit_count": {
-          "type": "integer"
-        },
-        "on_free_trial": {
-          "type": "boolean"
-        },
-        "free_trial_ends_on": {
-          "type": "null"
-        },
-        "next_billing_date": {
-          "type": "string"
-        },
+        "billing_cycle": { "type": "string" },
+        "unit_count": { "type": "integer" },
+        "on_free_trial": { "type": "boolean" },
+        "free_trial_ends_on": { "type": "null" },
+        "next_billing_date": { "type": "string" },
         "plan": {
           "type": "object",
           "required": [
@@ -151,46 +92,19 @@
             "bullets"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "yearly_price_in_cents": {
-              "type": "integer"
-            },
-            "price_model": {
-              "type": "string"
-            },
-            "has_free_trial": {
-              "type": "boolean"
-            },
+            "id": { "type": "integer" },
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "yearly_price_in_cents": { "type": "integer" },
+            "price_model": { "type": "string" },
+            "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "anyOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
+              "items": { "anyOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false
@@ -213,36 +127,18 @@
           "type": "object",
           "required": ["type", "id", "login", "organization_billing_email"],
           "properties": {
-            "type": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "login": {
-              "type": "string"
-            },
-            "organization_billing_email": {
-              "type": "string"
-            }
+            "type": { "type": "string" },
+            "id": { "type": "integer" },
+            "login": { "type": "string" },
+            "organization_billing_email": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "billing_cycle": {
-          "type": "string"
-        },
-        "unit_count": {
-          "type": "integer"
-        },
-        "on_free_trial": {
-          "type": "boolean"
-        },
-        "free_trial_ends_on": {
-          "type": "null"
-        },
-        "next_billing_date": {
-          "type": "string"
-        },
+        "billing_cycle": { "type": "string" },
+        "unit_count": { "type": "integer" },
+        "on_free_trial": { "type": "boolean" },
+        "free_trial_ends_on": { "type": "null" },
+        "next_billing_date": { "type": "string" },
         "plan": {
           "type": "object",
           "required": [
@@ -257,46 +153,19 @@
             "bullets"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "yearly_price_in_cents": {
-              "type": "integer"
-            },
-            "price_model": {
-              "type": "string"
-            },
-            "has_free_trial": {
-              "type": "boolean"
-            },
+            "id": { "type": "integer" },
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "yearly_price_in_cents": { "type": "integer" },
+            "price_model": { "type": "string" },
+            "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "anyOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
+              "items": { "anyOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false

--- a/payload-schemas/schemas/marketplace_purchase/purchased.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/purchased.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "effective_date", "sender", "marketplace_purchase"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["purchased"]
-    },
-    "effective_date": {
-      "type": "string"
-    },
+    "action": { "type": "string", "enum": ["purchased"] },
+    "effective_date": { "type": "string" },
     "sender": {
       "type": "object",
       "required": [
@@ -34,60 +29,24 @@
         "email"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        },
-        "email": {
-          "type": "string"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" },
+        "email": { "type": "string" }
       },
       "additionalProperties": false
     },
@@ -107,36 +66,18 @@
           "type": "object",
           "required": ["type", "id", "login", "organization_billing_email"],
           "properties": {
-            "type": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "login": {
-              "type": "string"
-            },
-            "organization_billing_email": {
-              "type": "string"
-            }
+            "type": { "type": "string" },
+            "id": { "type": "integer" },
+            "login": { "type": "string" },
+            "organization_billing_email": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "billing_cycle": {
-          "type": "string"
-        },
-        "unit_count": {
-          "type": "integer"
-        },
-        "on_free_trial": {
-          "type": "boolean"
-        },
-        "free_trial_ends_on": {
-          "type": "null"
-        },
-        "next_billing_date": {
-          "type": "string"
-        },
+        "billing_cycle": { "type": "string" },
+        "unit_count": { "type": "integer" },
+        "on_free_trial": { "type": "boolean" },
+        "free_trial_ends_on": { "type": "null" },
+        "next_billing_date": { "type": "string" },
         "plan": {
           "type": "object",
           "required": [
@@ -151,46 +92,19 @@
             "bullets"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "yearly_price_in_cents": {
-              "type": "integer"
-            },
-            "price_model": {
-              "type": "string"
-            },
-            "has_free_trial": {
-              "type": "boolean"
-            },
+            "id": { "type": "integer" },
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "yearly_price_in_cents": { "type": "integer" },
+            "price_model": { "type": "string" },
+            "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "anyOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
+              "items": { "anyOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false
@@ -213,36 +127,18 @@
           "type": "object",
           "required": ["type", "id", "login", "organization_billing_email"],
           "properties": {
-            "type": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "login": {
-              "type": "string"
-            },
-            "organization_billing_email": {
-              "type": "string"
-            }
+            "type": { "type": "string" },
+            "id": { "type": "integer" },
+            "login": { "type": "string" },
+            "organization_billing_email": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "billing_cycle": {
-          "type": "string"
-        },
-        "unit_count": {
-          "type": "integer"
-        },
-        "on_free_trial": {
-          "type": "boolean"
-        },
-        "free_trial_ends_on": {
-          "type": "null"
-        },
-        "next_billing_date": {
-          "type": "string"
-        },
+        "billing_cycle": { "type": "string" },
+        "unit_count": { "type": "integer" },
+        "on_free_trial": { "type": "boolean" },
+        "free_trial_ends_on": { "type": "null" },
+        "next_billing_date": { "type": "string" },
         "plan": {
           "type": "object",
           "required": [
@@ -257,46 +153,19 @@
             "bullets"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "yearly_price_in_cents": {
-              "type": "integer"
-            },
-            "price_model": {
-              "type": "string"
-            },
-            "has_free_trial": {
-              "type": "boolean"
-            },
+            "id": { "type": "integer" },
+            "name": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "yearly_price_in_cents": { "type": "integer" },
+            "price_model": { "type": "string" },
+            "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "anyOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
+              "items": { "anyOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false

--- a/payload-schemas/schemas/member/added.schema.json
+++ b/payload-schemas/schemas/member/added.schema.json
@@ -4,25 +4,12 @@
   "type": "object",
   "required": ["action", "member", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["added"]
-    },
-    "member": {
-      "$ref": "common/user.schema.json"
-    },
-    "changes": {
-      "type": "object"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "action": { "type": "string", "enum": ["added"] },
+    "member": { "$ref": "common/user.schema.json" },
+    "changes": { "type": "object" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "member added event"

--- a/payload-schemas/schemas/member/edited.schema.json
+++ b/payload-schemas/schemas/member/edited.schema.json
@@ -4,25 +4,12 @@
   "type": "object",
   "required": ["action", "member", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
-    "member": {
-      "$ref": "common/user.schema.json"
-    },
-    "changes": {
-      "type": "object"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "action": { "type": "string", "enum": ["edited"] },
+    "member": { "$ref": "common/user.schema.json" },
+    "changes": { "type": "object" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "member edited event"

--- a/payload-schemas/schemas/member/removed.schema.json
+++ b/payload-schemas/schemas/member/removed.schema.json
@@ -4,25 +4,12 @@
   "type": "object",
   "required": ["action", "member", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["removed"]
-    },
-    "member": {
-      "$ref": "common/user.schema.json"
-    },
-    "changes": {
-      "type": "object"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "action": { "type": "string", "enum": ["removed"] },
+    "member": { "$ref": "common/user.schema.json" },
+    "changes": { "type": "object" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "member removed event"

--- a/payload-schemas/schemas/membership/added.schema.json
+++ b/payload-schemas/schemas/membership/added.schema.json
@@ -4,19 +4,10 @@
   "type": "object",
   "required": ["action", "scope", "member", "sender", "team", "organization"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["added"]
-    },
-    "scope": {
-      "type": "string"
-    },
-    "member": {
-      "$ref": "common/user.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
+    "action": { "type": "string", "enum": ["added"] },
+    "scope": { "type": "string" },
+    "member": { "$ref": "common/user.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
     "team": {
       "type": "object",
       "required": [
@@ -33,48 +24,22 @@
         "permission"
       ],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "privacy": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "members_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "permission": {
-          "type": "string"
-        }
+        "name": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "slug": { "type": "string" },
+        "description": { "type": "string" },
+        "privacy": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "members_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "permission": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    }
+    "organization": { "$ref": "common/organization.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" }
   },
   "additionalProperties": false,
   "title": "membership added event"

--- a/payload-schemas/schemas/membership/removed.schema.json
+++ b/payload-schemas/schemas/membership/removed.schema.json
@@ -4,19 +4,10 @@
   "type": "object",
   "required": ["action", "scope", "member", "sender", "team", "organization"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["removed"]
-    },
-    "scope": {
-      "type": "string"
-    },
-    "member": {
-      "$ref": "common/user.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
+    "action": { "type": "string", "enum": ["removed"] },
+    "scope": { "type": "string" },
+    "member": { "$ref": "common/user.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
     "team": {
       "type": "object",
       "required": [
@@ -33,48 +24,22 @@
         "permission"
       ],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "privacy": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "members_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "permission": {
-          "type": "string"
-        }
+        "name": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "slug": { "type": "string" },
+        "description": { "type": "string" },
+        "privacy": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "members_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "permission": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    }
+    "organization": { "$ref": "common/organization.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" }
   },
   "additionalProperties": false,
   "title": "membership removed event"

--- a/payload-schemas/schemas/meta/deleted.schema.json
+++ b/payload-schemas/schemas/meta/deleted.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "hook_id", "hook", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
-    "hook_id": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
+    "hook_id": { "type": "integer" },
     "hook": {
       "type": "object",
       "required": [
@@ -24,59 +19,31 @@
         "created_at"
       ],
       "properties": {
-        "type": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "name": {
-          "type": "string"
-        },
-        "active": {
-          "type": "boolean"
-        },
+        "type": { "type": "string" },
+        "id": { "type": "integer" },
+        "name": { "type": "string" },
+        "active": { "type": "boolean" },
         "events": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "type": "string" }] }
         },
         "config": {
           "type": "object",
           "required": ["content_type", "insecure_ssl", "url"],
           "properties": {
-            "content_type": {
-              "type": "string"
-            },
-            "insecure_ssl": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            }
+            "content_type": { "type": "string" },
+            "insecure_ssl": { "type": "string" },
+            "url": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "updated_at": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        }
+        "updated_at": { "type": "string" },
+        "created_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "meta deleted event"

--- a/payload-schemas/schemas/milestone/closed.schema.json
+++ b/payload-schemas/schemas/milestone/closed.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "milestone", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["closed"]
-    },
+    "action": { "type": "string", "enum": ["closed"] },
     "milestone": {
       "type": "object",
       "required": [
@@ -29,76 +26,29 @@
         "closed_at"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "open_issues": {
-          "type": "integer"
-        },
-        "closed_issues": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "due_on": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "open_issues": { "type": "integer" },
+        "closed_issues": { "type": "integer" },
+        "state": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "due_on": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "milestone closed event"

--- a/payload-schemas/schemas/milestone/created.schema.json
+++ b/payload-schemas/schemas/milestone/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "milestone", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "milestone": {
       "type": "object",
       "required": [
@@ -29,76 +26,29 @@
         "closed_at"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "open_issues": {
-          "type": "integer"
-        },
-        "closed_issues": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "due_on": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "open_issues": { "type": "integer" },
+        "closed_issues": { "type": "integer" },
+        "state": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "due_on": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "milestone created event"

--- a/payload-schemas/schemas/milestone/deleted.schema.json
+++ b/payload-schemas/schemas/milestone/deleted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "milestone", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "milestone": {
       "type": "object",
       "required": [
@@ -29,76 +26,29 @@
         "closed_at"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "open_issues": {
-          "type": "integer"
-        },
-        "closed_issues": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "due_on": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "open_issues": { "type": "integer" },
+        "closed_issues": { "type": "integer" },
+        "state": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "due_on": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "milestone deleted event"

--- a/payload-schemas/schemas/milestone/edited.schema.json
+++ b/payload-schemas/schemas/milestone/edited.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "milestone", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "milestone": {
       "type": "object",
       "required": [
@@ -29,76 +26,29 @@
         "closed_at"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "open_issues": {
-          "type": "integer"
-        },
-        "closed_issues": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "due_on": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "open_issues": { "type": "integer" },
+        "closed_issues": { "type": "integer" },
+        "state": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "due_on": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "milestone edited event"

--- a/payload-schemas/schemas/milestone/opened.schema.json
+++ b/payload-schemas/schemas/milestone/opened.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "milestone", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["opened"]
-    },
+    "action": { "type": "string", "enum": ["opened"] },
     "milestone": {
       "type": "object",
       "required": [
@@ -29,76 +26,29 @@
         "closed_at"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "labels_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "open_issues": {
-          "type": "integer"
-        },
-        "closed_issues": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "due_on": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "labels_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "number": { "type": "integer" },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "open_issues": { "type": "integer" },
+        "closed_issues": { "type": "integer" },
+        "state": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "due_on": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "milestone opened event"

--- a/payload-schemas/schemas/org_block/blocked.schema.json
+++ b/payload-schemas/schemas/org_block/blocked.schema.json
@@ -4,22 +4,11 @@
   "type": "object",
   "required": ["action", "blocked_user", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["blocked"]
-    },
-    "blocked_user": {
-      "$ref": "common/user.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "action": { "type": "string", "enum": ["blocked"] },
+    "blocked_user": { "$ref": "common/user.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "org_block blocked event"

--- a/payload-schemas/schemas/org_block/unblocked.schema.json
+++ b/payload-schemas/schemas/org_block/unblocked.schema.json
@@ -4,22 +4,11 @@
   "type": "object",
   "required": ["action", "blocked_user", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["unblocked"]
-    },
-    "blocked_user": {
-      "$ref": "common/user.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "action": { "type": "string", "enum": ["unblocked"] },
+    "blocked_user": { "$ref": "common/user.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "org_block unblocked event"

--- a/payload-schemas/schemas/organization/deleted.schema.json
+++ b/payload-schemas/schemas/organization/deleted.schema.json
@@ -4,41 +4,22 @@
   "type": "object",
   "required": ["action", "membership", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "membership": {
       "type": "object",
       "required": ["url", "state", "role", "organization_url", "user"],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string"
-        },
-        "role": {
-          "type": "string"
-        },
-        "organization_url": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        }
+        "url": { "type": "string" },
+        "state": { "type": "string" },
+        "role": { "type": "string" },
+        "organization_url": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" }
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "organization deleted event"

--- a/payload-schemas/schemas/organization/member_added.schema.json
+++ b/payload-schemas/schemas/organization/member_added.schema.json
@@ -4,41 +4,22 @@
   "type": "object",
   "required": ["action", "membership", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["member_added"]
-    },
+    "action": { "type": "string", "enum": ["member_added"] },
     "membership": {
       "type": "object",
       "required": ["url", "state", "role", "organization_url", "user"],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string"
-        },
-        "role": {
-          "type": "string"
-        },
-        "organization_url": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        }
+        "url": { "type": "string" },
+        "state": { "type": "string" },
+        "role": { "type": "string" },
+        "organization_url": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" }
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "organization member_added event"

--- a/payload-schemas/schemas/organization/member_invited.schema.json
+++ b/payload-schemas/schemas/organization/member_invited.schema.json
@@ -4,41 +4,22 @@
   "type": "object",
   "required": ["action", "membership", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["member_invited"]
-    },
+    "action": { "type": "string", "enum": ["member_invited"] },
     "membership": {
       "type": "object",
       "required": ["url", "state", "role", "organization_url", "user"],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string"
-        },
-        "role": {
-          "type": "string"
-        },
-        "organization_url": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        }
+        "url": { "type": "string" },
+        "state": { "type": "string" },
+        "role": { "type": "string" },
+        "organization_url": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" }
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "organization member_invited event"

--- a/payload-schemas/schemas/organization/member_removed.schema.json
+++ b/payload-schemas/schemas/organization/member_removed.schema.json
@@ -4,41 +4,22 @@
   "type": "object",
   "required": ["action", "membership", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["member_removed"]
-    },
+    "action": { "type": "string", "enum": ["member_removed"] },
     "membership": {
       "type": "object",
       "required": ["url", "state", "role", "organization_url", "user"],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string"
-        },
-        "role": {
-          "type": "string"
-        },
-        "organization_url": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        }
+        "url": { "type": "string" },
+        "state": { "type": "string" },
+        "role": { "type": "string" },
+        "organization_url": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" }
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "organization member_removed event"

--- a/payload-schemas/schemas/organization/renamed.schema.json
+++ b/payload-schemas/schemas/organization/renamed.schema.json
@@ -4,41 +4,22 @@
   "type": "object",
   "required": ["action", "membership", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["renamed"]
-    },
+    "action": { "type": "string", "enum": ["renamed"] },
     "membership": {
       "type": "object",
       "required": ["url", "state", "role", "organization_url", "user"],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string"
-        },
-        "role": {
-          "type": "string"
-        },
-        "organization_url": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        }
+        "url": { "type": "string" },
+        "state": { "type": "string" },
+        "role": { "type": "string" },
+        "organization_url": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" }
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "organization renamed event"

--- a/payload-schemas/schemas/package/published.schema.json
+++ b/payload-schemas/schemas/package/published.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "package", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["published"]
-    },
+    "action": { "type": "string", "enum": ["published"] },
     "package": {
       "type": "object",
       "required": [
@@ -22,27 +19,13 @@
         "registry"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "name": {
-          "type": "string"
-        },
-        "package_type": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "owner": {
-          "$ref": "common/user.schema.json"
-        },
+        "id": { "type": "integer" },
+        "name": { "type": "string" },
+        "package_type": { "type": "string" },
+        "html_url": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "owner": { "$ref": "common/user.schema.json" },
         "package_version": {
           "type": "object",
           "required": [
@@ -67,21 +50,11 @@
             "installation_command"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "version": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "body": {
-              "type": "string"
-            },
-            "body_html": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "version": { "type": "string" },
+            "summary": { "type": "string" },
+            "body": { "type": "string" },
+            "body_html": { "type": "string" },
             "release": {
               "type": "object",
               "required": [
@@ -98,73 +71,30 @@
                 "published_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "tag_name": {
-                  "type": "string"
-                },
-                "target_commitish": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "draft": {
-                  "type": "boolean"
-                },
-                "author": {
-                  "$ref": "common/user.schema.json"
-                },
-                "prerelease": {
-                  "type": "boolean"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "published_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "tag_name": { "type": "string" },
+                "target_commitish": { "type": "string" },
+                "name": { "type": "string" },
+                "draft": { "type": "boolean" },
+                "author": { "$ref": "common/user.schema.json" },
+                "prerelease": { "type": "boolean" },
+                "created_at": { "type": "string" },
+                "published_at": { "type": "string" }
               },
               "additionalProperties": false
             },
-            "manifest": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "tag_name": {
-              "type": "string"
-            },
-            "target_commitish": {
-              "type": "string"
-            },
-            "target_oid": {
-              "type": "string"
-            },
-            "draft": {
-              "type": "boolean"
-            },
-            "prerelease": {
-              "type": "boolean"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
-            "metadata": {
-              "type": "array",
-              "items": {}
-            },
+            "manifest": { "type": "string" },
+            "html_url": { "type": "string" },
+            "tag_name": { "type": "string" },
+            "target_commitish": { "type": "string" },
+            "target_oid": { "type": "string" },
+            "draft": { "type": "boolean" },
+            "prerelease": { "type": "boolean" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "metadata": { "type": "array", "items": {} },
             "package_files": {
               "type": "array",
               "items": {
@@ -185,51 +115,25 @@
                       "updated_at"
                     ],
                     "properties": {
-                      "download_url": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "sha256": {
-                        "type": "string"
-                      },
-                      "sha1": {
-                        "type": "string"
-                      },
-                      "md5": {
-                        "type": "string"
-                      },
-                      "content_type": {
-                        "type": "string"
-                      },
-                      "state": {
-                        "type": "string"
-                      },
-                      "size": {
-                        "type": "integer"
-                      },
-                      "created_at": {
-                        "type": "string"
-                      },
-                      "updated_at": {
-                        "type": "string"
-                      }
+                      "download_url": { "type": "string" },
+                      "id": { "type": "integer" },
+                      "name": { "type": "string" },
+                      "sha256": { "type": "string" },
+                      "sha1": { "type": "string" },
+                      "md5": { "type": "string" },
+                      "content_type": { "type": "string" },
+                      "state": { "type": "string" },
+                      "size": { "type": "integer" },
+                      "created_at": { "type": "string" },
+                      "updated_at": { "type": "string" }
                     },
                     "additionalProperties": false
                   }
                 ]
               }
             },
-            "author": {
-              "$ref": "common/user.schema.json"
-            },
-            "installation_command": {
-              "type": "string"
-            }
+            "author": { "$ref": "common/user.schema.json" },
+            "installation_command": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -237,36 +141,20 @@
           "type": "object",
           "required": ["about_url", "name", "type", "url", "vendor"],
           "properties": {
-            "about_url": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "vendor": {
-              "type": "string"
-            }
+            "about_url": { "type": "string" },
+            "name": { "type": "string" },
+            "type": { "type": "string" },
+            "url": { "type": "string" },
+            "vendor": { "type": "string" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "package published event"

--- a/payload-schemas/schemas/package/updated.schema.json
+++ b/payload-schemas/schemas/package/updated.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "package", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["updated"]
-    },
+    "action": { "type": "string", "enum": ["updated"] },
     "package": {
       "type": "object",
       "required": [
@@ -22,27 +19,13 @@
         "registry"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "name": {
-          "type": "string"
-        },
-        "package_type": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "owner": {
-          "$ref": "common/user.schema.json"
-        },
+        "id": { "type": "integer" },
+        "name": { "type": "string" },
+        "package_type": { "type": "string" },
+        "html_url": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "owner": { "$ref": "common/user.schema.json" },
         "package_version": {
           "type": "object",
           "required": [
@@ -67,21 +50,11 @@
             "installation_command"
           ],
           "properties": {
-            "id": {
-              "type": "integer"
-            },
-            "version": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "body": {
-              "type": "string"
-            },
-            "body_html": {
-              "type": "string"
-            },
+            "id": { "type": "integer" },
+            "version": { "type": "string" },
+            "summary": { "type": "string" },
+            "body": { "type": "string" },
+            "body_html": { "type": "string" },
             "release": {
               "type": "object",
               "required": [
@@ -98,73 +71,30 @@
                 "published_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "tag_name": {
-                  "type": "string"
-                },
-                "target_commitish": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "draft": {
-                  "type": "boolean"
-                },
-                "author": {
-                  "$ref": "common/user.schema.json"
-                },
-                "prerelease": {
-                  "type": "boolean"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "published_at": {
-                  "type": "string"
-                }
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "tag_name": { "type": "string" },
+                "target_commitish": { "type": "string" },
+                "name": { "type": "string" },
+                "draft": { "type": "boolean" },
+                "author": { "$ref": "common/user.schema.json" },
+                "prerelease": { "type": "boolean" },
+                "created_at": { "type": "string" },
+                "published_at": { "type": "string" }
               },
               "additionalProperties": false
             },
-            "manifest": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "tag_name": {
-              "type": "string"
-            },
-            "target_commitish": {
-              "type": "string"
-            },
-            "target_oid": {
-              "type": "string"
-            },
-            "draft": {
-              "type": "boolean"
-            },
-            "prerelease": {
-              "type": "boolean"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "updated_at": {
-              "type": "string"
-            },
-            "metadata": {
-              "type": "array",
-              "items": {}
-            },
+            "manifest": { "type": "string" },
+            "html_url": { "type": "string" },
+            "tag_name": { "type": "string" },
+            "target_commitish": { "type": "string" },
+            "target_oid": { "type": "string" },
+            "draft": { "type": "boolean" },
+            "prerelease": { "type": "boolean" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "metadata": { "type": "array", "items": {} },
             "package_files": {
               "type": "array",
               "items": {
@@ -185,51 +115,25 @@
                       "updated_at"
                     ],
                     "properties": {
-                      "download_url": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "sha256": {
-                        "type": "string"
-                      },
-                      "sha1": {
-                        "type": "string"
-                      },
-                      "md5": {
-                        "type": "string"
-                      },
-                      "content_type": {
-                        "type": "string"
-                      },
-                      "state": {
-                        "type": "string"
-                      },
-                      "size": {
-                        "type": "integer"
-                      },
-                      "created_at": {
-                        "type": "string"
-                      },
-                      "updated_at": {
-                        "type": "string"
-                      }
+                      "download_url": { "type": "string" },
+                      "id": { "type": "integer" },
+                      "name": { "type": "string" },
+                      "sha256": { "type": "string" },
+                      "sha1": { "type": "string" },
+                      "md5": { "type": "string" },
+                      "content_type": { "type": "string" },
+                      "state": { "type": "string" },
+                      "size": { "type": "integer" },
+                      "created_at": { "type": "string" },
+                      "updated_at": { "type": "string" }
                     },
                     "additionalProperties": false
                   }
                 ]
               }
             },
-            "author": {
-              "$ref": "common/user.schema.json"
-            },
-            "installation_command": {
-              "type": "string"
-            }
+            "author": { "$ref": "common/user.schema.json" },
+            "installation_command": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -237,36 +141,20 @@
           "type": "object",
           "required": ["about_url", "name", "type", "url", "vendor"],
           "properties": {
-            "about_url": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "vendor": {
-              "type": "string"
-            }
+            "about_url": { "type": "string" },
+            "name": { "type": "string" },
+            "type": { "type": "string" },
+            "url": { "type": "string" },
+            "vendor": { "type": "string" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "package updated event"

--- a/payload-schemas/schemas/page_build/event.schema.json
+++ b/payload-schemas/schemas/page_build/event.schema.json
@@ -4,9 +4,7 @@
   "type": "object",
   "required": ["id", "build", "repository", "sender"],
   "properties": {
-    "id": {
-      "type": "integer"
-    },
+    "id": { "type": "integer" },
     "build": {
       "type": "object",
       "required": [
@@ -20,52 +18,26 @@
         "updated_at"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "status": {
-          "type": "string"
-        },
+        "url": { "type": "string" },
+        "status": { "type": "string" },
         "error": {
           "type": "object",
           "required": ["message"],
-          "properties": {
-            "message": {
-              "type": "null"
-            }
-          },
+          "properties": { "message": { "type": "null" } },
           "additionalProperties": false
         },
-        "pusher": {
-          "$ref": "common/user.schema.json"
-        },
-        "commit": {
-          "type": "string"
-        },
-        "duration": {
-          "type": "integer"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        }
+        "pusher": { "$ref": "common/user.schema.json" },
+        "commit": { "type": "string" },
+        "duration": { "type": "integer" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "page_build event"

--- a/payload-schemas/schemas/ping/event.schema.json
+++ b/payload-schemas/schemas/ping/event.schema.json
@@ -4,12 +4,8 @@
   "type": "object",
   "required": ["zen", "hook_id", "hook", "sender"],
   "properties": {
-    "zen": {
-      "type": "string"
-    },
-    "hook_id": {
-      "type": "integer"
-    },
+    "zen": { "type": "string" },
+    "hook_id": { "type": "integer" },
     "hook": {
       "type": "object",
       "required": [
@@ -25,90 +21,46 @@
         "ping_url"
       ],
       "properties": {
-        "type": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "name": {
-          "type": "string"
-        },
-        "active": {
-          "type": "boolean"
-        },
+        "type": { "type": "string" },
+        "id": { "type": "integer" },
+        "name": { "type": "string" },
+        "active": { "type": "boolean" },
         "events": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "type": "string" }] }
         },
         "config": {
           "type": "object",
           "required": ["content_type", "url", "insecure_ssl"],
           "properties": {
-            "content_type": {
-              "type": "string"
-            },
-            "secret": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "insecure_ssl": {
-              "type": "string"
-            }
+            "content_type": { "type": "string" },
+            "secret": { "type": "string" },
+            "url": { "type": "string" },
+            "insecure_ssl": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "updated_at": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "test_url": {
-          "type": "string"
-        },
-        "ping_url": {
-          "type": "string"
-        },
+        "updated_at": { "type": "string" },
+        "created_at": { "type": "string" },
+        "url": { "type": "string" },
+        "test_url": { "type": "string" },
+        "ping_url": { "type": "string" },
         "last_response": {
           "type": "object",
           "required": ["code", "status", "message"],
           "properties": {
-            "code": {
-              "type": "null"
-            },
-            "status": {
-              "type": "string"
-            },
-            "message": {
-              "type": "null"
-            }
+            "code": { "type": "null" },
+            "status": { "type": "string" },
+            "message": { "type": "null" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "ping event"

--- a/payload-schemas/schemas/project/closed.schema.json
+++ b/payload-schemas/schemas/project/closed.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["closed"]
-    },
+    "action": { "type": "string", "enum": ["closed"] },
     "project": {
       "type": "object",
       "required": [
@@ -26,60 +23,26 @@
         "updated_at"
       ],
       "properties": {
-        "owner_url": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "columns_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        }
+        "owner_url": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "columns_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "name": { "type": "string" },
+        "body": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "project closed event"

--- a/payload-schemas/schemas/project/created.schema.json
+++ b/payload-schemas/schemas/project/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "project": {
       "type": "object",
       "required": [
@@ -26,60 +23,26 @@
         "updated_at"
       ],
       "properties": {
-        "owner_url": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "columns_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        }
+        "owner_url": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "columns_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "name": { "type": "string" },
+        "body": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "project created event"

--- a/payload-schemas/schemas/project/deleted.schema.json
+++ b/payload-schemas/schemas/project/deleted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "project": {
       "type": "object",
       "required": [
@@ -26,60 +23,26 @@
         "updated_at"
       ],
       "properties": {
-        "owner_url": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "columns_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        }
+        "owner_url": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "columns_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "name": { "type": "string" },
+        "body": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "project deleted event"

--- a/payload-schemas/schemas/project/edited.schema.json
+++ b/payload-schemas/schemas/project/edited.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "project": {
       "type": "object",
       "required": [
@@ -26,60 +23,26 @@
         "updated_at"
       ],
       "properties": {
-        "owner_url": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "columns_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        }
+        "owner_url": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "columns_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "name": { "type": "string" },
+        "body": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "project edited event"

--- a/payload-schemas/schemas/project/reopened.schema.json
+++ b/payload-schemas/schemas/project/reopened.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["reopened"]
-    },
+    "action": { "type": "string", "enum": ["reopened"] },
     "project": {
       "type": "object",
       "required": [
@@ -26,60 +23,26 @@
         "updated_at"
       ],
       "properties": {
-        "owner_url": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "columns_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        }
+        "owner_url": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "columns_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "name": { "type": "string" },
+        "body": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "project reopened event"

--- a/payload-schemas/schemas/project_column/created.schema.json
+++ b/payload-schemas/schemas/project_column/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project_column", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "project_column": {
       "type": "object",
       "required": [
@@ -21,45 +18,21 @@
         "updated_at"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "project_url": {
-          "type": "string"
-        },
-        "cards_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "project_url": { "type": "string" },
+        "cards_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "name": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "project_column created event"

--- a/payload-schemas/schemas/project_column/deleted.schema.json
+++ b/payload-schemas/schemas/project_column/deleted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project_column", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "project_column": {
       "type": "object",
       "required": [
@@ -21,45 +18,21 @@
         "updated_at"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "project_url": {
-          "type": "string"
-        },
-        "cards_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "project_url": { "type": "string" },
+        "cards_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "name": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "project_column deleted event"

--- a/payload-schemas/schemas/project_column/edited.schema.json
+++ b/payload-schemas/schemas/project_column/edited.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project_column", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "project_column": {
       "type": "object",
       "required": [
@@ -21,45 +18,21 @@
         "updated_at"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "project_url": {
-          "type": "string"
-        },
-        "cards_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "project_url": { "type": "string" },
+        "cards_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "name": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "project_column edited event"

--- a/payload-schemas/schemas/project_column/moved.schema.json
+++ b/payload-schemas/schemas/project_column/moved.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project_column", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["moved"]
-    },
+    "action": { "type": "string", "enum": ["moved"] },
     "project_column": {
       "type": "object",
       "required": [
@@ -21,45 +18,21 @@
         "updated_at"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "project_url": {
-          "type": "string"
-        },
-        "cards_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "project_url": { "type": "string" },
+        "cards_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "name": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "project_column moved event"

--- a/payload-schemas/schemas/public/event.schema.json
+++ b/payload-schemas/schemas/public/event.schema.json
@@ -4,18 +4,10 @@
   "type": "object",
   "required": ["repository", "sender"],
   "properties": {
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "public event"

--- a/payload-schemas/schemas/pull_request/assigned.schema.json
+++ b/payload-schemas/schemas/pull_request/assigned.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["assigned"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["assigned"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request assigned event"

--- a/payload-schemas/schemas/pull_request/closed.schema.json
+++ b/payload-schemas/schemas/pull_request/closed.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["closed"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["closed"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request closed event"

--- a/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
+++ b/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["converted_to_draft"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["converted_to_draft"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request converted_to_draft event"

--- a/payload-schemas/schemas/pull_request/edited.schema.json
+++ b/payload-schemas/schemas/pull_request/edited.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["edited"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request edited event"

--- a/payload-schemas/schemas/pull_request/labeled.schema.json
+++ b/payload-schemas/schemas/pull_request/labeled.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["labeled"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["labeled"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request labeled event"

--- a/payload-schemas/schemas/pull_request/locked.schema.json
+++ b/payload-schemas/schemas/pull_request/locked.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["locked"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["locked"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request locked event"

--- a/payload-schemas/schemas/pull_request/opened.schema.json
+++ b/payload-schemas/schemas/pull_request/opened.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["opened"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["opened"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request opened event"

--- a/payload-schemas/schemas/pull_request/ready_for_review.schema.json
+++ b/payload-schemas/schemas/pull_request/ready_for_review.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["ready_for_review"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["ready_for_review"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request ready_for_review event"

--- a/payload-schemas/schemas/pull_request/reopened.schema.json
+++ b/payload-schemas/schemas/pull_request/reopened.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["reopened"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["reopened"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request reopened event"

--- a/payload-schemas/schemas/pull_request/review_request_removed.schema.json
+++ b/payload-schemas/schemas/pull_request/review_request_removed.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["review_request_removed"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["review_request_removed"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request review_request_removed event"

--- a/payload-schemas/schemas/pull_request/review_requested.schema.json
+++ b/payload-schemas/schemas/pull_request/review_requested.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["review_requested"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["review_requested"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request review_requested event"

--- a/payload-schemas/schemas/pull_request/synchronize.schema.json
+++ b/payload-schemas/schemas/pull_request/synchronize.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["synchronize"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["synchronize"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request synchronize event"

--- a/payload-schemas/schemas/pull_request/unassigned.schema.json
+++ b/payload-schemas/schemas/pull_request/unassigned.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["unassigned"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["unassigned"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request unassigned event"

--- a/payload-schemas/schemas/pull_request/unlabeled.schema.json
+++ b/payload-schemas/schemas/pull_request/unlabeled.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["unlabeled"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["unlabeled"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request unlabeled event"

--- a/payload-schemas/schemas/pull_request/unlocked.schema.json
+++ b/payload-schemas/schemas/pull_request/unlocked.schema.json
@@ -4,13 +4,8 @@
   "type": "object",
   "required": ["action", "number", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["unlocked"]
-    },
-    "number": {
-      "type": "integer"
-    },
+    "action": { "type": "string", "enum": ["unlocked"] },
+    "number": { "type": "integer" },
     "pull_request": {
       "type": "object",
       "required": [
@@ -63,120 +58,42 @@
         "changed_files"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "common/user.schema.json"
-              }
-            ]
-          }
+          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -198,100 +115,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -299,21 +159,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -333,153 +183,77 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        },
+        "author_association": { "type": "string" },
         "active_lock_reason": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
             }
           ]
         },
-        "draft": {
-          "type": "boolean"
-        },
-        "merged": {
-          "type": "boolean"
-        },
-        "mergeable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "rebaseable": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "boolean"
-            }
-          ]
-        },
-        "mergeable_state": {
-          "type": "string"
-        },
-        "merged_by": {
-          "type": "null"
-        },
-        "comments": {
-          "type": "integer"
-        },
-        "review_comments": {
-          "type": "integer"
-        },
-        "maintainer_can_modify": {
-          "type": "boolean"
-        },
-        "commits": {
-          "type": "integer"
-        },
-        "additions": {
-          "type": "integer"
-        },
-        "deletions": {
-          "type": "integer"
-        },
-        "changed_files": {
-          "type": "integer"
-        }
+        "draft": { "type": "boolean" },
+        "merged": { "type": "boolean" },
+        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable_state": { "type": "string" },
+        "merged_by": { "type": "null" },
+        "comments": { "type": "integer" },
+        "review_comments": { "type": "integer" },
+        "maintainer_can_modify": { "type": "boolean" },
+        "commits": { "type": "integer" },
+        "additions": { "type": "integer" },
+        "deletions": { "type": "integer" },
+        "changed_files": { "type": "integer" }
       },
       "additionalProperties": false
     },
@@ -487,24 +261,12 @@
       "type": "object",
       "required": ["id", "node_id", "url", "name", "color", "default"],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "color": {
-          "type": "string"
-        },
-        "default": {
-          "type": "boolean"
-        }
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "url": { "type": "string" },
+        "name": { "type": "string" },
+        "color": { "type": "string" },
+        "default": { "type": "boolean" }
       },
       "additionalProperties": false
     },
@@ -531,75 +293,31 @@
         "site_admin"
       ],
       "properties": {
-        "login": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "avatar_url": {
-          "type": "string"
-        },
-        "gravatar_id": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "followers_url": {
-          "type": "string"
-        },
-        "following_url": {
-          "type": "string"
-        },
-        "gists_url": {
-          "type": "string"
-        },
-        "starred_url": {
-          "type": "string"
-        },
-        "subscriptions_url": {
-          "type": "string"
-        },
-        "organizations_url": {
-          "type": "string"
-        },
-        "repos_url": {
-          "type": "string"
-        },
-        "events_url": {
-          "type": "string"
-        },
-        "received_events_url": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        },
-        "site_admin": {
-          "type": "boolean"
-        }
+        "login": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "avatar_url": { "type": "string" },
+        "gravatar_id": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "followers_url": { "type": "string" },
+        "following_url": { "type": "string" },
+        "gists_url": { "type": "string" },
+        "starred_url": { "type": "string" },
+        "subscriptions_url": { "type": "string" },
+        "organizations_url": { "type": "string" },
+        "repos_url": { "type": "string" },
+        "events_url": { "type": "string" },
+        "received_events_url": { "type": "string" },
+        "type": { "type": "string" },
+        "site_admin": { "type": "boolean" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request unlocked event"

--- a/payload-schemas/schemas/pull_request_review/submitted.schema.json
+++ b/payload-schemas/schemas/pull_request_review/submitted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "review", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["submitted"]
-    },
+    "action": { "type": "string", "enum": ["submitted"] },
     "review": {
       "type": "object",
       "required": [
@@ -24,43 +21,16 @@
         "_links"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "commit_id": {
-          "type": "string"
-        },
-        "submitted_at": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "pull_request_url": {
-          "type": "string"
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "commit_id": { "type": "string" },
+        "submitted_at": { "type": "string" },
+        "state": { "type": "string" },
+        "html_url": { "type": "string" },
+        "pull_request_url": { "type": "string" },
+        "author_association": { "type": "string" },
         "_links": {
           "type": "object",
           "required": ["html", "pull_request"],
@@ -68,21 +38,13 @@
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "pull_request": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
@@ -129,114 +91,39 @@
         "author_association"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_reviewers": {
-          "type": "array",
-          "items": {}
-        },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_reviewers": { "type": "array", "items": {} },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -258,94 +145,41 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
             "user": {
               "type": "object",
               "required": [
@@ -369,66 +203,28 @@
                 "site_admin"
               ],
               "properties": {
-                "login": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "avatar_url": {
-                  "type": "string"
-                },
-                "gravatar_id": {
-                  "type": "string"
-                },
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "followers_url": {
-                  "type": "string"
-                },
-                "following_url": {
-                  "type": "string"
-                },
-                "gists_url": {
-                  "type": "string"
-                },
-                "starred_url": {
-                  "type": "string"
-                },
-                "subscriptions_url": {
-                  "type": "string"
-                },
-                "organizations_url": {
-                  "type": "string"
-                },
-                "repos_url": {
-                  "type": "string"
-                },
-                "events_url": {
-                  "type": "string"
-                },
-                "received_events_url": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                },
-                "site_admin": {
-                  "type": "boolean"
-                }
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": "string" },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" }
               },
               "additionalProperties": false
             },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -436,15 +232,9 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
             "user": {
               "type": "object",
               "required": [
@@ -468,66 +258,28 @@
                 "site_admin"
               ],
               "properties": {
-                "login": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "avatar_url": {
-                  "type": "string"
-                },
-                "gravatar_id": {
-                  "type": "string"
-                },
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "followers_url": {
-                  "type": "string"
-                },
-                "following_url": {
-                  "type": "string"
-                },
-                "gists_url": {
-                  "type": "string"
-                },
-                "starred_url": {
-                  "type": "string"
-                },
-                "subscriptions_url": {
-                  "type": "string"
-                },
-                "organizations_url": {
-                  "type": "string"
-                },
-                "repos_url": {
-                  "type": "string"
-                },
-                "events_url": {
-                  "type": "string"
-                },
-                "received_events_url": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                },
-                "site_admin": {
-                  "type": "boolean"
-                }
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": "string" },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" }
               },
               "additionalProperties": false
             },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -547,104 +299,62 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        }
+        "author_association": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request_review submitted event"

--- a/payload-schemas/schemas/pull_request_review_comment/created.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "comment", "pull_request", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "comment": {
       "type": "object",
       "required": [
@@ -31,57 +28,23 @@
         "_links"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "pull_request_review_id": {
-          "type": "integer"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "diff_hunk": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "position": {
-          "type": "integer"
-        },
-        "original_position": {
-          "type": "integer"
-        },
-        "commit_id": {
-          "type": "string"
-        },
-        "original_commit_id": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "pull_request_url": {
-          "type": "string"
-        },
-        "author_association": {
-          "type": "string"
-        },
+        "url": { "type": "string" },
+        "pull_request_review_id": { "type": "integer" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "diff_hunk": { "type": "string" },
+        "path": { "type": "string" },
+        "position": { "type": "integer" },
+        "original_position": { "type": "integer" },
+        "commit_id": { "type": "string" },
+        "original_commit_id": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "html_url": { "type": "string" },
+        "pull_request_url": { "type": "string" },
+        "author_association": { "type": "string" },
         "_links": {
           "type": "object",
           "required": ["self", "html", "pull_request"],
@@ -89,31 +52,19 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "pull_request": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
@@ -160,114 +111,39 @@
         "author_association"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "diff_url": {
-          "type": "string"
-        },
-        "patch_url": {
-          "type": "string"
-        },
-        "issue_url": {
-          "type": "string"
-        },
-        "number": {
-          "type": "integer"
-        },
-        "state": {
-          "type": "string"
-        },
-        "locked": {
-          "type": "boolean"
-        },
-        "title": {
-          "type": "string"
-        },
-        "user": {
-          "$ref": "common/user.schema.json"
-        },
-        "body": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "closed_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "merged_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "html_url": { "type": "string" },
+        "diff_url": { "type": "string" },
+        "patch_url": { "type": "string" },
+        "issue_url": { "type": "string" },
+        "number": { "type": "integer" },
+        "state": { "type": "string" },
+        "locked": { "type": "boolean" },
+        "title": { "type": "string" },
+        "user": { "$ref": "common/user.schema.json" },
+        "body": { "type": "string" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "merge_commit_sha": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
         },
         "assignee": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "common/user.schema.json"
-            }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
         },
         "assignees": {
           "type": "array",
-          "items": {
-            "$ref": "common/user.schema.json"
-          }
+          "items": { "$ref": "common/user.schema.json" }
         },
-        "requested_reviewers": {
-          "type": "array",
-          "items": {}
-        },
-        "requested_teams": {
-          "type": "array",
-          "items": {}
-        },
-        "labels": {
-          "type": "array",
-          "items": {}
-        },
+        "requested_reviewers": { "type": "array", "items": {} },
+        "requested_teams": { "type": "array", "items": {} },
+        "labels": { "type": "array", "items": {} },
         "milestone": {
           "oneOf": [
-            {
-              "type": "null"
-            },
+            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -289,100 +165,43 @@
                 "closed_at"
               ],
               "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "html_url": {
-                  "type": "string"
-                },
-                "labels_url": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "node_id": {
-                  "type": "string"
-                },
-                "number": {
-                  "type": "integer"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "creator": {
-                  "$ref": "common/user.schema.json"
-                },
-                "open_issues": {
-                  "type": "integer"
-                },
-                "closed_issues": {
-                  "type": "integer"
-                },
-                "state": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "updated_at": {
-                  "type": "string"
-                },
-                "due_on": {
-                  "type": "string"
-                },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "labels_url": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "number": { "type": "integer" },
+                "title": { "type": "string" },
+                "description": { "type": "string" },
+                "creator": { "$ref": "common/user.schema.json" },
+                "open_issues": { "type": "integer" },
+                "closed_issues": { "type": "integer" },
+                "state": { "type": "string" },
+                "created_at": { "type": "string" },
+                "updated_at": { "type": "string" },
+                "due_on": { "type": "string" },
                 "closed_at": {
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                  "oneOf": [{ "type": "null" }, { "type": "string" }]
                 }
               },
               "additionalProperties": false
             }
           ]
         },
-        "commits_url": {
-          "type": "string"
-        },
-        "review_comments_url": {
-          "type": "string"
-        },
-        "review_comment_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
-        "statuses_url": {
-          "type": "string"
-        },
+        "commits_url": { "type": "string" },
+        "review_comments_url": { "type": "string" },
+        "review_comment_url": { "type": "string" },
+        "comments_url": { "type": "string" },
+        "statuses_url": { "type": "string" },
         "head": {
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -390,21 +209,11 @@
           "type": "object",
           "required": ["label", "ref", "sha", "user", "repo"],
           "properties": {
-            "label": {
-              "type": "string"
-            },
-            "ref": {
-              "type": "string"
-            },
-            "sha": {
-              "type": "string"
-            },
-            "user": {
-              "$ref": "common/user.schema.json"
-            },
-            "repo": {
-              "$ref": "common/repository.schema.json"
-            }
+            "label": { "type": "string" },
+            "ref": { "type": "string" },
+            "sha": { "type": "string" },
+            "user": { "$ref": "common/user.schema.json" },
+            "repo": { "$ref": "common/repository.schema.json" }
           },
           "additionalProperties": false
         },
@@ -424,104 +233,62 @@
             "self": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "html": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "issue": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comments": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "review_comment": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "commits": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             },
             "statuses": {
               "type": "object",
               "required": ["href"],
-              "properties": {
-                "href": {
-                  "type": "string"
-                }
-              },
+              "properties": { "href": { "type": "string" } },
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         },
-        "author_association": {
-          "type": "string"
-        }
+        "author_association": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "pull_request_review_comment created event"

--- a/payload-schemas/schemas/push/event.schema.json
+++ b/payload-schemas/schemas/push/event.schema.json
@@ -18,69 +18,29 @@
     "sender"
   ],
   "properties": {
-    "ref": {
-      "type": "string"
-    },
-    "before": {
-      "type": "string"
-    },
-    "after": {
-      "type": "string"
-    },
-    "created": {
-      "type": "boolean"
-    },
-    "deleted": {
-      "type": "boolean"
-    },
-    "forced": {
-      "type": "boolean"
-    },
-    "base_ref": {
-      "type": "null"
-    },
-    "compare": {
-      "type": "string"
-    },
-    "commits": {
-      "type": "array",
-      "items": {}
-    },
-    "head_commit": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
+    "ref": { "type": "string" },
+    "before": { "type": "string" },
+    "after": { "type": "string" },
+    "created": { "type": "boolean" },
+    "deleted": { "type": "boolean" },
+    "forced": { "type": "boolean" },
+    "base_ref": { "type": "null" },
+    "compare": { "type": "string" },
+    "commits": { "type": "array", "items": {} },
+    "head_commit": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "repository": { "$ref": "common/repository.schema.json" },
     "pusher": {
       "type": "object",
       "required": ["name", "email"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        }
+        "name": { "type": "string" },
+        "email": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "push event"

--- a/payload-schemas/schemas/release/created.schema.json
+++ b/payload-schemas/schemas/release/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "release", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "release": {
       "type": "object",
       "required": [
@@ -31,76 +28,31 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "assets_url": {
-          "type": "string"
-        },
-        "upload_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "tag_name": {
-          "type": "string"
-        },
-        "target_commitish": {
-          "type": "string"
-        },
-        "name": {
-          "type": "null"
-        },
-        "draft": {
-          "type": "boolean"
-        },
-        "author": {
-          "$ref": "common/user.schema.json"
-        },
-        "prerelease": {
-          "type": "boolean"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "published_at": {
-          "type": "string"
-        },
-        "assets": {
-          "type": "array",
-          "items": {}
-        },
-        "tarball_url": {
-          "type": "string"
-        },
-        "zipball_url": {
-          "type": "string"
-        },
-        "body": {
-          "type": "null"
-        }
+        "url": { "type": "string" },
+        "assets_url": { "type": "string" },
+        "upload_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "tag_name": { "type": "string" },
+        "target_commitish": { "type": "string" },
+        "name": { "type": "null" },
+        "draft": { "type": "boolean" },
+        "author": { "$ref": "common/user.schema.json" },
+        "prerelease": { "type": "boolean" },
+        "created_at": { "type": "string" },
+        "published_at": { "type": "string" },
+        "assets": { "type": "array", "items": {} },
+        "tarball_url": { "type": "string" },
+        "zipball_url": { "type": "string" },
+        "body": { "type": "null" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "release created event"

--- a/payload-schemas/schemas/release/deleted.schema.json
+++ b/payload-schemas/schemas/release/deleted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "release", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "release": {
       "type": "object",
       "required": [
@@ -31,76 +28,31 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "assets_url": {
-          "type": "string"
-        },
-        "upload_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "tag_name": {
-          "type": "string"
-        },
-        "target_commitish": {
-          "type": "string"
-        },
-        "name": {
-          "type": "null"
-        },
-        "draft": {
-          "type": "boolean"
-        },
-        "author": {
-          "$ref": "common/user.schema.json"
-        },
-        "prerelease": {
-          "type": "boolean"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "published_at": {
-          "type": "string"
-        },
-        "assets": {
-          "type": "array",
-          "items": {}
-        },
-        "tarball_url": {
-          "type": "string"
-        },
-        "zipball_url": {
-          "type": "string"
-        },
-        "body": {
-          "type": "null"
-        }
+        "url": { "type": "string" },
+        "assets_url": { "type": "string" },
+        "upload_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "tag_name": { "type": "string" },
+        "target_commitish": { "type": "string" },
+        "name": { "type": "null" },
+        "draft": { "type": "boolean" },
+        "author": { "$ref": "common/user.schema.json" },
+        "prerelease": { "type": "boolean" },
+        "created_at": { "type": "string" },
+        "published_at": { "type": "string" },
+        "assets": { "type": "array", "items": {} },
+        "tarball_url": { "type": "string" },
+        "zipball_url": { "type": "string" },
+        "body": { "type": "null" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "release deleted event"

--- a/payload-schemas/schemas/release/edited.schema.json
+++ b/payload-schemas/schemas/release/edited.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "release", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "release": {
       "type": "object",
       "required": [
@@ -31,76 +28,31 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "assets_url": {
-          "type": "string"
-        },
-        "upload_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "tag_name": {
-          "type": "string"
-        },
-        "target_commitish": {
-          "type": "string"
-        },
-        "name": {
-          "type": "null"
-        },
-        "draft": {
-          "type": "boolean"
-        },
-        "author": {
-          "$ref": "common/user.schema.json"
-        },
-        "prerelease": {
-          "type": "boolean"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "published_at": {
-          "type": "string"
-        },
-        "assets": {
-          "type": "array",
-          "items": {}
-        },
-        "tarball_url": {
-          "type": "string"
-        },
-        "zipball_url": {
-          "type": "string"
-        },
-        "body": {
-          "type": "null"
-        }
+        "url": { "type": "string" },
+        "assets_url": { "type": "string" },
+        "upload_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "tag_name": { "type": "string" },
+        "target_commitish": { "type": "string" },
+        "name": { "type": "null" },
+        "draft": { "type": "boolean" },
+        "author": { "$ref": "common/user.schema.json" },
+        "prerelease": { "type": "boolean" },
+        "created_at": { "type": "string" },
+        "published_at": { "type": "string" },
+        "assets": { "type": "array", "items": {} },
+        "tarball_url": { "type": "string" },
+        "zipball_url": { "type": "string" },
+        "body": { "type": "null" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "release edited event"

--- a/payload-schemas/schemas/release/prereleased.schema.json
+++ b/payload-schemas/schemas/release/prereleased.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "release", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["prereleased"]
-    },
+    "action": { "type": "string", "enum": ["prereleased"] },
     "release": {
       "type": "object",
       "required": [
@@ -31,76 +28,31 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "assets_url": {
-          "type": "string"
-        },
-        "upload_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "tag_name": {
-          "type": "string"
-        },
-        "target_commitish": {
-          "type": "string"
-        },
-        "name": {
-          "type": "null"
-        },
-        "draft": {
-          "type": "boolean"
-        },
-        "author": {
-          "$ref": "common/user.schema.json"
-        },
-        "prerelease": {
-          "type": "boolean"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "published_at": {
-          "type": "string"
-        },
-        "assets": {
-          "type": "array",
-          "items": {}
-        },
-        "tarball_url": {
-          "type": "string"
-        },
-        "zipball_url": {
-          "type": "string"
-        },
-        "body": {
-          "type": "null"
-        }
+        "url": { "type": "string" },
+        "assets_url": { "type": "string" },
+        "upload_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "tag_name": { "type": "string" },
+        "target_commitish": { "type": "string" },
+        "name": { "type": "null" },
+        "draft": { "type": "boolean" },
+        "author": { "$ref": "common/user.schema.json" },
+        "prerelease": { "type": "boolean" },
+        "created_at": { "type": "string" },
+        "published_at": { "type": "string" },
+        "assets": { "type": "array", "items": {} },
+        "tarball_url": { "type": "string" },
+        "zipball_url": { "type": "string" },
+        "body": { "type": "null" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "release prereleased event"

--- a/payload-schemas/schemas/release/published.schema.json
+++ b/payload-schemas/schemas/release/published.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "release", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["published"]
-    },
+    "action": { "type": "string", "enum": ["published"] },
     "release": {
       "type": "object",
       "required": [
@@ -31,76 +28,31 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "assets_url": {
-          "type": "string"
-        },
-        "upload_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "tag_name": {
-          "type": "string"
-        },
-        "target_commitish": {
-          "type": "string"
-        },
-        "name": {
-          "type": "null"
-        },
-        "draft": {
-          "type": "boolean"
-        },
-        "author": {
-          "$ref": "common/user.schema.json"
-        },
-        "prerelease": {
-          "type": "boolean"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "published_at": {
-          "type": "string"
-        },
-        "assets": {
-          "type": "array",
-          "items": {}
-        },
-        "tarball_url": {
-          "type": "string"
-        },
-        "zipball_url": {
-          "type": "string"
-        },
-        "body": {
-          "type": "null"
-        }
+        "url": { "type": "string" },
+        "assets_url": { "type": "string" },
+        "upload_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "tag_name": { "type": "string" },
+        "target_commitish": { "type": "string" },
+        "name": { "type": "null" },
+        "draft": { "type": "boolean" },
+        "author": { "$ref": "common/user.schema.json" },
+        "prerelease": { "type": "boolean" },
+        "created_at": { "type": "string" },
+        "published_at": { "type": "string" },
+        "assets": { "type": "array", "items": {} },
+        "tarball_url": { "type": "string" },
+        "zipball_url": { "type": "string" },
+        "body": { "type": "null" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "release published event"

--- a/payload-schemas/schemas/release/released.schema.json
+++ b/payload-schemas/schemas/release/released.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "release", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["released"]
-    },
+    "action": { "type": "string", "enum": ["released"] },
     "release": {
       "type": "object",
       "required": [
@@ -31,76 +28,31 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "assets_url": {
-          "type": "string"
-        },
-        "upload_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "tag_name": {
-          "type": "string"
-        },
-        "target_commitish": {
-          "type": "string"
-        },
-        "name": {
-          "type": "null"
-        },
-        "draft": {
-          "type": "boolean"
-        },
-        "author": {
-          "$ref": "common/user.schema.json"
-        },
-        "prerelease": {
-          "type": "boolean"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "published_at": {
-          "type": "string"
-        },
-        "assets": {
-          "type": "array",
-          "items": {}
-        },
-        "tarball_url": {
-          "type": "string"
-        },
-        "zipball_url": {
-          "type": "string"
-        },
-        "body": {
-          "type": "null"
-        }
+        "url": { "type": "string" },
+        "assets_url": { "type": "string" },
+        "upload_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "tag_name": { "type": "string" },
+        "target_commitish": { "type": "string" },
+        "name": { "type": "null" },
+        "draft": { "type": "boolean" },
+        "author": { "$ref": "common/user.schema.json" },
+        "prerelease": { "type": "boolean" },
+        "created_at": { "type": "string" },
+        "published_at": { "type": "string" },
+        "assets": { "type": "array", "items": {} },
+        "tarball_url": { "type": "string" },
+        "zipball_url": { "type": "string" },
+        "body": { "type": "null" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "release released event"

--- a/payload-schemas/schemas/release/unpublished.schema.json
+++ b/payload-schemas/schemas/release/unpublished.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "release", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["unpublished"]
-    },
+    "action": { "type": "string", "enum": ["unpublished"] },
     "release": {
       "type": "object",
       "required": [
@@ -31,76 +28,31 @@
         "body"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "assets_url": {
-          "type": "string"
-        },
-        "upload_url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "tag_name": {
-          "type": "string"
-        },
-        "target_commitish": {
-          "type": "string"
-        },
-        "name": {
-          "type": "null"
-        },
-        "draft": {
-          "type": "boolean"
-        },
-        "author": {
-          "$ref": "common/user.schema.json"
-        },
-        "prerelease": {
-          "type": "boolean"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "published_at": {
-          "type": "string"
-        },
-        "assets": {
-          "type": "array",
-          "items": {}
-        },
-        "tarball_url": {
-          "type": "string"
-        },
-        "zipball_url": {
-          "type": "string"
-        },
-        "body": {
-          "type": "null"
-        }
+        "url": { "type": "string" },
+        "assets_url": { "type": "string" },
+        "upload_url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "tag_name": { "type": "string" },
+        "target_commitish": { "type": "string" },
+        "name": { "type": "null" },
+        "draft": { "type": "boolean" },
+        "author": { "$ref": "common/user.schema.json" },
+        "prerelease": { "type": "boolean" },
+        "created_at": { "type": "string" },
+        "published_at": { "type": "string" },
+        "assets": { "type": "array", "items": {} },
+        "tarball_url": { "type": "string" },
+        "zipball_url": { "type": "string" },
+        "body": { "type": "null" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "release unpublished event"

--- a/payload-schemas/schemas/repository/archived.schema.json
+++ b/payload-schemas/schemas/repository/archived.schema.json
@@ -4,66 +4,39 @@
   "type": "object",
   "required": ["action", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["archived"]
-    },
+    "action": { "type": "string", "enum": ["archived"] },
     "changes": {
       "type": "object",
       "properties": {
         "description": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "default_branch": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "owner": {
           "type": "object",
           "properties": {
             "from": {
               "type": "object",
-              "properties": {
-                "user": {
-                  "$ref": "common/user.schema.json"
-                }
-              }
+              "properties": { "user": { "$ref": "common/user.schema.json" } }
             }
           }
         },
         "homepage": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "additionalProperties": false
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository archived event"

--- a/payload-schemas/schemas/repository/created.schema.json
+++ b/payload-schemas/schemas/repository/created.schema.json
@@ -4,66 +4,39 @@
   "type": "object",
   "required": ["action", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "changes": {
       "type": "object",
       "properties": {
         "description": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "default_branch": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "owner": {
           "type": "object",
           "properties": {
             "from": {
               "type": "object",
-              "properties": {
-                "user": {
-                  "$ref": "common/user.schema.json"
-                }
-              }
+              "properties": { "user": { "$ref": "common/user.schema.json" } }
             }
           }
         },
         "homepage": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "additionalProperties": false
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository created event"

--- a/payload-schemas/schemas/repository/deleted.schema.json
+++ b/payload-schemas/schemas/repository/deleted.schema.json
@@ -4,66 +4,39 @@
   "type": "object",
   "required": ["action", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "changes": {
       "type": "object",
       "properties": {
         "description": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "default_branch": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "owner": {
           "type": "object",
           "properties": {
             "from": {
               "type": "object",
-              "properties": {
-                "user": {
-                  "$ref": "common/user.schema.json"
-                }
-              }
+              "properties": { "user": { "$ref": "common/user.schema.json" } }
             }
           }
         },
         "homepage": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "additionalProperties": false
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository deleted event"

--- a/payload-schemas/schemas/repository/edited.schema.json
+++ b/payload-schemas/schemas/repository/edited.schema.json
@@ -4,66 +4,39 @@
   "type": "object",
   "required": ["action", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "changes": {
       "type": "object",
       "properties": {
         "description": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "default_branch": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "owner": {
           "type": "object",
           "properties": {
             "from": {
               "type": "object",
-              "properties": {
-                "user": {
-                  "$ref": "common/user.schema.json"
-                }
-              }
+              "properties": { "user": { "$ref": "common/user.schema.json" } }
             }
           }
         },
         "homepage": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "additionalProperties": false
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository edited event"

--- a/payload-schemas/schemas/repository/privatized.schema.json
+++ b/payload-schemas/schemas/repository/privatized.schema.json
@@ -4,66 +4,39 @@
   "type": "object",
   "required": ["action", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["privatized"]
-    },
+    "action": { "type": "string", "enum": ["privatized"] },
     "changes": {
       "type": "object",
       "properties": {
         "description": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "default_branch": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "owner": {
           "type": "object",
           "properties": {
             "from": {
               "type": "object",
-              "properties": {
-                "user": {
-                  "$ref": "common/user.schema.json"
-                }
-              }
+              "properties": { "user": { "$ref": "common/user.schema.json" } }
             }
           }
         },
         "homepage": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "additionalProperties": false
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository privatized event"

--- a/payload-schemas/schemas/repository/publicized.schema.json
+++ b/payload-schemas/schemas/repository/publicized.schema.json
@@ -4,66 +4,39 @@
   "type": "object",
   "required": ["action", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["publicized"]
-    },
+    "action": { "type": "string", "enum": ["publicized"] },
     "changes": {
       "type": "object",
       "properties": {
         "description": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "default_branch": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "owner": {
           "type": "object",
           "properties": {
             "from": {
               "type": "object",
-              "properties": {
-                "user": {
-                  "$ref": "common/user.schema.json"
-                }
-              }
+              "properties": { "user": { "$ref": "common/user.schema.json" } }
             }
           }
         },
         "homepage": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "additionalProperties": false
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository publicized event"

--- a/payload-schemas/schemas/repository/renamed.schema.json
+++ b/payload-schemas/schemas/repository/renamed.schema.json
@@ -4,66 +4,39 @@
   "type": "object",
   "required": ["action", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["renamed"]
-    },
+    "action": { "type": "string", "enum": ["renamed"] },
     "changes": {
       "type": "object",
       "properties": {
         "description": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "default_branch": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "owner": {
           "type": "object",
           "properties": {
             "from": {
               "type": "object",
-              "properties": {
-                "user": {
-                  "$ref": "common/user.schema.json"
-                }
-              }
+              "properties": { "user": { "$ref": "common/user.schema.json" } }
             }
           }
         },
         "homepage": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "additionalProperties": false
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository renamed event"

--- a/payload-schemas/schemas/repository/transferred.schema.json
+++ b/payload-schemas/schemas/repository/transferred.schema.json
@@ -4,66 +4,39 @@
   "type": "object",
   "required": ["action", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["transferred"]
-    },
+    "action": { "type": "string", "enum": ["transferred"] },
     "changes": {
       "type": "object",
       "properties": {
         "description": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "default_branch": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "owner": {
           "type": "object",
           "properties": {
             "from": {
               "type": "object",
-              "properties": {
-                "user": {
-                  "$ref": "common/user.schema.json"
-                }
-              }
+              "properties": { "user": { "$ref": "common/user.schema.json" } }
             }
           }
         },
         "homepage": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "additionalProperties": false
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository transferred event"

--- a/payload-schemas/schemas/repository/unarchived.schema.json
+++ b/payload-schemas/schemas/repository/unarchived.schema.json
@@ -4,66 +4,39 @@
   "type": "object",
   "required": ["action", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["unarchived"]
-    },
+    "action": { "type": "string", "enum": ["unarchived"] },
     "changes": {
       "type": "object",
       "properties": {
         "description": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "default_branch": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "owner": {
           "type": "object",
           "properties": {
             "from": {
               "type": "object",
-              "properties": {
-                "user": {
-                  "$ref": "common/user.schema.json"
-                }
-              }
+              "properties": { "user": { "$ref": "common/user.schema.json" } }
             }
           }
         },
         "homepage": {
           "type": "object",
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          }
+          "properties": { "from": { "type": "string" } }
         },
         "additionalProperties": false
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository unarchived event"

--- a/payload-schemas/schemas/repository_dispatch/event.schema.json
+++ b/payload-schemas/schemas/repository_dispatch/event.schema.json
@@ -12,29 +12,17 @@
     "installation"
   ],
   "properties": {
-    "action": {
-      "type": "string"
-    },
-    "branch": {
-      "type": "string"
-    },
+    "action": { "type": "string" },
+    "branch": { "type": "string" },
     "client_payload": {
       "type": "object",
       "properties": {},
       "additionalProperties": true
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository_dispatch event"

--- a/payload-schemas/schemas/repository_import/event.schema.json
+++ b/payload-schemas/schemas/repository_import/event.schema.json
@@ -4,22 +4,11 @@
   "type": "object",
   "required": ["status", "repository", "organization", "sender"],
   "properties": {
-    "status": {
-      "type": "string",
-      "enum": ["success", "cancelled", "failure"]
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "status": { "type": "string", "enum": ["success", "cancelled", "failure"] },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository_import event"

--- a/payload-schemas/schemas/repository_vulnerability_alert/create.schema.json
+++ b/payload-schemas/schemas/repository_vulnerability_alert/create.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "alert"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["create"]
-    },
+    "action": { "type": "string", "enum": ["create"] },
     "alert": {
       "type": "object",
       "required": [
@@ -19,51 +16,23 @@
         "fixed_in"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "affected_range": {
-          "type": "string"
-        },
-        "affected_package_name": {
-          "type": "string"
-        },
-        "dismisser": {
-          "$ref": "common/user.schema.json"
-        },
-        "dismiss_reason": {
-          "type": "string"
-        },
-        "dismissed_at": {
-          "type": "string"
-        },
-        "ghsa_id": {
-          "type": "string"
-        },
-        "external_reference": {
-          "type": "string"
-        },
-        "external_identifier": {
-          "type": "string"
-        },
-        "fixed_in": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        }
+        "id": { "type": "integer" },
+        "affected_range": { "type": "string" },
+        "affected_package_name": { "type": "string" },
+        "dismisser": { "$ref": "common/user.schema.json" },
+        "dismiss_reason": { "type": "string" },
+        "dismissed_at": { "type": "string" },
+        "ghsa_id": { "type": "string" },
+        "external_reference": { "type": "string" },
+        "external_identifier": { "type": "string" },
+        "fixed_in": { "type": "string" },
+        "created_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository_vulnerability_alert create event"

--- a/payload-schemas/schemas/repository_vulnerability_alert/dismiss.schema.json
+++ b/payload-schemas/schemas/repository_vulnerability_alert/dismiss.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "alert"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["dismiss"]
-    },
+    "action": { "type": "string", "enum": ["dismiss"] },
     "alert": {
       "type": "object",
       "required": [
@@ -19,51 +16,23 @@
         "fixed_in"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "affected_range": {
-          "type": "string"
-        },
-        "affected_package_name": {
-          "type": "string"
-        },
-        "dismisser": {
-          "$ref": "common/user.schema.json"
-        },
-        "dismiss_reason": {
-          "type": "string"
-        },
-        "dismissed_at": {
-          "type": "string"
-        },
-        "ghsa_id": {
-          "type": "string"
-        },
-        "external_reference": {
-          "type": "string"
-        },
-        "external_identifier": {
-          "type": "string"
-        },
-        "fixed_in": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        }
+        "id": { "type": "integer" },
+        "affected_range": { "type": "string" },
+        "affected_package_name": { "type": "string" },
+        "dismisser": { "$ref": "common/user.schema.json" },
+        "dismiss_reason": { "type": "string" },
+        "dismissed_at": { "type": "string" },
+        "ghsa_id": { "type": "string" },
+        "external_reference": { "type": "string" },
+        "external_identifier": { "type": "string" },
+        "fixed_in": { "type": "string" },
+        "created_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository_vulnerability_alert dismiss event"

--- a/payload-schemas/schemas/repository_vulnerability_alert/resolve.schema.json
+++ b/payload-schemas/schemas/repository_vulnerability_alert/resolve.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "alert"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["resolve"]
-    },
+    "action": { "type": "string", "enum": ["resolve"] },
     "alert": {
       "type": "object",
       "required": [
@@ -19,51 +16,23 @@
         "fixed_in"
       ],
       "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "affected_range": {
-          "type": "string"
-        },
-        "affected_package_name": {
-          "type": "string"
-        },
-        "dismisser": {
-          "$ref": "common/user.schema.json"
-        },
-        "dismiss_reason": {
-          "type": "string"
-        },
-        "dismissed_at": {
-          "type": "string"
-        },
-        "ghsa_id": {
-          "type": "string"
-        },
-        "external_reference": {
-          "type": "string"
-        },
-        "external_identifier": {
-          "type": "string"
-        },
-        "fixed_in": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        }
+        "id": { "type": "integer" },
+        "affected_range": { "type": "string" },
+        "affected_package_name": { "type": "string" },
+        "dismisser": { "$ref": "common/user.schema.json" },
+        "dismiss_reason": { "type": "string" },
+        "dismissed_at": { "type": "string" },
+        "ghsa_id": { "type": "string" },
+        "external_reference": { "type": "string" },
+        "external_identifier": { "type": "string" },
+        "fixed_in": { "type": "string" },
+        "created_at": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "repository_vulnerability_alert resolve event"

--- a/payload-schemas/schemas/security_advisory/performed.schema.json
+++ b/payload-schemas/schemas/security_advisory/performed.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "security_advisory"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["performed"]
-    },
+    "action": { "type": "string", "enum": ["performed"] },
     "security_advisory": {
       "type": "object",
       "required": [
@@ -23,18 +20,10 @@
         "vulnerabilities"
       ],
       "properties": {
-        "ghsa_id": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "severity": {
-          "type": "string"
-        },
+        "ghsa_id": { "type": "string" },
+        "summary": { "type": "string" },
+        "description": { "type": "string" },
+        "severity": { "type": "string" },
         "identifiers": {
           "type": "array",
           "items": {
@@ -43,12 +32,8 @@
                 "type": "object",
                 "required": ["value", "type"],
                 "properties": {
-                  "value": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "type": "string"
-                  }
+                  "value": { "type": "string" },
+                  "type": { "type": "string" }
                 },
                 "additionalProperties": false
               }
@@ -62,32 +47,15 @@
               {
                 "type": "object",
                 "required": ["url"],
-                "properties": {
-                  "url": {
-                    "type": "string"
-                  }
-                },
+                "properties": { "url": { "type": "string" } },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "published_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "published_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "withdrawn_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "vulnerabilities": {
           "type": "array",
           "items": {
@@ -105,36 +73,22 @@
                     "type": "object",
                     "required": ["ecosystem", "name"],
                     "properties": {
-                      "ecosystem": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
+                      "ecosystem": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
                   },
-                  "severity": {
-                    "type": "string"
-                  },
-                  "vulnerable_version_range": {
-                    "type": "string"
-                  },
+                  "severity": { "type": "string" },
+                  "vulnerable_version_range": { "type": "string" },
                   "first_patched_version": {
                     "oneOf": [
                       {
                         "type": "object",
                         "required": ["identifier"],
-                        "properties": {
-                          "identifier": {
-                            "type": "string"
-                          }
-                        },
+                        "properties": { "identifier": { "type": "string" } },
                         "additionalProperties": false
                       },
-                      {
-                        "type": "null"
-                      }
+                      { "type": "null" }
                     ]
                   }
                 },

--- a/payload-schemas/schemas/security_advisory/published.schema.json
+++ b/payload-schemas/schemas/security_advisory/published.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "security_advisory"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["published"]
-    },
+    "action": { "type": "string", "enum": ["published"] },
     "security_advisory": {
       "type": "object",
       "required": [
@@ -23,18 +20,10 @@
         "vulnerabilities"
       ],
       "properties": {
-        "ghsa_id": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "severity": {
-          "type": "string"
-        },
+        "ghsa_id": { "type": "string" },
+        "summary": { "type": "string" },
+        "description": { "type": "string" },
+        "severity": { "type": "string" },
         "identifiers": {
           "type": "array",
           "items": {
@@ -43,12 +32,8 @@
                 "type": "object",
                 "required": ["value", "type"],
                 "properties": {
-                  "value": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "type": "string"
-                  }
+                  "value": { "type": "string" },
+                  "type": { "type": "string" }
                 },
                 "additionalProperties": false
               }
@@ -62,32 +47,15 @@
               {
                 "type": "object",
                 "required": ["url"],
-                "properties": {
-                  "url": {
-                    "type": "string"
-                  }
-                },
+                "properties": { "url": { "type": "string" } },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "published_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "published_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "withdrawn_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "vulnerabilities": {
           "type": "array",
           "items": {
@@ -105,36 +73,22 @@
                     "type": "object",
                     "required": ["ecosystem", "name"],
                     "properties": {
-                      "ecosystem": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
+                      "ecosystem": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
                   },
-                  "severity": {
-                    "type": "string"
-                  },
-                  "vulnerable_version_range": {
-                    "type": "string"
-                  },
+                  "severity": { "type": "string" },
+                  "vulnerable_version_range": { "type": "string" },
                   "first_patched_version": {
                     "oneOf": [
                       {
                         "type": "object",
                         "required": ["identifier"],
-                        "properties": {
-                          "identifier": {
-                            "type": "string"
-                          }
-                        },
+                        "properties": { "identifier": { "type": "string" } },
                         "additionalProperties": false
                       },
-                      {
-                        "type": "null"
-                      }
+                      { "type": "null" }
                     ]
                   }
                 },

--- a/payload-schemas/schemas/security_advisory/updated.schema.json
+++ b/payload-schemas/schemas/security_advisory/updated.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "security_advisory"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["updated"]
-    },
+    "action": { "type": "string", "enum": ["updated"] },
     "security_advisory": {
       "type": "object",
       "required": [
@@ -23,18 +20,10 @@
         "vulnerabilities"
       ],
       "properties": {
-        "ghsa_id": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "severity": {
-          "type": "string"
-        },
+        "ghsa_id": { "type": "string" },
+        "summary": { "type": "string" },
+        "description": { "type": "string" },
+        "severity": { "type": "string" },
         "identifiers": {
           "type": "array",
           "items": {
@@ -43,12 +32,8 @@
                 "type": "object",
                 "required": ["value", "type"],
                 "properties": {
-                  "value": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "type": "string"
-                  }
+                  "value": { "type": "string" },
+                  "type": { "type": "string" }
                 },
                 "additionalProperties": false
               }
@@ -62,32 +47,15 @@
               {
                 "type": "object",
                 "required": ["url"],
-                "properties": {
-                  "url": {
-                    "type": "string"
-                  }
-                },
+                "properties": { "url": { "type": "string" } },
                 "additionalProperties": false
               }
             ]
           }
         },
-        "published_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "withdrawn_at": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
+        "published_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "withdrawn_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
         "vulnerabilities": {
           "type": "array",
           "items": {
@@ -105,36 +73,22 @@
                     "type": "object",
                     "required": ["ecosystem", "name"],
                     "properties": {
-                      "ecosystem": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
+                      "ecosystem": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
                   },
-                  "severity": {
-                    "type": "string"
-                  },
-                  "vulnerable_version_range": {
-                    "type": "string"
-                  },
+                  "severity": { "type": "string" },
+                  "vulnerable_version_range": { "type": "string" },
                   "first_patched_version": {
                     "oneOf": [
                       {
                         "type": "object",
                         "required": ["identifier"],
-                        "properties": {
-                          "identifier": {
-                            "type": "string"
-                          }
-                        },
+                        "properties": { "identifier": { "type": "string" } },
                         "additionalProperties": false
                       },
-                      {
-                        "type": "null"
-                      }
+                      { "type": "null" }
                     ]
                   }
                 },

--- a/payload-schemas/schemas/sponsorship/cancelled.schema.json
+++ b/payload-schemas/schemas/sponsorship/cancelled.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "sponsorship", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["cancelled"]
-    },
+    "action": { "type": "string", "enum": ["cancelled"] },
     "sponsorship": {
       "type": "object",
       "required": [
@@ -19,21 +16,11 @@
         "tier"
       ],
       "properties": {
-        "node_id": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "sponsorable": {
-          "$ref": "common/user.schema.json"
-        },
-        "sponsor": {
-          "$ref": "common/user.schema.json"
-        },
-        "privacy_level": {
-          "type": "string"
-        },
+        "node_id": { "type": "string" },
+        "created_at": { "type": "string" },
+        "sponsorable": { "$ref": "common/user.schema.json" },
+        "sponsor": { "$ref": "common/user.schema.json" },
+        "privacy_level": { "type": "string" },
         "tier": {
           "type": "object",
           "required": [
@@ -45,33 +32,19 @@
             "name"
           ],
           "properties": {
-            "node_id": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "monthly_price_in_dollars": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            }
+            "node_id": { "type": "string" },
+            "created_at": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "monthly_price_in_dollars": { "type": "integer" },
+            "name": { "type": "string" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "effective_date": {
-      "type": "string"
-    },
+    "effective_date": { "type": "string" },
     "changes": {
       "type": "object",
       "required": ["tier"],
@@ -91,24 +64,12 @@
                 "name"
               ],
               "properties": {
-                "node_id": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "monthly_price_in_cents": {
-                  "type": "integer"
-                },
-                "monthly_price_in_dollars": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                }
+                "node_id": { "type": "string" },
+                "created_at": { "type": "string" },
+                "description": { "type": "string" },
+                "monthly_price_in_cents": { "type": "integer" },
+                "monthly_price_in_dollars": { "type": "integer" },
+                "name": { "type": "string" }
               },
               "additionalProperties": false
             }
@@ -118,9 +79,7 @@
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "sponsorship cancelled event"

--- a/payload-schemas/schemas/sponsorship/created.schema.json
+++ b/payload-schemas/schemas/sponsorship/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "sponsorship", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "sponsorship": {
       "type": "object",
       "required": [
@@ -19,21 +16,11 @@
         "tier"
       ],
       "properties": {
-        "node_id": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "sponsorable": {
-          "$ref": "common/user.schema.json"
-        },
-        "sponsor": {
-          "$ref": "common/user.schema.json"
-        },
-        "privacy_level": {
-          "type": "string"
-        },
+        "node_id": { "type": "string" },
+        "created_at": { "type": "string" },
+        "sponsorable": { "$ref": "common/user.schema.json" },
+        "sponsor": { "$ref": "common/user.schema.json" },
+        "privacy_level": { "type": "string" },
         "tier": {
           "type": "object",
           "required": [
@@ -45,33 +32,19 @@
             "name"
           ],
           "properties": {
-            "node_id": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "monthly_price_in_dollars": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            }
+            "node_id": { "type": "string" },
+            "created_at": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "monthly_price_in_dollars": { "type": "integer" },
+            "name": { "type": "string" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "effective_date": {
-      "type": "string"
-    },
+    "effective_date": { "type": "string" },
     "changes": {
       "type": "object",
       "required": ["tier"],
@@ -91,24 +64,12 @@
                 "name"
               ],
               "properties": {
-                "node_id": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "monthly_price_in_cents": {
-                  "type": "integer"
-                },
-                "monthly_price_in_dollars": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                }
+                "node_id": { "type": "string" },
+                "created_at": { "type": "string" },
+                "description": { "type": "string" },
+                "monthly_price_in_cents": { "type": "integer" },
+                "monthly_price_in_dollars": { "type": "integer" },
+                "name": { "type": "string" }
               },
               "additionalProperties": false
             }
@@ -118,9 +79,7 @@
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "sponsorship created event"

--- a/payload-schemas/schemas/sponsorship/edited.schema.json
+++ b/payload-schemas/schemas/sponsorship/edited.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "sponsorship", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "sponsorship": {
       "type": "object",
       "required": [
@@ -19,21 +16,11 @@
         "tier"
       ],
       "properties": {
-        "node_id": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "sponsorable": {
-          "$ref": "common/user.schema.json"
-        },
-        "sponsor": {
-          "$ref": "common/user.schema.json"
-        },
-        "privacy_level": {
-          "type": "string"
-        },
+        "node_id": { "type": "string" },
+        "created_at": { "type": "string" },
+        "sponsorable": { "$ref": "common/user.schema.json" },
+        "sponsor": { "$ref": "common/user.schema.json" },
+        "privacy_level": { "type": "string" },
         "tier": {
           "type": "object",
           "required": [
@@ -45,33 +32,19 @@
             "name"
           ],
           "properties": {
-            "node_id": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "monthly_price_in_dollars": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            }
+            "node_id": { "type": "string" },
+            "created_at": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "monthly_price_in_dollars": { "type": "integer" },
+            "name": { "type": "string" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "effective_date": {
-      "type": "string"
-    },
+    "effective_date": { "type": "string" },
     "changes": {
       "type": "object",
       "required": ["tier"],
@@ -91,24 +64,12 @@
                 "name"
               ],
               "properties": {
-                "node_id": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "monthly_price_in_cents": {
-                  "type": "integer"
-                },
-                "monthly_price_in_dollars": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                }
+                "node_id": { "type": "string" },
+                "created_at": { "type": "string" },
+                "description": { "type": "string" },
+                "monthly_price_in_cents": { "type": "integer" },
+                "monthly_price_in_dollars": { "type": "integer" },
+                "name": { "type": "string" }
               },
               "additionalProperties": false
             }
@@ -118,9 +79,7 @@
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "sponsorship edited event"

--- a/payload-schemas/schemas/sponsorship/pending_cancellation.schema.json
+++ b/payload-schemas/schemas/sponsorship/pending_cancellation.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "sponsorship", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["pending_cancellation"]
-    },
+    "action": { "type": "string", "enum": ["pending_cancellation"] },
     "sponsorship": {
       "type": "object",
       "required": [
@@ -19,21 +16,11 @@
         "tier"
       ],
       "properties": {
-        "node_id": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "sponsorable": {
-          "$ref": "common/user.schema.json"
-        },
-        "sponsor": {
-          "$ref": "common/user.schema.json"
-        },
-        "privacy_level": {
-          "type": "string"
-        },
+        "node_id": { "type": "string" },
+        "created_at": { "type": "string" },
+        "sponsorable": { "$ref": "common/user.schema.json" },
+        "sponsor": { "$ref": "common/user.schema.json" },
+        "privacy_level": { "type": "string" },
         "tier": {
           "type": "object",
           "required": [
@@ -45,33 +32,19 @@
             "name"
           ],
           "properties": {
-            "node_id": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "monthly_price_in_dollars": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            }
+            "node_id": { "type": "string" },
+            "created_at": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "monthly_price_in_dollars": { "type": "integer" },
+            "name": { "type": "string" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "effective_date": {
-      "type": "string"
-    },
+    "effective_date": { "type": "string" },
     "changes": {
       "type": "object",
       "required": ["tier"],
@@ -91,24 +64,12 @@
                 "name"
               ],
               "properties": {
-                "node_id": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "monthly_price_in_cents": {
-                  "type": "integer"
-                },
-                "monthly_price_in_dollars": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                }
+                "node_id": { "type": "string" },
+                "created_at": { "type": "string" },
+                "description": { "type": "string" },
+                "monthly_price_in_cents": { "type": "integer" },
+                "monthly_price_in_dollars": { "type": "integer" },
+                "name": { "type": "string" }
               },
               "additionalProperties": false
             }
@@ -118,9 +79,7 @@
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "sponsorship pending_cancellation event"

--- a/payload-schemas/schemas/sponsorship/pending_tier_change.schema.json
+++ b/payload-schemas/schemas/sponsorship/pending_tier_change.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "sponsorship", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["pending_tier_change"]
-    },
+    "action": { "type": "string", "enum": ["pending_tier_change"] },
     "sponsorship": {
       "type": "object",
       "required": [
@@ -19,21 +16,11 @@
         "tier"
       ],
       "properties": {
-        "node_id": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "sponsorable": {
-          "$ref": "common/user.schema.json"
-        },
-        "sponsor": {
-          "$ref": "common/user.schema.json"
-        },
-        "privacy_level": {
-          "type": "string"
-        },
+        "node_id": { "type": "string" },
+        "created_at": { "type": "string" },
+        "sponsorable": { "$ref": "common/user.schema.json" },
+        "sponsor": { "$ref": "common/user.schema.json" },
+        "privacy_level": { "type": "string" },
         "tier": {
           "type": "object",
           "required": [
@@ -45,33 +32,19 @@
             "name"
           ],
           "properties": {
-            "node_id": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "monthly_price_in_dollars": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            }
+            "node_id": { "type": "string" },
+            "created_at": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "monthly_price_in_dollars": { "type": "integer" },
+            "name": { "type": "string" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "effective_date": {
-      "type": "string"
-    },
+    "effective_date": { "type": "string" },
     "changes": {
       "type": "object",
       "required": ["tier"],
@@ -91,24 +64,12 @@
                 "name"
               ],
               "properties": {
-                "node_id": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "monthly_price_in_cents": {
-                  "type": "integer"
-                },
-                "monthly_price_in_dollars": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                }
+                "node_id": { "type": "string" },
+                "created_at": { "type": "string" },
+                "description": { "type": "string" },
+                "monthly_price_in_cents": { "type": "integer" },
+                "monthly_price_in_dollars": { "type": "integer" },
+                "name": { "type": "string" }
               },
               "additionalProperties": false
             }
@@ -118,9 +79,7 @@
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "sponsorship pending_tier_change event"

--- a/payload-schemas/schemas/sponsorship/tier_changed.schema.json
+++ b/payload-schemas/schemas/sponsorship/tier_changed.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "sponsorship", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["tier_changed"]
-    },
+    "action": { "type": "string", "enum": ["tier_changed"] },
     "sponsorship": {
       "type": "object",
       "required": [
@@ -19,21 +16,11 @@
         "tier"
       ],
       "properties": {
-        "node_id": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "sponsorable": {
-          "$ref": "common/user.schema.json"
-        },
-        "sponsor": {
-          "$ref": "common/user.schema.json"
-        },
-        "privacy_level": {
-          "type": "string"
-        },
+        "node_id": { "type": "string" },
+        "created_at": { "type": "string" },
+        "sponsorable": { "$ref": "common/user.schema.json" },
+        "sponsor": { "$ref": "common/user.schema.json" },
+        "privacy_level": { "type": "string" },
         "tier": {
           "type": "object",
           "required": [
@@ -45,33 +32,19 @@
             "name"
           ],
           "properties": {
-            "node_id": {
-              "type": "string"
-            },
-            "created_at": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "monthly_price_in_cents": {
-              "type": "integer"
-            },
-            "monthly_price_in_dollars": {
-              "type": "integer"
-            },
-            "name": {
-              "type": "string"
-            }
+            "node_id": { "type": "string" },
+            "created_at": { "type": "string" },
+            "description": { "type": "string" },
+            "monthly_price_in_cents": { "type": "integer" },
+            "monthly_price_in_dollars": { "type": "integer" },
+            "name": { "type": "string" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "effective_date": {
-      "type": "string"
-    },
+    "effective_date": { "type": "string" },
     "changes": {
       "type": "object",
       "required": ["tier"],
@@ -91,24 +64,12 @@
                 "name"
               ],
               "properties": {
-                "node_id": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "monthly_price_in_cents": {
-                  "type": "integer"
-                },
-                "monthly_price_in_dollars": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                }
+                "node_id": { "type": "string" },
+                "created_at": { "type": "string" },
+                "description": { "type": "string" },
+                "monthly_price_in_cents": { "type": "integer" },
+                "monthly_price_in_dollars": { "type": "integer" },
+                "name": { "type": "string" }
               },
               "additionalProperties": false
             }
@@ -118,9 +79,7 @@
       },
       "additionalProperties": false
     },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    }
+    "sender": { "$ref": "common/user.schema.json" }
   },
   "additionalProperties": false,
   "title": "sponsorship tier_changed event"

--- a/payload-schemas/schemas/star/created.schema.json
+++ b/payload-schemas/schemas/star/created.schema.json
@@ -4,29 +4,11 @@
   "type": "object",
   "required": ["action", "starred_at", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
-    "starred_at": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "action": { "type": "string", "enum": ["created"] },
+    "starred_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "star created event"

--- a/payload-schemas/schemas/star/deleted.schema.json
+++ b/payload-schemas/schemas/star/deleted.schema.json
@@ -4,29 +4,11 @@
   "type": "object",
   "required": ["action", "starred_at", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
-    "starred_at": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "action": { "type": "string", "enum": ["deleted"] },
+    "starred_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "star deleted event"

--- a/payload-schemas/schemas/status/event.schema.json
+++ b/payload-schemas/schemas/status/event.schema.json
@@ -18,48 +18,13 @@
     "sender"
   ],
   "properties": {
-    "id": {
-      "type": "integer"
-    },
-    "sha": {
-      "type": "string"
-    },
-    "name": {
-      "type": "string"
-    },
-    "avatar_url": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "target_url": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "context": {
-      "type": "string"
-    },
-    "description": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
+    "id": { "type": "integer" },
+    "sha": { "type": "string" },
+    "name": { "type": "string" },
+    "avatar_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "target_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "context": { "type": "string" },
+    "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
     "state": {
       "type": "string",
       "enum": ["pending", "success", "failure", "error"]
@@ -78,12 +43,8 @@
         "parents"
       ],
       "properties": {
-        "sha": {
-          "type": "string"
-        },
-        "node_id": {
-          "type": "string"
-        },
+        "sha": { "type": "string" },
+        "node_id": { "type": "string" },
         "commit": {
           "type": "object",
           "required": [
@@ -100,15 +61,9 @@
               "type": "object",
               "required": ["name", "email", "date"],
               "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                },
-                "date": {
-                  "type": "string"
-                }
+                "name": { "type": "string" },
+                "email": { "type": "string" },
+                "date": { "type": "string" }
               },
               "additionalProperties": false
             },
@@ -116,70 +71,38 @@
               "type": "object",
               "required": ["name", "email", "date"],
               "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                },
-                "date": {
-                  "type": "string"
-                }
+                "name": { "type": "string" },
+                "email": { "type": "string" },
+                "date": { "type": "string" }
               },
               "additionalProperties": false
             },
-            "message": {
-              "type": "string"
-            },
+            "message": { "type": "string" },
             "tree": {
               "type": "object",
               "required": ["sha", "url"],
               "properties": {
-                "sha": {
-                  "type": "string"
-                },
-                "url": {
-                  "type": "string"
-                }
+                "sha": { "type": "string" },
+                "url": { "type": "string" }
               },
               "additionalProperties": false
             },
-            "url": {
-              "type": "string"
-            },
-            "comment_count": {
-              "type": "integer"
-            },
+            "url": { "type": "string" },
+            "comment_count": { "type": "integer" },
             "verification": {
               "type": "object",
               "required": ["verified", "reason", "signature", "payload"],
               "properties": {
-                "verified": {
-                  "type": "boolean"
-                },
+                "verified": { "type": "boolean" },
                 "reason": {
                   "type": "string",
                   "enum": ["unsigned", "valid", "invalid"]
                 },
                 "signature": {
-                  "oneOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
+                  "oneOf": [{ "type": "string" }, { "type": "null" }]
                 },
                 "payload": {
-                  "oneOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
+                  "oneOf": [{ "type": "string" }, { "type": "null" }]
                 }
               },
               "additionalProperties": false
@@ -187,15 +110,9 @@
           },
           "additionalProperties": false
         },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "comments_url": {
-          "type": "string"
-        },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "comments_url": { "type": "string" },
         "author": {
           "type": "object",
           "required": [
@@ -219,60 +136,24 @@
             "site_admin"
           ],
           "properties": {
-            "login": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "avatar_url": {
-              "type": "string"
-            },
-            "gravatar_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "followers_url": {
-              "type": "string"
-            },
-            "following_url": {
-              "type": "string"
-            },
-            "gists_url": {
-              "type": "string"
-            },
-            "starred_url": {
-              "type": "string"
-            },
-            "subscriptions_url": {
-              "type": "string"
-            },
-            "organizations_url": {
-              "type": "string"
-            },
-            "repos_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "received_events_url": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "site_admin": {
-              "type": "boolean"
-            }
+            "login": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "avatar_url": { "type": "string" },
+            "gravatar_id": { "type": "string" },
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "followers_url": { "type": "string" },
+            "following_url": { "type": "string" },
+            "gists_url": { "type": "string" },
+            "starred_url": { "type": "string" },
+            "subscriptions_url": { "type": "string" },
+            "organizations_url": { "type": "string" },
+            "repos_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "received_events_url": { "type": "string" },
+            "type": { "type": "string" },
+            "site_admin": { "type": "boolean" }
           },
           "additionalProperties": false
         },
@@ -299,67 +180,28 @@
             "site_admin"
           ],
           "properties": {
-            "login": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "avatar_url": {
-              "type": "string"
-            },
-            "gravatar_id": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "followers_url": {
-              "type": "string"
-            },
-            "following_url": {
-              "type": "string"
-            },
-            "gists_url": {
-              "type": "string"
-            },
-            "starred_url": {
-              "type": "string"
-            },
-            "subscriptions_url": {
-              "type": "string"
-            },
-            "organizations_url": {
-              "type": "string"
-            },
-            "repos_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "received_events_url": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string"
-            },
-            "site_admin": {
-              "type": "boolean"
-            }
+            "login": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "avatar_url": { "type": "string" },
+            "gravatar_id": { "type": "string" },
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "followers_url": { "type": "string" },
+            "following_url": { "type": "string" },
+            "gists_url": { "type": "string" },
+            "starred_url": { "type": "string" },
+            "subscriptions_url": { "type": "string" },
+            "organizations_url": { "type": "string" },
+            "repos_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "received_events_url": { "type": "string" },
+            "type": { "type": "string" },
+            "site_admin": { "type": "boolean" }
           },
           "additionalProperties": false
         },
-        "parents": {
-          "type": "array",
-          "items": {}
-        }
+        "parents": { "type": "array", "items": {} }
       },
       "additionalProperties": false
     },
@@ -371,49 +213,29 @@
             "type": "object",
             "required": ["name", "commit", "protected"],
             "properties": {
-              "name": {
-                "type": "string"
-              },
+              "name": { "type": "string" },
               "commit": {
                 "type": "object",
                 "required": ["sha", "url"],
                 "properties": {
-                  "sha": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  }
+                  "sha": { "type": "string" },
+                  "url": { "type": "string" }
                 },
                 "additionalProperties": false
               },
-              "protected": {
-                "type": "boolean"
-              }
+              "protected": { "type": "boolean" }
             },
             "additionalProperties": false
           }
         ]
       }
     },
-    "created_at": {
-      "type": "string"
-    },
-    "updated_at": {
-      "type": "string"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "created_at": { "type": "string" },
+    "updated_at": { "type": "string" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "status event"

--- a/payload-schemas/schemas/team/added_to_repository.schema.json
+++ b/payload-schemas/schemas/team/added_to_repository.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "team", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["added_to_repository"]
-    },
+    "action": { "type": "string", "enum": ["added_to_repository"] },
     "changes": {
       "type": "object",
       "required": [],
@@ -29,58 +26,23 @@
         "permission"
       ],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "description": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "privacy": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "members_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "permission": {
-          "type": "string"
-        }
+        "name": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "slug": { "type": "string" },
+        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "privacy": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "members_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "permission": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "team added_to_repository event"

--- a/payload-schemas/schemas/team/created.schema.json
+++ b/payload-schemas/schemas/team/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "team", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "changes": {
       "type": "object",
       "required": [],
@@ -29,58 +26,23 @@
         "permission"
       ],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "description": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "privacy": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "members_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "permission": {
-          "type": "string"
-        }
+        "name": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "slug": { "type": "string" },
+        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "privacy": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "members_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "permission": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "team created event"

--- a/payload-schemas/schemas/team/deleted.schema.json
+++ b/payload-schemas/schemas/team/deleted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "team", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "changes": {
       "type": "object",
       "required": [],
@@ -29,58 +26,23 @@
         "permission"
       ],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "description": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "privacy": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "members_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "permission": {
-          "type": "string"
-        }
+        "name": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "slug": { "type": "string" },
+        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "privacy": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "members_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "permission": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "team deleted event"

--- a/payload-schemas/schemas/team/edited.schema.json
+++ b/payload-schemas/schemas/team/edited.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "team", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "changes": {
       "type": "object",
       "required": [],
@@ -29,58 +26,23 @@
         "permission"
       ],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "description": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "privacy": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "members_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "permission": {
-          "type": "string"
-        }
+        "name": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "slug": { "type": "string" },
+        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "privacy": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "members_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "permission": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "team edited event"

--- a/payload-schemas/schemas/team/removed_from_repository.schema.json
+++ b/payload-schemas/schemas/team/removed_from_repository.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "team", "organization", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["removed_from_repository"]
-    },
+    "action": { "type": "string", "enum": ["removed_from_repository"] },
     "changes": {
       "type": "object",
       "required": [],
@@ -29,58 +26,23 @@
         "permission"
       ],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "description": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "privacy": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "members_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "permission": {
-          "type": "string"
-        }
+        "name": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "slug": { "type": "string" },
+        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "privacy": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "members_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "permission": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "team removed_from_repository event"

--- a/payload-schemas/schemas/team_add/event.schema.json
+++ b/payload-schemas/schemas/team_add/event.schema.json
@@ -20,54 +20,24 @@
         "permission"
       ],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "slug": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "privacy": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "members_url": {
-          "type": "string"
-        },
-        "repositories_url": {
-          "type": "string"
-        },
-        "permission": {
-          "type": "string"
-        }
+        "name": { "type": "string" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "slug": { "type": "string" },
+        "description": { "type": "string" },
+        "privacy": { "type": "string" },
+        "url": { "type": "string" },
+        "html_url": { "type": "string" },
+        "members_url": { "type": "string" },
+        "repositories_url": { "type": "string" },
+        "permission": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "team_add event"

--- a/payload-schemas/schemas/watch/started.schema.json
+++ b/payload-schemas/schemas/watch/started.schema.json
@@ -4,22 +4,11 @@
   "type": "object",
   "required": ["action", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["started"]
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    }
+    "action": { "type": "string", "enum": ["started"] },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
   },
   "additionalProperties": false,
   "title": "watch started event"

--- a/payload-schemas/schemas/workflow_dispatch/event.schema.json
+++ b/payload-schemas/schemas/workflow_dispatch/event.schema.json
@@ -16,24 +16,12 @@
       "properties": {},
       "additionalProperties": true
     },
-    "ref": {
-      "type": "string"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "workflow": {
-      "type": "string"
-    }
+    "ref": { "type": "string" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "workflow": { "type": "string" }
   },
   "additionalProperties": false,
   "title": "workflow_dispatch event"

--- a/payload-schemas/schemas/workflow_run/event.schema.json
+++ b/payload-schemas/schemas/workflow_run/event.schema.json
@@ -11,18 +11,10 @@
     "workflow_run"
   ],
   "properties": {
-    "action": {
-      "type": "string"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
+    "action": { "type": "string" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
     "workflow": {
       "type": "object",
       "required": [
@@ -38,36 +30,16 @@
         "url"
       ],
       "properties": {
-        "badge_url": {
-          "type": "string"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "name": {
-          "type": "string"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "state": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        }
+        "badge_url": { "type": "string" },
+        "created_at": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "name": { "type": "string" },
+        "node_id": { "type": "string" },
+        "path": { "type": "string" },
+        "state": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "url": { "type": "string" }
       },
       "additionalProperties": false
     },
@@ -100,34 +72,13 @@
         "workflow_url"
       ],
       "properties": {
-        "artifacts_url": {
-          "type": "string"
-        },
-        "cancel_url": {
-          "type": "string"
-        },
-        "check_suite_url": {
-          "type": "string"
-        },
-        "conclusion": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "event": {
-          "type": "string"
-        },
-        "head_branch": {
-          "type": "string"
-        },
+        "artifacts_url": { "type": "string" },
+        "cancel_url": { "type": "string" },
+        "check_suite_url": { "type": "string" },
+        "conclusion": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "created_at": { "type": "string" },
+        "event": { "type": "string" },
+        "head_branch": { "type": "string" },
         "head_commit": {
           "type": "object",
           "required": [
@@ -143,12 +94,8 @@
               "type": "object",
               "required": ["email", "name"],
               "properties": {
-                "email": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                }
+                "email": { "type": "string" },
+                "name": { "type": "string" }
               },
               "additionalProperties": false
             },
@@ -156,27 +103,15 @@
               "type": "object",
               "required": ["email", "name"],
               "properties": {
-                "email": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                }
+                "email": { "type": "string" },
+                "name": { "type": "string" }
               },
               "additionalProperties": false
             },
-            "id": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "timestamp": {
-              "type": "string"
-            },
-            "tree_id": {
-              "type": "string"
-            }
+            "id": { "type": "string" },
+            "message": { "type": "string" },
+            "timestamp": { "type": "string" },
+            "tree_id": { "type": "string" }
           },
           "additionalProperties": false
         },
@@ -231,169 +166,62 @@
             "url"
           ],
           "properties": {
-            "archive_url": {
-              "type": "string"
-            },
-            "assignees_url": {
-              "type": "string"
-            },
-            "blobs_url": {
-              "type": "string"
-            },
-            "branches_url": {
-              "type": "string"
-            },
-            "collaborators_url": {
-              "type": "string"
-            },
-            "comments_url": {
-              "type": "string"
-            },
-            "commits_url": {
-              "type": "string"
-            },
-            "compare_url": {
-              "type": "string"
-            },
-            "contents_url": {
-              "type": "string"
-            },
-            "contributors_url": {
-              "type": "string"
-            },
-            "deployments_url": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "downloads_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "fork": {
-              "type": "boolean"
-            },
-            "forks_url": {
-              "type": "string"
-            },
-            "full_name": {
-              "type": "string"
-            },
-            "git_commits_url": {
-              "type": "string"
-            },
-            "git_refs_url": {
-              "type": "string"
-            },
-            "git_tags_url": {
-              "type": "string"
-            },
-            "hooks_url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "issue_comment_url": {
-              "type": "string"
-            },
-            "issue_events_url": {
-              "type": "string"
-            },
-            "issues_url": {
-              "type": "string"
-            },
-            "keys_url": {
-              "type": "string"
-            },
-            "labels_url": {
-              "type": "string"
-            },
-            "languages_url": {
-              "type": "string"
-            },
-            "merges_url": {
-              "type": "string"
-            },
-            "milestones_url": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "notifications_url": {
-              "type": "string"
-            },
-            "owner": {
-              "$ref": "common/user.schema.json"
-            },
-            "private": {
-              "type": "boolean"
-            },
-            "pulls_url": {
-              "type": "string"
-            },
-            "releases_url": {
-              "type": "string"
-            },
-            "stargazers_url": {
-              "type": "string"
-            },
-            "statuses_url": {
-              "type": "string"
-            },
-            "subscribers_url": {
-              "type": "string"
-            },
-            "subscription_url": {
-              "type": "string"
-            },
-            "tags_url": {
-              "type": "string"
-            },
-            "teams_url": {
-              "type": "string"
-            },
-            "trees_url": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            }
+            "archive_url": { "type": "string" },
+            "assignees_url": { "type": "string" },
+            "blobs_url": { "type": "string" },
+            "branches_url": { "type": "string" },
+            "collaborators_url": { "type": "string" },
+            "comments_url": { "type": "string" },
+            "commits_url": { "type": "string" },
+            "compare_url": { "type": "string" },
+            "contents_url": { "type": "string" },
+            "contributors_url": { "type": "string" },
+            "deployments_url": { "type": "string" },
+            "description": { "type": "string" },
+            "downloads_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "fork": { "type": "boolean" },
+            "forks_url": { "type": "string" },
+            "full_name": { "type": "string" },
+            "git_commits_url": { "type": "string" },
+            "git_refs_url": { "type": "string" },
+            "git_tags_url": { "type": "string" },
+            "hooks_url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "issue_comment_url": { "type": "string" },
+            "issue_events_url": { "type": "string" },
+            "issues_url": { "type": "string" },
+            "keys_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "languages_url": { "type": "string" },
+            "merges_url": { "type": "string" },
+            "milestones_url": { "type": "string" },
+            "name": { "type": "string" },
+            "node_id": { "type": "string" },
+            "notifications_url": { "type": "string" },
+            "owner": { "$ref": "common/user.schema.json" },
+            "private": { "type": "boolean" },
+            "pulls_url": { "type": "string" },
+            "releases_url": { "type": "string" },
+            "stargazers_url": { "type": "string" },
+            "statuses_url": { "type": "string" },
+            "subscribers_url": { "type": "string" },
+            "subscription_url": { "type": "string" },
+            "tags_url": { "type": "string" },
+            "teams_url": { "type": "string" },
+            "trees_url": { "type": "string" },
+            "url": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "head_sha": {
-          "type": "string"
-        },
-        "html_url": {
-          "type": "string"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "jobs_url": {
-          "type": "string"
-        },
-        "logs_url": {
-          "type": "string"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "pull_requests": {
-          "type": "array",
-          "items": {}
-        },
+        "head_sha": { "type": "string" },
+        "html_url": { "type": "string" },
+        "id": { "type": "integer" },
+        "jobs_url": { "type": "string" },
+        "logs_url": { "type": "string" },
+        "node_id": { "type": "string" },
+        "pull_requests": { "type": "array", "items": {} },
         "repository": {
           "type": "object",
           "required": [
@@ -445,174 +273,66 @@
             "url"
           ],
           "properties": {
-            "archive_url": {
-              "type": "string"
-            },
-            "assignees_url": {
-              "type": "string"
-            },
-            "blobs_url": {
-              "type": "string"
-            },
-            "branches_url": {
-              "type": "string"
-            },
-            "collaborators_url": {
-              "type": "string"
-            },
-            "comments_url": {
-              "type": "string"
-            },
-            "commits_url": {
-              "type": "string"
-            },
-            "compare_url": {
-              "type": "string"
-            },
-            "contents_url": {
-              "type": "string"
-            },
-            "contributors_url": {
-              "type": "string"
-            },
-            "deployments_url": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "downloads_url": {
-              "type": "string"
-            },
-            "events_url": {
-              "type": "string"
-            },
-            "fork": {
-              "type": "boolean"
-            },
-            "forks_url": {
-              "type": "string"
-            },
-            "full_name": {
-              "type": "string"
-            },
-            "git_commits_url": {
-              "type": "string"
-            },
-            "git_refs_url": {
-              "type": "string"
-            },
-            "git_tags_url": {
-              "type": "string"
-            },
-            "hooks_url": {
-              "type": "string"
-            },
-            "html_url": {
-              "type": "string"
-            },
-            "id": {
-              "type": "integer"
-            },
-            "issue_comment_url": {
-              "type": "string"
-            },
-            "issue_events_url": {
-              "type": "string"
-            },
-            "issues_url": {
-              "type": "string"
-            },
-            "keys_url": {
-              "type": "string"
-            },
-            "labels_url": {
-              "type": "string"
-            },
-            "languages_url": {
-              "type": "string"
-            },
-            "merges_url": {
-              "type": "string"
-            },
-            "milestones_url": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "node_id": {
-              "type": "string"
-            },
-            "notifications_url": {
-              "type": "string"
-            },
-            "owner": {
-              "$ref": "common/user.schema.json"
-            },
-            "private": {
-              "type": "boolean"
-            },
-            "pulls_url": {
-              "type": "string"
-            },
-            "releases_url": {
-              "type": "string"
-            },
-            "stargazers_url": {
-              "type": "string"
-            },
-            "statuses_url": {
-              "type": "string"
-            },
-            "subscribers_url": {
-              "type": "string"
-            },
-            "subscription_url": {
-              "type": "string"
-            },
-            "tags_url": {
-              "type": "string"
-            },
-            "teams_url": {
-              "type": "string"
-            },
-            "trees_url": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string"
-            }
+            "archive_url": { "type": "string" },
+            "assignees_url": { "type": "string" },
+            "blobs_url": { "type": "string" },
+            "branches_url": { "type": "string" },
+            "collaborators_url": { "type": "string" },
+            "comments_url": { "type": "string" },
+            "commits_url": { "type": "string" },
+            "compare_url": { "type": "string" },
+            "contents_url": { "type": "string" },
+            "contributors_url": { "type": "string" },
+            "deployments_url": { "type": "string" },
+            "description": { "type": "string" },
+            "downloads_url": { "type": "string" },
+            "events_url": { "type": "string" },
+            "fork": { "type": "boolean" },
+            "forks_url": { "type": "string" },
+            "full_name": { "type": "string" },
+            "git_commits_url": { "type": "string" },
+            "git_refs_url": { "type": "string" },
+            "git_tags_url": { "type": "string" },
+            "hooks_url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "issue_comment_url": { "type": "string" },
+            "issue_events_url": { "type": "string" },
+            "issues_url": { "type": "string" },
+            "keys_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "languages_url": { "type": "string" },
+            "merges_url": { "type": "string" },
+            "milestones_url": { "type": "string" },
+            "name": { "type": "string" },
+            "node_id": { "type": "string" },
+            "notifications_url": { "type": "string" },
+            "owner": { "$ref": "common/user.schema.json" },
+            "private": { "type": "boolean" },
+            "pulls_url": { "type": "string" },
+            "releases_url": { "type": "string" },
+            "stargazers_url": { "type": "string" },
+            "statuses_url": { "type": "string" },
+            "subscribers_url": { "type": "string" },
+            "subscription_url": { "type": "string" },
+            "tags_url": { "type": "string" },
+            "teams_url": { "type": "string" },
+            "trees_url": { "type": "string" },
+            "url": { "type": "string" }
           },
           "additionalProperties": false
         },
-        "rerun_url": {
-          "type": "string"
-        },
-        "run_number": {
-          "type": "integer"
-        },
-        "status": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "workflow_id": {
-          "type": "integer"
-        },
-        "workflow_url": {
-          "type": "string"
-        }
+        "rerun_url": { "type": "string" },
+        "run_number": { "type": "integer" },
+        "status": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "url": { "type": "string" },
+        "workflow_id": { "type": "integer" },
+        "workflow_url": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    }
+    "installation": { "$ref": "common/installation.schema.json" }
   },
   "additionalProperties": false,
   "title": "workflow_run event"


### PR DESCRIPTION
The backstory is that while `prettier` formats things consistently, with objects you can "choose" if they're on a single line or not based on if you put a newline after the opening brace - while I think this is a great thing, this is a rare case where we don't want that since such newlines are lost when you parse raw json into js objects, meaning noisy diffs when you're working with scripts and especially when you're wanting to compare two versions of schemas to check if the output is what you're wanting or if you've messed something up.

I've made this PR as a once-off reformatting as I've got a bunch of bulk-changes to the schemas to land that are much easier to review when the formatting is consistent - the script for doing will have its own PR.

