### PR TITLE
chore: add script for formatting schemas & payloads with `prettier`

### DIFF
--- a/bin/format-with-prettier.ts
+++ b/bin/format-with-prettier.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env ts-node-transpile-only
+
+import fs from "fs";
+import { JSONSchema7 } from "json-schema";
+import { format } from "prettier";
+
+const checkOnly = process.argv.includes("--check");
+
+const formatJsonInDirectory = (pathToJsons: string) => {
+  fs.readdirSync(pathToJsons).forEach((jsonName) => {
+    const folderPath = `${pathToJsons}/${jsonName}`;
+
+    fs.readdirSync(folderPath).forEach((file) => {
+      const filePath = `${folderPath}/${file}`;
+
+      const contentsBefore = fs.readFileSync(filePath, "utf-8");
+      const contentsAfter = format(
+        JSON.stringify(JSON.parse(contentsBefore) as JSONSchema7),
+        { parser: "json" }
+      );
+
+      if (contentsBefore === contentsAfter) {
+        return;
+      }
+
+      if (checkOnly) {
+        console.warn(`${filePath} needs to be formatted`);
+        process.exitCode = 1;
+
+        return;
+      }
+
+      fs.writeFileSync(filePath, contentsBefore);
+    });
+  });
+};
+
+formatJsonInDirectory("payload-examples/api.github.com");
+formatJsonInDirectory("payload-schemas/schemas");


### PR DESCRIPTION
This is the script that made #260

The backstory is that while `prettier` formats things consistently, with objects you can "choose" if they're on a single line or not based on if you put a newline after the opening brace - while I think this is a great thing, this is a rare case where we don't want that since such newlines are lost when you parse raw json into js objects, meaning noisy diffs when you're working with scripts and especially when you're wanting to compare two versions of schemas to check if the output is what you're wanting or if you've messed something up.

I'm on the fence about making this script "required", as it takes a few seconds to run since you're reading in every json file formatting and then writing them again, and it's not something I'm expecting to pop up day-to-day - more I expect this being run every so often before doing some change that touches every json file.

Happy to bikeshed over the name, ci/script implementation etc

