### PR TITLE
Create schema optimizer

### DIFF
--- a/bin/optimize-schemas.ts
+++ b/bin/optimize-schemas.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env ts-node-transpile-only
+
+import { strict as assert } from "assert";
+import fs from "fs";
+import { JSONSchema7 } from "json-schema";
+import { format } from "prettier";
+
+const payloads = "payload-schemas/schemas";
+
+const isJsonSchemaObject = (object: unknown): object is JSONSchema7 =>
+  typeof object === "object" && object !== null && !Array.isArray(object);
+
+fs.readdirSync(payloads).forEach((event) => {
+  fs.readdirSync(`${payloads}/${event}`).forEach((schema) => {
+    const pathToSchema = `${payloads}/${event}/${schema}`;
+    const contents = JSON.parse(fs.readFileSync(pathToSchema, "utf-8"));
+
+    fs.writeFileSync(
+      pathToSchema,
+      format(
+        JSON.stringify(contents, (key, value: unknown | JSONSchema7) => {
+          if (!isJsonSchemaObject(value)) {
+            return value;
+          }
+
+          if (value.anyOf) {
+            assert.ok(!value.oneOf, "object has both oneOf & anyOf");
+
+            // we don't have any use for anyOf, while oneOf is stricter
+            value.oneOf = value.anyOf;
+            delete value.anyOf;
+          }
+
+          return value;
+        }),
+        { parser: "json" }
+      )
+    );
+  });
+});

--- a/payload-schemas/schemas/check_run/completed.schema.json
+++ b/payload-schemas/schemas/check_run/completed.schema.json
@@ -105,7 +105,7 @@
             "pull_requests": {
               "type": "array",
               "items": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "required": ["url", "id", "number", "head", "base"],
@@ -345,7 +345,7 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],

--- a/payload-schemas/schemas/check_run/created.schema.json
+++ b/payload-schemas/schemas/check_run/created.schema.json
@@ -105,7 +105,7 @@
             "pull_requests": {
               "type": "array",
               "items": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "required": ["url", "id", "number", "head", "base"],
@@ -345,7 +345,7 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],

--- a/payload-schemas/schemas/check_run/requested_action.schema.json
+++ b/payload-schemas/schemas/check_run/requested_action.schema.json
@@ -105,7 +105,7 @@
             "pull_requests": {
               "type": "array",
               "items": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "required": ["url", "id", "number", "head", "base"],
@@ -345,7 +345,7 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],

--- a/payload-schemas/schemas/check_run/rerequested.schema.json
+++ b/payload-schemas/schemas/check_run/rerequested.schema.json
@@ -105,7 +105,7 @@
             "pull_requests": {
               "type": "array",
               "items": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "required": ["url", "id", "number", "head", "base"],
@@ -345,7 +345,7 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],

--- a/payload-schemas/schemas/check_suite/completed.schema.json
+++ b/payload-schemas/schemas/check_suite/completed.schema.json
@@ -62,7 +62,7 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],

--- a/payload-schemas/schemas/check_suite/requested.schema.json
+++ b/payload-schemas/schemas/check_suite/requested.schema.json
@@ -62,7 +62,7 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],

--- a/payload-schemas/schemas/check_suite/rerequested.schema.json
+++ b/payload-schemas/schemas/check_suite/rerequested.schema.json
@@ -62,7 +62,7 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["url", "id", "number", "head", "base"],

--- a/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
@@ -35,7 +35,7 @@
         "instances": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],

--- a/payload-schemas/schemas/code_scanning_alert/closed_by_user.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/closed_by_user.schema.json
@@ -35,7 +35,7 @@
         "instances": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],

--- a/payload-schemas/schemas/code_scanning_alert/created.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/created.schema.json
@@ -35,7 +35,7 @@
         "instances": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],

--- a/payload-schemas/schemas/code_scanning_alert/fixed.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/fixed.schema.json
@@ -35,7 +35,7 @@
         "instances": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],

--- a/payload-schemas/schemas/code_scanning_alert/reopened.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/reopened.schema.json
@@ -35,7 +35,7 @@
         "instances": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],

--- a/payload-schemas/schemas/code_scanning_alert/reopened_by_user.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/reopened_by_user.schema.json
@@ -35,7 +35,7 @@
         "instances": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["ref", "analysis_key", "environment", "state"],

--- a/payload-schemas/schemas/create/event.schema.json
+++ b/payload-schemas/schemas/create/event.schema.json
@@ -13,10 +13,7 @@
   ],
   "properties": {
     "ref": { "type": "string" },
-    "ref_type": {
-      "type": "string",
-      "enum": ["tag", "branch"]
-    },
+    "ref_type": { "type": "string", "enum": ["tag", "branch"] },
     "master_branch": { "type": "string" },
     "description": { "oneOf": [{ "type": "string" }, { "type": "null" }] },
     "pusher_type": { "type": "string" },

--- a/payload-schemas/schemas/gollum/event.schema.json
+++ b/payload-schemas/schemas/gollum/event.schema.json
@@ -7,7 +7,7 @@
     "pages": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": [

--- a/payload-schemas/schemas/installation/created.schema.json
+++ b/payload-schemas/schemas/installation/created.schema.json
@@ -121,7 +121,7 @@
     "repositories": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],

--- a/payload-schemas/schemas/installation/deleted.schema.json
+++ b/payload-schemas/schemas/installation/deleted.schema.json
@@ -121,7 +121,7 @@
     "repositories": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],

--- a/payload-schemas/schemas/installation/new_permissions_accepted.schema.json
+++ b/payload-schemas/schemas/installation/new_permissions_accepted.schema.json
@@ -121,7 +121,7 @@
     "repositories": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],

--- a/payload-schemas/schemas/installation/suspended.schema.json
+++ b/payload-schemas/schemas/installation/suspended.schema.json
@@ -121,7 +121,7 @@
     "repositories": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],

--- a/payload-schemas/schemas/installation/unsuspended.schema.json
+++ b/payload-schemas/schemas/installation/unsuspended.schema.json
@@ -121,7 +121,7 @@
     "repositories": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],

--- a/payload-schemas/schemas/installation_repositories/added.schema.json
+++ b/payload-schemas/schemas/installation_repositories/added.schema.json
@@ -120,14 +120,11 @@
       },
       "additionalProperties": false
     },
-    "repository_selection": {
-      "type": "string",
-      "enum": ["all", "selected"]
-    },
+    "repository_selection": { "type": "string", "enum": ["all", "selected"] },
     "repositories_added": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],

--- a/payload-schemas/schemas/installation_repositories/removed.schema.json
+++ b/payload-schemas/schemas/installation_repositories/removed.schema.json
@@ -124,7 +124,7 @@
     "repositories_added": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],

--- a/payload-schemas/schemas/integration_installation/created.schema.json
+++ b/payload-schemas/schemas/integration_installation/created.schema.json
@@ -118,7 +118,7 @@
     "repositories": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],

--- a/payload-schemas/schemas/integration_installation_repositories/added.schema.json
+++ b/payload-schemas/schemas/integration_installation_repositories/added.schema.json
@@ -126,7 +126,7 @@
     "repositories_added": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": ["id", "node_id", "name", "full_name", "private"],

--- a/payload-schemas/schemas/issue_comment/created.schema.json
+++ b/payload-schemas/schemas/issue_comment/created.schema.json
@@ -48,7 +48,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -79,7 +79,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "type": "object",

--- a/payload-schemas/schemas/issue_comment/deleted.schema.json
+++ b/payload-schemas/schemas/issue_comment/deleted.schema.json
@@ -48,7 +48,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -79,7 +79,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "type": "object",

--- a/payload-schemas/schemas/issue_comment/edited.schema.json
+++ b/payload-schemas/schemas/issue_comment/edited.schema.json
@@ -60,7 +60,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -91,7 +91,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "type": "object",

--- a/payload-schemas/schemas/issues/assigned.schema.json
+++ b/payload-schemas/schemas/issues/assigned.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/closed.schema.json
+++ b/payload-schemas/schemas/issues/closed.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/deleted.schema.json
+++ b/payload-schemas/schemas/issues/deleted.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/demilestoned.schema.json
+++ b/payload-schemas/schemas/issues/demilestoned.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/edited.schema.json
+++ b/payload-schemas/schemas/issues/edited.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/labeled.schema.json
+++ b/payload-schemas/schemas/issues/labeled.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/locked.schema.json
+++ b/payload-schemas/schemas/issues/locked.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/milestoned.schema.json
+++ b/payload-schemas/schemas/issues/milestoned.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/opened.schema.json
+++ b/payload-schemas/schemas/issues/opened.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/pinned.schema.json
+++ b/payload-schemas/schemas/issues/pinned.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/reopened.schema.json
+++ b/payload-schemas/schemas/issues/reopened.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/transferred.schema.json
+++ b/payload-schemas/schemas/issues/transferred.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/unassigned.schema.json
+++ b/payload-schemas/schemas/issues/unassigned.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/unlabeled.schema.json
+++ b/payload-schemas/schemas/issues/unlabeled.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/unlocked.schema.json
+++ b/payload-schemas/schemas/issues/unlocked.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/unpinned.schema.json
+++ b/payload-schemas/schemas/issues/unpinned.schema.json
@@ -44,7 +44,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -75,7 +75,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/marketplace_purchase/cancelled.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/cancelled.schema.json
@@ -100,11 +100,11 @@
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [{ "type": "null" }, { "type": "string" }]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": { "anyOf": [{ "type": "string" }] }
+              "items": { "oneOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false
@@ -161,11 +161,11 @@
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [{ "type": "null" }, { "type": "string" }]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": { "anyOf": [{ "type": "string" }] }
+              "items": { "oneOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false

--- a/payload-schemas/schemas/marketplace_purchase/changed.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/changed.schema.json
@@ -100,11 +100,11 @@
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [{ "type": "null" }, { "type": "string" }]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": { "anyOf": [{ "type": "string" }] }
+              "items": { "oneOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false
@@ -161,11 +161,11 @@
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [{ "type": "null" }, { "type": "string" }]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": { "anyOf": [{ "type": "string" }] }
+              "items": { "oneOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false

--- a/payload-schemas/schemas/marketplace_purchase/purchased.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/purchased.schema.json
@@ -100,11 +100,11 @@
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [{ "type": "null" }, { "type": "string" }]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": { "anyOf": [{ "type": "string" }] }
+              "items": { "oneOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false
@@ -161,11 +161,11 @@
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
             "unit_name": {
-              "anyOf": [{ "type": "null" }, { "type": "string" }]
+              "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
             "bullets": {
               "type": "array",
-              "items": { "anyOf": [{ "type": "string" }] }
+              "items": { "oneOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false

--- a/payload-schemas/schemas/member/edited.schema.json
+++ b/payload-schemas/schemas/member/edited.schema.json
@@ -13,11 +13,7 @@
         "old_permission": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         }
       },

--- a/payload-schemas/schemas/meta/deleted.schema.json
+++ b/payload-schemas/schemas/meta/deleted.schema.json
@@ -25,7 +25,7 @@
         "active": { "type": "boolean" },
         "events": {
           "type": "array",
-          "items": { "anyOf": [{ "type": "string" }] }
+          "items": { "oneOf": [{ "type": "string" }] }
         },
         "config": {
           "type": "object",

--- a/payload-schemas/schemas/milestone/edited.schema.json
+++ b/payload-schemas/schemas/milestone/edited.schema.json
@@ -11,31 +11,19 @@
         "description": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         },
         "due_on": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         },
         "title": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         }
       },

--- a/payload-schemas/schemas/package/published.schema.json
+++ b/payload-schemas/schemas/package/published.schema.json
@@ -98,7 +98,7 @@
             "package_files": {
               "type": "array",
               "items": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "required": [

--- a/payload-schemas/schemas/package/updated.schema.json
+++ b/payload-schemas/schemas/package/updated.schema.json
@@ -98,7 +98,7 @@
             "package_files": {
               "type": "array",
               "items": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "required": [

--- a/payload-schemas/schemas/ping/event.schema.json
+++ b/payload-schemas/schemas/ping/event.schema.json
@@ -27,7 +27,7 @@
         "active": { "type": "boolean" },
         "events": {
           "type": "array",
-          "items": { "anyOf": [{ "type": "string" }] }
+          "items": { "oneOf": [{ "type": "string" }] }
         },
         "config": {
           "type": "object",

--- a/payload-schemas/schemas/project/edited.schema.json
+++ b/payload-schemas/schemas/project/edited.schema.json
@@ -11,17 +11,13 @@
         "name": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": { "type": "string" }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         },
         "body": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": { "type": "string" }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         }
       },

--- a/payload-schemas/schemas/project_card/converted.schema.json
+++ b/payload-schemas/schemas/project_card/converted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project_card", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["converted"]
-    },
+    "action": { "type": "string", "enum": ["converted"] },
     "project_card": {
       "type": "object",
       "required": [
@@ -25,57 +22,25 @@
         "content_url"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "project_url": {
-          "type": "string"
-        },
-        "column_url": {
-          "type": "string"
-        },
-        "column_id": {
-          "type": "integer"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "note": {
-          "type": "string"
-        },
-        "archived": {
-          "type": "boolean"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "content_url": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "project_url": { "type": "string" },
+        "column_url": { "type": "string" },
+        "column_id": { "type": "integer" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "note": { "type": "string" },
+        "archived": { "type": "boolean" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "content_url": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" }
   },
   "additionalProperties": false,
   "title": "project_card converted event"

--- a/payload-schemas/schemas/project_card/created.schema.json
+++ b/payload-schemas/schemas/project_card/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project_card", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "project_card": {
       "type": "object",
       "required": [
@@ -25,57 +22,25 @@
         "content_url"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "project_url": {
-          "type": "string"
-        },
-        "column_url": {
-          "type": "string"
-        },
-        "column_id": {
-          "type": "integer"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "note": {
-          "type": "string"
-        },
-        "archived": {
-          "type": "boolean"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "content_url": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "project_url": { "type": "string" },
+        "column_url": { "type": "string" },
+        "column_id": { "type": "integer" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "note": { "type": "string" },
+        "archived": { "type": "boolean" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "content_url": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" }
   },
   "additionalProperties": false,
   "title": "project_card created event"

--- a/payload-schemas/schemas/project_card/deleted.schema.json
+++ b/payload-schemas/schemas/project_card/deleted.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project_card", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["deleted"]
-    },
+    "action": { "type": "string", "enum": ["deleted"] },
     "project_card": {
       "type": "object",
       "required": [
@@ -25,57 +22,25 @@
         "content_url"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "project_url": {
-          "type": "string"
-        },
-        "column_url": {
-          "type": "string"
-        },
-        "column_id": {
-          "type": "integer"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "note": {
-          "type": "string"
-        },
-        "archived": {
-          "type": "boolean"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "content_url": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "project_url": { "type": "string" },
+        "column_url": { "type": "string" },
+        "column_id": { "type": "integer" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "note": { "type": "string" },
+        "archived": { "type": "boolean" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "content_url": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" }
   },
   "additionalProperties": false,
   "title": "project_card deleted event"

--- a/payload-schemas/schemas/project_card/edited.schema.json
+++ b/payload-schemas/schemas/project_card/edited.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project_card", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["edited"]
-    },
+    "action": { "type": "string", "enum": ["edited"] },
     "project_card": {
       "type": "object",
       "required": [
@@ -25,57 +22,25 @@
         "content_url"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "project_url": {
-          "type": "string"
-        },
-        "column_url": {
-          "type": "string"
-        },
-        "column_id": {
-          "type": "integer"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "note": {
-          "type": "string"
-        },
-        "archived": {
-          "type": "boolean"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "content_url": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "project_url": { "type": "string" },
+        "column_url": { "type": "string" },
+        "column_id": { "type": "integer" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "note": { "type": "string" },
+        "archived": { "type": "boolean" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "content_url": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" }
   },
   "additionalProperties": false,
   "title": "project_card edited event"

--- a/payload-schemas/schemas/project_card/moved.schema.json
+++ b/payload-schemas/schemas/project_card/moved.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "project_card", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["moved"]
-    },
+    "action": { "type": "string", "enum": ["moved"] },
     "project_card": {
       "type": "object",
       "required": [
@@ -25,57 +22,25 @@
         "content_url"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
-        "project_url": {
-          "type": "string"
-        },
-        "column_url": {
-          "type": "string"
-        },
-        "column_id": {
-          "type": "integer"
-        },
-        "id": {
-          "type": "integer"
-        },
-        "node_id": {
-          "type": "string"
-        },
-        "note": {
-          "type": "string"
-        },
-        "archived": {
-          "type": "boolean"
-        },
-        "creator": {
-          "$ref": "common/user.schema.json"
-        },
-        "created_at": {
-          "type": "string"
-        },
-        "updated_at": {
-          "type": "string"
-        },
-        "content_url": {
-          "type": "string"
-        }
+        "url": { "type": "string" },
+        "project_url": { "type": "string" },
+        "column_url": { "type": "string" },
+        "column_id": { "type": "integer" },
+        "id": { "type": "integer" },
+        "node_id": { "type": "string" },
+        "note": { "type": "string" },
+        "archived": { "type": "boolean" },
+        "creator": { "$ref": "common/user.schema.json" },
+        "created_at": { "type": "string" },
+        "updated_at": { "type": "string" },
+        "content_url": { "type": "string" }
       },
       "additionalProperties": false
     },
-    "repository": {
-      "$ref": "common/repository.schema.json"
-    },
-    "sender": {
-      "$ref": "common/user.schema.json"
-    },
-    "organization": {
-      "$ref": "common/organization.schema.json"
-    },
-    "installation": {
-      "$ref": "common/installation.schema.json"
-    }
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" },
+    "installation": { "$ref": "common/installation.schema.json" }
   },
   "additionalProperties": false,
   "title": "project_card moved event"

--- a/payload-schemas/schemas/pull_request/assigned.schema.json
+++ b/payload-schemas/schemas/pull_request/assigned.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,7 +93,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/closed.schema.json
+++ b/payload-schemas/schemas/pull_request/closed.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,7 +93,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
+++ b/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
@@ -81,7 +81,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -91,7 +91,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/edited.schema.json
+++ b/payload-schemas/schemas/pull_request/edited.schema.json
@@ -108,7 +108,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -118,7 +118,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/labeled.schema.json
+++ b/payload-schemas/schemas/pull_request/labeled.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,7 +93,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/locked.schema.json
+++ b/payload-schemas/schemas/pull_request/locked.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,7 +93,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/opened.schema.json
+++ b/payload-schemas/schemas/pull_request/opened.schema.json
@@ -81,7 +81,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -91,7 +91,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [
@@ -268,9 +268,7 @@
             "OWNER"
           ]
         },
-        "active_lock_reason": {
-          "type": "null"
-        },
+        "active_lock_reason": { "type": "null" },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
         "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },

--- a/payload-schemas/schemas/pull_request/ready_for_review.schema.json
+++ b/payload-schemas/schemas/pull_request/ready_for_review.schema.json
@@ -81,7 +81,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -91,7 +91,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/reopened.schema.json
+++ b/payload-schemas/schemas/pull_request/reopened.schema.json
@@ -81,7 +81,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -91,7 +91,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/review_request_removed.schema.json
+++ b/payload-schemas/schemas/pull_request/review_request_removed.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,7 +93,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/review_requested.schema.json
+++ b/payload-schemas/schemas/pull_request/review_requested.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,7 +93,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/synchronize.schema.json
+++ b/payload-schemas/schemas/pull_request/synchronize.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,7 +93,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/unassigned.schema.json
+++ b/payload-schemas/schemas/pull_request/unassigned.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,7 +93,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/unlabeled.schema.json
+++ b/payload-schemas/schemas/pull_request/unlabeled.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,7 +93,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request/unlocked.schema.json
+++ b/payload-schemas/schemas/pull_request/unlocked.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "anyOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,7 +93,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request_review/submitted.schema.json
+++ b/payload-schemas/schemas/pull_request_review/submitted.schema.json
@@ -135,7 +135,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request_review_comment/created.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/created.schema.json
@@ -155,7 +155,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request_review_comment/deleted.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/deleted.schema.json
@@ -155,7 +155,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/pull_request_review_comment/edited.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/edited.schema.json
@@ -18,9 +18,7 @@
         "body": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": { "type": "string" }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         }
       },
@@ -176,7 +174,7 @@
         "labels": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/push/event.schema.json
+++ b/payload-schemas/schemas/push/event.schema.json
@@ -29,7 +29,7 @@
     "commits": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": [
@@ -74,21 +74,15 @@
               },
               "added": {
                 "type": "array",
-                "items": {
-                  "anyOf": [{ "type": "string" }]
-                }
+                "items": { "oneOf": [{ "type": "string" }] }
               },
               "removed": {
                 "type": "array",
-                "items": {
-                  "anyOf": [{ "type": "string" }]
-                }
+                "items": { "oneOf": [{ "type": "string" }] }
               },
               "modified": {
                 "type": "array",
-                "items": {
-                  "anyOf": [{ "type": "string" }]
-                }
+                "items": { "oneOf": [{ "type": "string" }] }
               }
             },
             "additionalProperties": false
@@ -143,21 +137,15 @@
             },
             "added": {
               "type": "array",
-              "items": {
-                "anyOf": [{ "type": "string" }]
-              }
+              "items": { "oneOf": [{ "type": "string" }] }
             },
             "removed": {
               "type": "array",
-              "items": {
-                "anyOf": [{ "type": "string" }]
-              }
+              "items": { "oneOf": [{ "type": "string" }] }
             },
             "modified": {
               "type": "array",
-              "items": {
-                "anyOf": [{ "type": "string" }]
-              }
+              "items": { "oneOf": [{ "type": "string" }] }
             }
           },
           "additionalProperties": false

--- a/payload-schemas/schemas/release/created.schema.json
+++ b/payload-schemas/schemas/release/created.schema.json
@@ -45,7 +45,7 @@
         "assets": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/release/deleted.schema.json
+++ b/payload-schemas/schemas/release/deleted.schema.json
@@ -45,7 +45,7 @@
         "assets": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/release/edited.schema.json
+++ b/payload-schemas/schemas/release/edited.schema.json
@@ -11,17 +11,13 @@
         "body": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": { "type": "string" }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         },
         "name": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": { "type": "string" }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         }
       },
@@ -67,7 +63,7 @@
         "assets": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/release/prereleased.schema.json
+++ b/payload-schemas/schemas/release/prereleased.schema.json
@@ -45,7 +45,7 @@
         "assets": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/release/published.schema.json
+++ b/payload-schemas/schemas/release/published.schema.json
@@ -45,7 +45,7 @@
         "assets": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/release/released.schema.json
+++ b/payload-schemas/schemas/release/released.schema.json
@@ -45,7 +45,7 @@
         "assets": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/release/unpublished.schema.json
+++ b/payload-schemas/schemas/release/unpublished.schema.json
@@ -45,7 +45,7 @@
         "assets": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/secret_scanning_alert/created.schema.json
+++ b/payload-schemas/schemas/secret_scanning_alert/created.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "alert", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["created"]
-    },
+    "action": { "type": "string", "enum": ["created"] },
     "alert": {
       "type": "object",
       "required": [

--- a/payload-schemas/schemas/secret_scanning_alert/reopened.schema.json
+++ b/payload-schemas/schemas/secret_scanning_alert/reopened.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "alert", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["reopened"]
-    },
+    "action": { "type": "string", "enum": ["reopened"] },
     "alert": {
       "type": "object",
       "required": [

--- a/payload-schemas/schemas/secret_scanning_alert/resolved.schema.json
+++ b/payload-schemas/schemas/secret_scanning_alert/resolved.schema.json
@@ -4,10 +4,7 @@
   "type": "object",
   "required": ["action", "alert", "repository", "sender"],
   "properties": {
-    "action": {
-      "type": "string",
-      "enum": ["resolved"]
-    },
+    "action": { "type": "string", "enum": ["resolved"] },
     "alert": {
       "type": "object",
       "required": [

--- a/payload-schemas/schemas/security_advisory/performed.schema.json
+++ b/payload-schemas/schemas/security_advisory/performed.schema.json
@@ -27,7 +27,7 @@
         "identifiers": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["value", "type"],
@@ -43,7 +43,7 @@
         "references": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["url"],
@@ -59,7 +59,7 @@
         "vulnerabilities": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/security_advisory/published.schema.json
+++ b/payload-schemas/schemas/security_advisory/published.schema.json
@@ -27,7 +27,7 @@
         "identifiers": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["value", "type"],
@@ -43,7 +43,7 @@
         "references": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["url"],
@@ -59,7 +59,7 @@
         "vulnerabilities": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/security_advisory/updated.schema.json
+++ b/payload-schemas/schemas/security_advisory/updated.schema.json
@@ -27,7 +27,7 @@
         "identifiers": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["value", "type"],
@@ -43,7 +43,7 @@
         "references": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": ["url"],
@@ -59,7 +59,7 @@
         "vulnerabilities": {
           "type": "array",
           "items": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "object",
                 "required": [

--- a/payload-schemas/schemas/sponsorship/edited.schema.json
+++ b/payload-schemas/schemas/sponsorship/edited.schema.json
@@ -50,9 +50,7 @@
         "privacy_level": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": { "type": "string" }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         }
       },

--- a/payload-schemas/schemas/status/event.schema.json
+++ b/payload-schemas/schemas/status/event.schema.json
@@ -222,7 +222,7 @@
     "branches": {
       "type": "array",
       "items": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "required": ["name", "commit", "protected"],

--- a/payload-schemas/schemas/team/edited.schema.json
+++ b/payload-schemas/schemas/team/edited.schema.json
@@ -12,31 +12,19 @@
         "description": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         },
         "name": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         },
         "privacy": {
           "type": "object",
           "required": ["from"],
-          "properties": {
-            "from": {
-              "type": "string"
-            }
-          },
+          "properties": { "from": { "type": "string" } },
           "additionalProperties": false
         },
         "repository": {


### PR DESCRIPTION
This is a pre-commit mainly to get the script created so that I can make PRs adding each optimization one-by-one without as much conflicting.

Like `format-with-prettier`, this isn't something I'm expecting to have to run much after the initial bulk run, but think its worth having committed.

In the future it would be nice to have a tool checking new schemas for the situations this script is handling, but we can do that later.

-----

This first optimization replaces all `anyOf`s with `oneOf`.

`anyOf` means "this should match at least one", while `oneOf` means "this should match at least one, but no more than one".
Situations where you actually want `anyOf` are very rare, as they usually indicate un-normalized schemas since if `d` could match `x` and `y` at the same time that usually means one is a subset of the other (in which case you can just match the super type), or you've got at least two types that are equivalent and so one is duplicating the other.

(I actually struggle to think of a good usecase for `anyOf`, as they all end up with some form of redundant or duplicated parts in the schema).