### PR TITLE
refactor: remove redundant `oneOf`s from schemas

### DIFF
--- a/bin/optimize-schemas.ts
+++ b/bin/optimize-schemas.ts
@@ -31,6 +31,11 @@ fs.readdirSync(payloads).forEach((event) => {
             delete value.anyOf;
           }
 
+          // "oneOf" is redundant if it's only got one schema
+          if (value.oneOf && value.oneOf.length === 1) {
+            return value.oneOf[0];
+          }
+
           return value;
         }),
         { parser: "json" }

--- a/payload-schemas/schemas/check_run/completed.schema.json
+++ b/payload-schemas/schemas/check_run/completed.schema.json
@@ -105,56 +105,52 @@
             "pull_requests": {
               "type": "array",
               "items": {
-                "oneOf": [
-                  {
+                "type": "object",
+                "required": ["url", "id", "number", "head", "base"],
+                "properties": {
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
+                  "head": {
                     "type": "object",
-                    "required": ["url", "id", "number", "head", "base"],
+                    "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "url": { "type": "string" },
-                      "id": { "type": "integer" },
-                      "number": { "type": "integer" },
-                      "head": {
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
+                      "repo": {
                         "type": "object",
-                        "required": ["ref", "sha", "repo"],
+                        "required": ["id", "url", "name"],
                         "properties": {
-                          "ref": { "type": "string" },
-                          "sha": { "type": "string" },
-                          "repo": {
-                            "type": "object",
-                            "required": ["id", "url", "name"],
-                            "properties": {
-                              "id": { "type": "integer" },
-                              "url": { "type": "string" },
-                              "name": { "type": "string" }
-                            },
-                            "additionalProperties": false
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
-                      },
-                      "base": {
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "base": {
+                    "type": "object",
+                    "required": ["ref", "sha", "repo"],
+                    "properties": {
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
+                      "repo": {
                         "type": "object",
-                        "required": ["ref", "sha", "repo"],
+                        "required": ["id", "url", "name"],
                         "properties": {
-                          "ref": { "type": "string" },
-                          "sha": { "type": "string" },
-                          "repo": {
-                            "type": "object",
-                            "required": ["id", "url", "name"],
-                            "properties": {
-                              "id": { "type": "integer" },
-                              "url": { "type": "string" },
-                              "name": { "type": "string" }
-                            },
-                            "additionalProperties": false
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
                     },
                     "additionalProperties": false
                   }
-                ]
+                },
+                "additionalProperties": false
               }
             },
             "app": {
@@ -345,56 +341,52 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
+            "type": "object",
+            "required": ["url", "id", "number", "head", "base"],
+            "properties": {
+              "url": { "type": "string" },
+              "id": { "type": "integer" },
+              "number": { "type": "integer" },
+              "head": {
                 "type": "object",
-                "required": ["url", "id", "number", "head", "base"],
+                "required": ["ref", "sha", "repo"],
                 "properties": {
-                  "url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "number": { "type": "integer" },
-                  "head": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
-                  },
-                  "base": {
+                  }
+                },
+                "additionalProperties": false
+              },
+              "base": {
+                "type": "object",
+                "required": ["ref", "sha", "repo"],
+                "properties": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
               }
-            ]
+            },
+            "additionalProperties": false
           }
         }
       },

--- a/payload-schemas/schemas/check_run/created.schema.json
+++ b/payload-schemas/schemas/check_run/created.schema.json
@@ -105,56 +105,52 @@
             "pull_requests": {
               "type": "array",
               "items": {
-                "oneOf": [
-                  {
+                "type": "object",
+                "required": ["url", "id", "number", "head", "base"],
+                "properties": {
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
+                  "head": {
                     "type": "object",
-                    "required": ["url", "id", "number", "head", "base"],
+                    "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "url": { "type": "string" },
-                      "id": { "type": "integer" },
-                      "number": { "type": "integer" },
-                      "head": {
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
+                      "repo": {
                         "type": "object",
-                        "required": ["ref", "sha", "repo"],
+                        "required": ["id", "url", "name"],
                         "properties": {
-                          "ref": { "type": "string" },
-                          "sha": { "type": "string" },
-                          "repo": {
-                            "type": "object",
-                            "required": ["id", "url", "name"],
-                            "properties": {
-                              "id": { "type": "integer" },
-                              "url": { "type": "string" },
-                              "name": { "type": "string" }
-                            },
-                            "additionalProperties": false
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
-                      },
-                      "base": {
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "base": {
+                    "type": "object",
+                    "required": ["ref", "sha", "repo"],
+                    "properties": {
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
+                      "repo": {
                         "type": "object",
-                        "required": ["ref", "sha", "repo"],
+                        "required": ["id", "url", "name"],
                         "properties": {
-                          "ref": { "type": "string" },
-                          "sha": { "type": "string" },
-                          "repo": {
-                            "type": "object",
-                            "required": ["id", "url", "name"],
-                            "properties": {
-                              "id": { "type": "integer" },
-                              "url": { "type": "string" },
-                              "name": { "type": "string" }
-                            },
-                            "additionalProperties": false
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
                     },
                     "additionalProperties": false
                   }
-                ]
+                },
+                "additionalProperties": false
               }
             },
             "app": {
@@ -345,56 +341,52 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
+            "type": "object",
+            "required": ["url", "id", "number", "head", "base"],
+            "properties": {
+              "url": { "type": "string" },
+              "id": { "type": "integer" },
+              "number": { "type": "integer" },
+              "head": {
                 "type": "object",
-                "required": ["url", "id", "number", "head", "base"],
+                "required": ["ref", "sha", "repo"],
                 "properties": {
-                  "url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "number": { "type": "integer" },
-                  "head": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
-                  },
-                  "base": {
+                  }
+                },
+                "additionalProperties": false
+              },
+              "base": {
+                "type": "object",
+                "required": ["ref", "sha", "repo"],
+                "properties": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
               }
-            ]
+            },
+            "additionalProperties": false
           }
         }
       },

--- a/payload-schemas/schemas/check_run/requested_action.schema.json
+++ b/payload-schemas/schemas/check_run/requested_action.schema.json
@@ -105,56 +105,52 @@
             "pull_requests": {
               "type": "array",
               "items": {
-                "oneOf": [
-                  {
+                "type": "object",
+                "required": ["url", "id", "number", "head", "base"],
+                "properties": {
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
+                  "head": {
                     "type": "object",
-                    "required": ["url", "id", "number", "head", "base"],
+                    "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "url": { "type": "string" },
-                      "id": { "type": "integer" },
-                      "number": { "type": "integer" },
-                      "head": {
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
+                      "repo": {
                         "type": "object",
-                        "required": ["ref", "sha", "repo"],
+                        "required": ["id", "url", "name"],
                         "properties": {
-                          "ref": { "type": "string" },
-                          "sha": { "type": "string" },
-                          "repo": {
-                            "type": "object",
-                            "required": ["id", "url", "name"],
-                            "properties": {
-                              "id": { "type": "integer" },
-                              "url": { "type": "string" },
-                              "name": { "type": "string" }
-                            },
-                            "additionalProperties": false
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
-                      },
-                      "base": {
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "base": {
+                    "type": "object",
+                    "required": ["ref", "sha", "repo"],
+                    "properties": {
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
+                      "repo": {
                         "type": "object",
-                        "required": ["ref", "sha", "repo"],
+                        "required": ["id", "url", "name"],
                         "properties": {
-                          "ref": { "type": "string" },
-                          "sha": { "type": "string" },
-                          "repo": {
-                            "type": "object",
-                            "required": ["id", "url", "name"],
-                            "properties": {
-                              "id": { "type": "integer" },
-                              "url": { "type": "string" },
-                              "name": { "type": "string" }
-                            },
-                            "additionalProperties": false
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
                     },
                     "additionalProperties": false
                   }
-                ]
+                },
+                "additionalProperties": false
               }
             },
             "app": {
@@ -345,56 +341,52 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
+            "type": "object",
+            "required": ["url", "id", "number", "head", "base"],
+            "properties": {
+              "url": { "type": "string" },
+              "id": { "type": "integer" },
+              "number": { "type": "integer" },
+              "head": {
                 "type": "object",
-                "required": ["url", "id", "number", "head", "base"],
+                "required": ["ref", "sha", "repo"],
                 "properties": {
-                  "url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "number": { "type": "integer" },
-                  "head": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
-                  },
-                  "base": {
+                  }
+                },
+                "additionalProperties": false
+              },
+              "base": {
+                "type": "object",
+                "required": ["ref", "sha", "repo"],
+                "properties": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
               }
-            ]
+            },
+            "additionalProperties": false
           }
         }
       },

--- a/payload-schemas/schemas/check_run/rerequested.schema.json
+++ b/payload-schemas/schemas/check_run/rerequested.schema.json
@@ -105,56 +105,52 @@
             "pull_requests": {
               "type": "array",
               "items": {
-                "oneOf": [
-                  {
+                "type": "object",
+                "required": ["url", "id", "number", "head", "base"],
+                "properties": {
+                  "url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "number": { "type": "integer" },
+                  "head": {
                     "type": "object",
-                    "required": ["url", "id", "number", "head", "base"],
+                    "required": ["ref", "sha", "repo"],
                     "properties": {
-                      "url": { "type": "string" },
-                      "id": { "type": "integer" },
-                      "number": { "type": "integer" },
-                      "head": {
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
+                      "repo": {
                         "type": "object",
-                        "required": ["ref", "sha", "repo"],
+                        "required": ["id", "url", "name"],
                         "properties": {
-                          "ref": { "type": "string" },
-                          "sha": { "type": "string" },
-                          "repo": {
-                            "type": "object",
-                            "required": ["id", "url", "name"],
-                            "properties": {
-                              "id": { "type": "integer" },
-                              "url": { "type": "string" },
-                              "name": { "type": "string" }
-                            },
-                            "additionalProperties": false
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
-                      },
-                      "base": {
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "base": {
+                    "type": "object",
+                    "required": ["ref", "sha", "repo"],
+                    "properties": {
+                      "ref": { "type": "string" },
+                      "sha": { "type": "string" },
+                      "repo": {
                         "type": "object",
-                        "required": ["ref", "sha", "repo"],
+                        "required": ["id", "url", "name"],
                         "properties": {
-                          "ref": { "type": "string" },
-                          "sha": { "type": "string" },
-                          "repo": {
-                            "type": "object",
-                            "required": ["id", "url", "name"],
-                            "properties": {
-                              "id": { "type": "integer" },
-                              "url": { "type": "string" },
-                              "name": { "type": "string" }
-                            },
-                            "additionalProperties": false
-                          }
+                          "id": { "type": "integer" },
+                          "url": { "type": "string" },
+                          "name": { "type": "string" }
                         },
                         "additionalProperties": false
                       }
                     },
                     "additionalProperties": false
                   }
-                ]
+                },
+                "additionalProperties": false
               }
             },
             "app": {
@@ -345,56 +341,52 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
+            "type": "object",
+            "required": ["url", "id", "number", "head", "base"],
+            "properties": {
+              "url": { "type": "string" },
+              "id": { "type": "integer" },
+              "number": { "type": "integer" },
+              "head": {
                 "type": "object",
-                "required": ["url", "id", "number", "head", "base"],
+                "required": ["ref", "sha", "repo"],
                 "properties": {
-                  "url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "number": { "type": "integer" },
-                  "head": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
-                  },
-                  "base": {
+                  }
+                },
+                "additionalProperties": false
+              },
+              "base": {
+                "type": "object",
+                "required": ["ref", "sha", "repo"],
+                "properties": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
               }
-            ]
+            },
+            "additionalProperties": false
           }
         }
       },

--- a/payload-schemas/schemas/check_suite/completed.schema.json
+++ b/payload-schemas/schemas/check_suite/completed.schema.json
@@ -62,56 +62,52 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
+            "type": "object",
+            "required": ["url", "id", "number", "head", "base"],
+            "properties": {
+              "url": { "type": "string" },
+              "id": { "type": "integer" },
+              "number": { "type": "integer" },
+              "head": {
                 "type": "object",
-                "required": ["url", "id", "number", "head", "base"],
+                "required": ["ref", "sha", "repo"],
                 "properties": {
-                  "url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "number": { "type": "integer" },
-                  "head": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
-                  },
-                  "base": {
+                  }
+                },
+                "additionalProperties": false
+              },
+              "base": {
+                "type": "object",
+                "required": ["ref", "sha", "repo"],
+                "properties": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
               }
-            ]
+            },
+            "additionalProperties": false
           }
         },
         "app": {

--- a/payload-schemas/schemas/check_suite/requested.schema.json
+++ b/payload-schemas/schemas/check_suite/requested.schema.json
@@ -62,56 +62,52 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
+            "type": "object",
+            "required": ["url", "id", "number", "head", "base"],
+            "properties": {
+              "url": { "type": "string" },
+              "id": { "type": "integer" },
+              "number": { "type": "integer" },
+              "head": {
                 "type": "object",
-                "required": ["url", "id", "number", "head", "base"],
+                "required": ["ref", "sha", "repo"],
                 "properties": {
-                  "url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "number": { "type": "integer" },
-                  "head": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
-                  },
-                  "base": {
+                  }
+                },
+                "additionalProperties": false
+              },
+              "base": {
+                "type": "object",
+                "required": ["ref", "sha", "repo"],
+                "properties": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
               }
-            ]
+            },
+            "additionalProperties": false
           }
         },
         "app": {

--- a/payload-schemas/schemas/check_suite/rerequested.schema.json
+++ b/payload-schemas/schemas/check_suite/rerequested.schema.json
@@ -62,56 +62,52 @@
         "pull_requests": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
+            "type": "object",
+            "required": ["url", "id", "number", "head", "base"],
+            "properties": {
+              "url": { "type": "string" },
+              "id": { "type": "integer" },
+              "number": { "type": "integer" },
+              "head": {
                 "type": "object",
-                "required": ["url", "id", "number", "head", "base"],
+                "required": ["ref", "sha", "repo"],
                 "properties": {
-                  "url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "number": { "type": "integer" },
-                  "head": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
-                  },
-                  "base": {
+                  }
+                },
+                "additionalProperties": false
+              },
+              "base": {
+                "type": "object",
+                "required": ["ref", "sha", "repo"],
+                "properties": {
+                  "ref": { "type": "string" },
+                  "sha": { "type": "string" },
+                  "repo": {
                     "type": "object",
-                    "required": ["ref", "sha", "repo"],
+                    "required": ["id", "url", "name"],
                     "properties": {
-                      "ref": { "type": "string" },
-                      "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "id": { "type": "integer" },
+                      "url": { "type": "string" },
+                      "name": { "type": "string" }
                     },
                     "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
               }
-            ]
+            },
+            "additionalProperties": false
           }
         },
         "app": {

--- a/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
@@ -35,19 +35,15 @@
         "instances": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["ref", "analysis_key", "environment", "state"],
-                "properties": {
-                  "ref": { "type": "string" },
-                  "analysis_key": { "type": "string" },
-                  "environment": { "type": "string" },
-                  "state": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["ref", "analysis_key", "environment", "state"],
+            "properties": {
+              "ref": { "type": "string" },
+              "analysis_key": { "type": "string" },
+              "environment": { "type": "string" },
+              "state": { "type": "string" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string" },

--- a/payload-schemas/schemas/code_scanning_alert/closed_by_user.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/closed_by_user.schema.json
@@ -35,19 +35,15 @@
         "instances": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["ref", "analysis_key", "environment", "state"],
-                "properties": {
-                  "ref": { "type": "string" },
-                  "analysis_key": { "type": "string" },
-                  "environment": { "type": "string" },
-                  "state": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["ref", "analysis_key", "environment", "state"],
+            "properties": {
+              "ref": { "type": "string" },
+              "analysis_key": { "type": "string" },
+              "environment": { "type": "string" },
+              "state": { "type": "string" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string" },

--- a/payload-schemas/schemas/code_scanning_alert/created.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/created.schema.json
@@ -35,19 +35,15 @@
         "instances": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["ref", "analysis_key", "environment", "state"],
-                "properties": {
-                  "ref": { "type": "string" },
-                  "analysis_key": { "type": "string" },
-                  "environment": { "type": "string" },
-                  "state": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["ref", "analysis_key", "environment", "state"],
+            "properties": {
+              "ref": { "type": "string" },
+              "analysis_key": { "type": "string" },
+              "environment": { "type": "string" },
+              "state": { "type": "string" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string" },

--- a/payload-schemas/schemas/code_scanning_alert/fixed.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/fixed.schema.json
@@ -35,19 +35,15 @@
         "instances": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["ref", "analysis_key", "environment", "state"],
-                "properties": {
-                  "ref": { "type": "string" },
-                  "analysis_key": { "type": "string" },
-                  "environment": { "type": "string" },
-                  "state": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["ref", "analysis_key", "environment", "state"],
+            "properties": {
+              "ref": { "type": "string" },
+              "analysis_key": { "type": "string" },
+              "environment": { "type": "string" },
+              "state": { "type": "string" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string" },

--- a/payload-schemas/schemas/code_scanning_alert/reopened.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/reopened.schema.json
@@ -35,19 +35,15 @@
         "instances": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["ref", "analysis_key", "environment", "state"],
-                "properties": {
-                  "ref": { "type": "string" },
-                  "analysis_key": { "type": "string" },
-                  "environment": { "type": "string" },
-                  "state": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["ref", "analysis_key", "environment", "state"],
+            "properties": {
+              "ref": { "type": "string" },
+              "analysis_key": { "type": "string" },
+              "environment": { "type": "string" },
+              "state": { "type": "string" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string" },

--- a/payload-schemas/schemas/code_scanning_alert/reopened_by_user.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/reopened_by_user.schema.json
@@ -35,19 +35,15 @@
         "instances": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["ref", "analysis_key", "environment", "state"],
-                "properties": {
-                  "ref": { "type": "string" },
-                  "analysis_key": { "type": "string" },
-                  "environment": { "type": "string" },
-                  "state": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["ref", "analysis_key", "environment", "state"],
+            "properties": {
+              "ref": { "type": "string" },
+              "analysis_key": { "type": "string" },
+              "environment": { "type": "string" },
+              "state": { "type": "string" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string" },

--- a/payload-schemas/schemas/gollum/event.schema.json
+++ b/payload-schemas/schemas/gollum/event.schema.json
@@ -7,28 +7,24 @@
     "pages": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "page_name",
-              "title",
-              "summary",
-              "action",
-              "sha",
-              "html_url"
-            ],
-            "properties": {
-              "page_name": { "type": "string" },
-              "title": { "type": "string" },
-              "summary": { "type": "null" },
-              "action": { "type": "string", "enum": ["created", "edited"] },
-              "sha": { "type": "string" },
-              "html_url": { "type": "string" }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "type": "object",
+        "required": [
+          "page_name",
+          "title",
+          "summary",
+          "action",
+          "sha",
+          "html_url"
+        ],
+        "properties": {
+          "page_name": { "type": "string" },
+          "title": { "type": "string" },
+          "summary": { "type": "null" },
+          "action": { "type": "string", "enum": ["created", "edited"] },
+          "sha": { "type": "string" },
+          "html_url": { "type": "string" }
+        },
+        "additionalProperties": false
       }
     },
     "repository": { "$ref": "common/repository.schema.json" },

--- a/payload-schemas/schemas/installation/created.schema.json
+++ b/payload-schemas/schemas/installation/created.schema.json
@@ -121,20 +121,16 @@
     "repositories": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["id", "node_id", "name", "full_name", "private"],
-            "properties": {
-              "id": { "type": "integer" },
-              "node_id": { "type": "string" },
-              "name": { "type": "string" },
-              "full_name": { "type": "string" },
-              "private": { "type": "boolean" }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "type": "object",
+        "required": ["id", "node_id", "name", "full_name", "private"],
+        "properties": {
+          "id": { "type": "integer" },
+          "node_id": { "type": "string" },
+          "name": { "type": "string" },
+          "full_name": { "type": "string" },
+          "private": { "type": "boolean" }
+        },
+        "additionalProperties": false
       }
     },
     "requester": { "type": "null" },

--- a/payload-schemas/schemas/installation/deleted.schema.json
+++ b/payload-schemas/schemas/installation/deleted.schema.json
@@ -121,20 +121,16 @@
     "repositories": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["id", "node_id", "name", "full_name", "private"],
-            "properties": {
-              "id": { "type": "integer" },
-              "node_id": { "type": "string" },
-              "name": { "type": "string" },
-              "full_name": { "type": "string" },
-              "private": { "type": "boolean" }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "type": "object",
+        "required": ["id", "node_id", "name", "full_name", "private"],
+        "properties": {
+          "id": { "type": "integer" },
+          "node_id": { "type": "string" },
+          "name": { "type": "string" },
+          "full_name": { "type": "string" },
+          "private": { "type": "boolean" }
+        },
+        "additionalProperties": false
       }
     },
     "requester": { "type": "null" },

--- a/payload-schemas/schemas/installation/new_permissions_accepted.schema.json
+++ b/payload-schemas/schemas/installation/new_permissions_accepted.schema.json
@@ -121,20 +121,16 @@
     "repositories": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["id", "node_id", "name", "full_name", "private"],
-            "properties": {
-              "id": { "type": "integer" },
-              "node_id": { "type": "string" },
-              "name": { "type": "string" },
-              "full_name": { "type": "string" },
-              "private": { "type": "boolean" }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "type": "object",
+        "required": ["id", "node_id", "name", "full_name", "private"],
+        "properties": {
+          "id": { "type": "integer" },
+          "node_id": { "type": "string" },
+          "name": { "type": "string" },
+          "full_name": { "type": "string" },
+          "private": { "type": "boolean" }
+        },
+        "additionalProperties": false
       }
     },
     "requester": { "type": "null" },

--- a/payload-schemas/schemas/installation/suspended.schema.json
+++ b/payload-schemas/schemas/installation/suspended.schema.json
@@ -121,20 +121,16 @@
     "repositories": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["id", "node_id", "name", "full_name", "private"],
-            "properties": {
-              "id": { "type": "integer" },
-              "node_id": { "type": "string" },
-              "name": { "type": "string" },
-              "full_name": { "type": "string" },
-              "private": { "type": "boolean" }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "type": "object",
+        "required": ["id", "node_id", "name", "full_name", "private"],
+        "properties": {
+          "id": { "type": "integer" },
+          "node_id": { "type": "string" },
+          "name": { "type": "string" },
+          "full_name": { "type": "string" },
+          "private": { "type": "boolean" }
+        },
+        "additionalProperties": false
       }
     },
     "requester": { "type": "null" },

--- a/payload-schemas/schemas/installation/unsuspended.schema.json
+++ b/payload-schemas/schemas/installation/unsuspended.schema.json
@@ -121,20 +121,16 @@
     "repositories": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["id", "node_id", "name", "full_name", "private"],
-            "properties": {
-              "id": { "type": "integer" },
-              "node_id": { "type": "string" },
-              "name": { "type": "string" },
-              "full_name": { "type": "string" },
-              "private": { "type": "boolean" }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "type": "object",
+        "required": ["id", "node_id", "name", "full_name", "private"],
+        "properties": {
+          "id": { "type": "integer" },
+          "node_id": { "type": "string" },
+          "name": { "type": "string" },
+          "full_name": { "type": "string" },
+          "private": { "type": "boolean" }
+        },
+        "additionalProperties": false
       }
     },
     "requester": { "type": "null" },

--- a/payload-schemas/schemas/installation_repositories/added.schema.json
+++ b/payload-schemas/schemas/installation_repositories/added.schema.json
@@ -124,20 +124,16 @@
     "repositories_added": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["id", "node_id", "name", "full_name", "private"],
-            "properties": {
-              "id": { "type": "integer" },
-              "node_id": { "type": "string" },
-              "name": { "type": "string" },
-              "full_name": { "type": "string" },
-              "private": { "type": "boolean" }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "type": "object",
+        "required": ["id", "node_id", "name", "full_name", "private"],
+        "properties": {
+          "id": { "type": "integer" },
+          "node_id": { "type": "string" },
+          "name": { "type": "string" },
+          "full_name": { "type": "string" },
+          "private": { "type": "boolean" }
+        },
+        "additionalProperties": false
       }
     },
     "repositories_removed": { "type": "array", "items": {} },

--- a/payload-schemas/schemas/installation_repositories/removed.schema.json
+++ b/payload-schemas/schemas/installation_repositories/removed.schema.json
@@ -124,20 +124,16 @@
     "repositories_added": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["id", "node_id", "name", "full_name", "private"],
-            "properties": {
-              "id": { "type": "integer" },
-              "node_id": { "type": "string" },
-              "name": { "type": "string" },
-              "full_name": { "type": "string" },
-              "private": { "type": "boolean" }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "type": "object",
+        "required": ["id", "node_id", "name", "full_name", "private"],
+        "properties": {
+          "id": { "type": "integer" },
+          "node_id": { "type": "string" },
+          "name": { "type": "string" },
+          "full_name": { "type": "string" },
+          "private": { "type": "boolean" }
+        },
+        "additionalProperties": false
       }
     },
     "repositories_removed": { "type": "array", "items": {} },

--- a/payload-schemas/schemas/integration_installation/created.schema.json
+++ b/payload-schemas/schemas/integration_installation/created.schema.json
@@ -118,20 +118,16 @@
     "repositories": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["id", "node_id", "name", "full_name", "private"],
-            "properties": {
-              "id": { "type": "integer" },
-              "node_id": { "type": "string" },
-              "name": { "type": "string" },
-              "full_name": { "type": "string" },
-              "private": { "type": "boolean" }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "type": "object",
+        "required": ["id", "node_id", "name", "full_name", "private"],
+        "properties": {
+          "id": { "type": "integer" },
+          "node_id": { "type": "string" },
+          "name": { "type": "string" },
+          "full_name": { "type": "string" },
+          "private": { "type": "boolean" }
+        },
+        "additionalProperties": false
       }
     },
     "sender": { "$ref": "common/user.schema.json" }

--- a/payload-schemas/schemas/integration_installation_repositories/added.schema.json
+++ b/payload-schemas/schemas/integration_installation_repositories/added.schema.json
@@ -126,20 +126,16 @@
     "repositories_added": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["id", "node_id", "name", "full_name", "private"],
-            "properties": {
-              "id": { "type": "integer" },
-              "node_id": { "type": "string" },
-              "name": { "type": "string" },
-              "full_name": { "type": "string" },
-              "private": { "type": "boolean" }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "type": "object",
+        "required": ["id", "node_id", "name", "full_name", "private"],
+        "properties": {
+          "id": { "type": "integer" },
+          "node_id": { "type": "string" },
+          "name": { "type": "string" },
+          "full_name": { "type": "string" },
+          "private": { "type": "boolean" }
+        },
+        "additionalProperties": false
       }
     },
     "repositories_removed": { "type": "array", "items": {} },

--- a/payload-schemas/schemas/issue_comment/created.schema.json
+++ b/payload-schemas/schemas/issue_comment/created.schema.json
@@ -48,28 +48,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -79,7 +68,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "type": "object",

--- a/payload-schemas/schemas/issue_comment/deleted.schema.json
+++ b/payload-schemas/schemas/issue_comment/deleted.schema.json
@@ -48,28 +48,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -79,7 +68,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "type": "object",

--- a/payload-schemas/schemas/issue_comment/edited.schema.json
+++ b/payload-schemas/schemas/issue_comment/edited.schema.json
@@ -60,28 +60,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -91,7 +80,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "type": "object",

--- a/payload-schemas/schemas/issues/assigned.schema.json
+++ b/payload-schemas/schemas/issues/assigned.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/closed.schema.json
+++ b/payload-schemas/schemas/issues/closed.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/deleted.schema.json
+++ b/payload-schemas/schemas/issues/deleted.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/demilestoned.schema.json
+++ b/payload-schemas/schemas/issues/demilestoned.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/edited.schema.json
+++ b/payload-schemas/schemas/issues/edited.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/labeled.schema.json
+++ b/payload-schemas/schemas/issues/labeled.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/locked.schema.json
+++ b/payload-schemas/schemas/issues/locked.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/milestoned.schema.json
+++ b/payload-schemas/schemas/issues/milestoned.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/opened.schema.json
+++ b/payload-schemas/schemas/issues/opened.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/pinned.schema.json
+++ b/payload-schemas/schemas/issues/pinned.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/reopened.schema.json
+++ b/payload-schemas/schemas/issues/reopened.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/transferred.schema.json
+++ b/payload-schemas/schemas/issues/transferred.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/unassigned.schema.json
+++ b/payload-schemas/schemas/issues/unassigned.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/unlabeled.schema.json
+++ b/payload-schemas/schemas/issues/unlabeled.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/unlocked.schema.json
+++ b/payload-schemas/schemas/issues/unlocked.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/issues/unpinned.schema.json
+++ b/payload-schemas/schemas/issues/unpinned.schema.json
@@ -44,28 +44,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "state": { "type": "string", "enum": ["open", "closed"] },
@@ -75,7 +64,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
           "oneOf": [

--- a/payload-schemas/schemas/marketplace_purchase/cancelled.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/cancelled.schema.json
@@ -102,10 +102,7 @@
             "unit_name": {
               "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "bullets": {
-              "type": "array",
-              "items": { "oneOf": [{ "type": "string" }] }
-            }
+            "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
         }
@@ -163,10 +160,7 @@
             "unit_name": {
               "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "bullets": {
-              "type": "array",
-              "items": { "oneOf": [{ "type": "string" }] }
-            }
+            "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
         }

--- a/payload-schemas/schemas/marketplace_purchase/changed.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/changed.schema.json
@@ -102,10 +102,7 @@
             "unit_name": {
               "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "bullets": {
-              "type": "array",
-              "items": { "oneOf": [{ "type": "string" }] }
-            }
+            "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
         }
@@ -163,10 +160,7 @@
             "unit_name": {
               "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "bullets": {
-              "type": "array",
-              "items": { "oneOf": [{ "type": "string" }] }
-            }
+            "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
         }

--- a/payload-schemas/schemas/marketplace_purchase/purchased.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/purchased.schema.json
@@ -102,10 +102,7 @@
             "unit_name": {
               "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "bullets": {
-              "type": "array",
-              "items": { "oneOf": [{ "type": "string" }] }
-            }
+            "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
         }
@@ -163,10 +160,7 @@
             "unit_name": {
               "oneOf": [{ "type": "null" }, { "type": "string" }]
             },
-            "bullets": {
-              "type": "array",
-              "items": { "oneOf": [{ "type": "string" }] }
-            }
+            "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
         }

--- a/payload-schemas/schemas/meta/deleted.schema.json
+++ b/payload-schemas/schemas/meta/deleted.schema.json
@@ -23,10 +23,7 @@
         "id": { "type": "integer" },
         "name": { "type": "string" },
         "active": { "type": "boolean" },
-        "events": {
-          "type": "array",
-          "items": { "oneOf": [{ "type": "string" }] }
-        },
+        "events": { "type": "array", "items": { "type": "string" } },
         "config": {
           "type": "object",
           "required": ["content_type", "insecure_ssl", "url"],

--- a/payload-schemas/schemas/package/published.schema.json
+++ b/payload-schemas/schemas/package/published.schema.json
@@ -98,38 +98,34 @@
             "package_files": {
               "type": "array",
               "items": {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "required": [
-                      "download_url",
-                      "id",
-                      "name",
-                      "sha256",
-                      "sha1",
-                      "md5",
-                      "content_type",
-                      "state",
-                      "size",
-                      "created_at",
-                      "updated_at"
-                    ],
-                    "properties": {
-                      "download_url": { "type": "string" },
-                      "id": { "type": "integer" },
-                      "name": { "type": "string" },
-                      "sha256": { "type": "string" },
-                      "sha1": { "type": "string" },
-                      "md5": { "type": "string" },
-                      "content_type": { "type": "string" },
-                      "state": { "type": "string" },
-                      "size": { "type": "integer" },
-                      "created_at": { "type": "string" },
-                      "updated_at": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
-                ]
+                "type": "object",
+                "required": [
+                  "download_url",
+                  "id",
+                  "name",
+                  "sha256",
+                  "sha1",
+                  "md5",
+                  "content_type",
+                  "state",
+                  "size",
+                  "created_at",
+                  "updated_at"
+                ],
+                "properties": {
+                  "download_url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "name": { "type": "string" },
+                  "sha256": { "type": "string" },
+                  "sha1": { "type": "string" },
+                  "md5": { "type": "string" },
+                  "content_type": { "type": "string" },
+                  "state": { "type": "string" },
+                  "size": { "type": "integer" },
+                  "created_at": { "type": "string" },
+                  "updated_at": { "type": "string" }
+                },
+                "additionalProperties": false
               }
             },
             "author": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/package/updated.schema.json
+++ b/payload-schemas/schemas/package/updated.schema.json
@@ -98,38 +98,34 @@
             "package_files": {
               "type": "array",
               "items": {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "required": [
-                      "download_url",
-                      "id",
-                      "name",
-                      "sha256",
-                      "sha1",
-                      "md5",
-                      "content_type",
-                      "state",
-                      "size",
-                      "created_at",
-                      "updated_at"
-                    ],
-                    "properties": {
-                      "download_url": { "type": "string" },
-                      "id": { "type": "integer" },
-                      "name": { "type": "string" },
-                      "sha256": { "type": "string" },
-                      "sha1": { "type": "string" },
-                      "md5": { "type": "string" },
-                      "content_type": { "type": "string" },
-                      "state": { "type": "string" },
-                      "size": { "type": "integer" },
-                      "created_at": { "type": "string" },
-                      "updated_at": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
-                ]
+                "type": "object",
+                "required": [
+                  "download_url",
+                  "id",
+                  "name",
+                  "sha256",
+                  "sha1",
+                  "md5",
+                  "content_type",
+                  "state",
+                  "size",
+                  "created_at",
+                  "updated_at"
+                ],
+                "properties": {
+                  "download_url": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "name": { "type": "string" },
+                  "sha256": { "type": "string" },
+                  "sha1": { "type": "string" },
+                  "md5": { "type": "string" },
+                  "content_type": { "type": "string" },
+                  "state": { "type": "string" },
+                  "size": { "type": "integer" },
+                  "created_at": { "type": "string" },
+                  "updated_at": { "type": "string" }
+                },
+                "additionalProperties": false
               }
             },
             "author": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/ping/event.schema.json
+++ b/payload-schemas/schemas/ping/event.schema.json
@@ -25,10 +25,7 @@
         "id": { "type": "integer" },
         "name": { "type": "string" },
         "active": { "type": "boolean" },
-        "events": {
-          "type": "array",
-          "items": { "oneOf": [{ "type": "string" }] }
-        },
+        "events": { "type": "array", "items": { "type": "string" } },
         "config": {
           "type": "object",
           "required": ["content_type", "url", "insecure_ssl"],

--- a/payload-schemas/schemas/pull_request/assigned.schema.json
+++ b/payload-schemas/schemas/pull_request/assigned.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,28 +93,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/closed.schema.json
+++ b/payload-schemas/schemas/pull_request/closed.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,28 +93,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
+++ b/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
@@ -81,7 +81,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -91,28 +91,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/edited.schema.json
+++ b/payload-schemas/schemas/pull_request/edited.schema.json
@@ -108,7 +108,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -118,28 +118,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/labeled.schema.json
+++ b/payload-schemas/schemas/pull_request/labeled.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,28 +93,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/locked.schema.json
+++ b/payload-schemas/schemas/pull_request/locked.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,28 +93,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/opened.schema.json
+++ b/payload-schemas/schemas/pull_request/opened.schema.json
@@ -81,7 +81,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -91,28 +91,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/ready_for_review.schema.json
+++ b/payload-schemas/schemas/pull_request/ready_for_review.schema.json
@@ -81,7 +81,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -91,28 +91,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/reopened.schema.json
+++ b/payload-schemas/schemas/pull_request/reopened.schema.json
@@ -81,7 +81,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -91,28 +91,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/review_request_removed.schema.json
+++ b/payload-schemas/schemas/pull_request/review_request_removed.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,28 +93,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/review_requested.schema.json
+++ b/payload-schemas/schemas/pull_request/review_requested.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,28 +93,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/synchronize.schema.json
+++ b/payload-schemas/schemas/pull_request/synchronize.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,28 +93,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/unassigned.schema.json
+++ b/payload-schemas/schemas/pull_request/unassigned.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,28 +93,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/unlabeled.schema.json
+++ b/payload-schemas/schemas/pull_request/unlabeled.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,28 +93,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request/unlocked.schema.json
+++ b/payload-schemas/schemas/pull_request/unlocked.schema.json
@@ -83,7 +83,7 @@
         },
         "assignees": {
           "type": "array",
-          "items": { "oneOf": [{ "$ref": "common/user.schema.json" }] }
+          "items": { "$ref": "common/user.schema.json" }
         },
         "requested_reviewers": {
           "type": "array",
@@ -93,28 +93,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request_review/submitted.schema.json
+++ b/payload-schemas/schemas/pull_request_review/submitted.schema.json
@@ -135,28 +135,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request_review_comment/created.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/created.schema.json
@@ -155,28 +155,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request_review_comment/deleted.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/deleted.schema.json
@@ -155,28 +155,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/pull_request_review_comment/edited.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/edited.schema.json
@@ -174,28 +174,17 @@
         "labels": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "id",
-                  "node_id",
-                  "url",
-                  "name",
-                  "color",
-                  "default"
-                ],
-                "properties": {
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "url": { "type": "string" },
-                  "name": { "type": "string" },
-                  "color": { "type": "string" },
-                  "default": { "type": "boolean" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["id", "node_id", "url", "name", "color", "default"],
+            "properties": {
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "name": { "type": "string" },
+              "color": { "type": "string" },
+              "default": { "type": "boolean" }
+            },
+            "additionalProperties": false
           }
         },
         "milestone": {

--- a/payload-schemas/schemas/push/event.schema.json
+++ b/payload-schemas/schemas/push/event.schema.json
@@ -29,65 +29,52 @@
     "commits": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
+        "type": "object",
+        "required": [
+          "id",
+          "tree_id",
+          "distinct",
+          "message",
+          "timestamp",
+          "url",
+          "author",
+          "committer",
+          "added",
+          "removed",
+          "modified"
+        ],
+        "properties": {
+          "id": { "type": "string" },
+          "tree_id": { "type": "string" },
+          "distinct": { "type": "boolean" },
+          "message": { "type": "string" },
+          "timestamp": { "type": "string" },
+          "url": { "type": "string" },
+          "author": {
             "type": "object",
-            "required": [
-              "id",
-              "tree_id",
-              "distinct",
-              "message",
-              "timestamp",
-              "url",
-              "author",
-              "committer",
-              "added",
-              "removed",
-              "modified"
-            ],
+            "required": ["name", "email", "username"],
             "properties": {
-              "id": { "type": "string" },
-              "tree_id": { "type": "string" },
-              "distinct": { "type": "boolean" },
-              "message": { "type": "string" },
-              "timestamp": { "type": "string" },
-              "url": { "type": "string" },
-              "author": {
-                "type": "object",
-                "required": ["name", "email", "username"],
-                "properties": {
-                  "name": { "type": "string" },
-                  "email": { "type": "string" },
-                  "username": { "type": "string" }
-                },
-                "additionalProperties": false
-              },
-              "committer": {
-                "type": "object",
-                "required": ["name", "email", "username"],
-                "properties": {
-                  "name": { "type": "string" },
-                  "email": { "type": "string" },
-                  "username": { "type": "string" }
-                },
-                "additionalProperties": false
-              },
-              "added": {
-                "type": "array",
-                "items": { "oneOf": [{ "type": "string" }] }
-              },
-              "removed": {
-                "type": "array",
-                "items": { "oneOf": [{ "type": "string" }] }
-              },
-              "modified": {
-                "type": "array",
-                "items": { "oneOf": [{ "type": "string" }] }
-              }
+              "name": { "type": "string" },
+              "email": { "type": "string" },
+              "username": { "type": "string" }
             },
             "additionalProperties": false
-          }
-        ]
+          },
+          "committer": {
+            "type": "object",
+            "required": ["name", "email", "username"],
+            "properties": {
+              "name": { "type": "string" },
+              "email": { "type": "string" },
+              "username": { "type": "string" }
+            },
+            "additionalProperties": false
+          },
+          "added": { "type": "array", "items": { "type": "string" } },
+          "removed": { "type": "array", "items": { "type": "string" } },
+          "modified": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
       }
     },
     "head_commit": {
@@ -135,18 +122,9 @@
               },
               "additionalProperties": false
             },
-            "added": {
-              "type": "array",
-              "items": { "oneOf": [{ "type": "string" }] }
-            },
-            "removed": {
-              "type": "array",
-              "items": { "oneOf": [{ "type": "string" }] }
-            },
-            "modified": {
-              "type": "array",
-              "items": { "oneOf": [{ "type": "string" }] }
-            }
+            "added": { "type": "array", "items": { "type": "string" } },
+            "removed": { "type": "array", "items": { "type": "string" } },
+            "modified": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
         }

--- a/payload-schemas/schemas/release/created.schema.json
+++ b/payload-schemas/schemas/release/created.schema.json
@@ -45,41 +45,37 @@
         "assets": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "url",
-                  "browser_download_url",
-                  "id",
-                  "node_id",
-                  "name",
-                  "label",
-                  "state",
-                  "content_type",
-                  "size",
-                  "download_count",
-                  "created_at",
-                  "updated_at",
-                  "creator"
-                ],
-                "properties": {
-                  "url": { "type": "string" },
-                  "browser_download_url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "name": { "type": "string" },
-                  "label": { "type": "string" },
-                  "state": { "type": "string" },
-                  "content_type": { "type": "string" },
-                  "size": { "type": "integer" },
-                  "download_count": { "type": "integer" },
-                  "created_at": { "type": "string" },
-                  "updated_at": { "type": "string" },
-                  "uploader": { "$ref": "common/user.schema.json" }
-                }
-              }
-            ]
+            "type": "object",
+            "required": [
+              "url",
+              "browser_download_url",
+              "id",
+              "node_id",
+              "name",
+              "label",
+              "state",
+              "content_type",
+              "size",
+              "download_count",
+              "created_at",
+              "updated_at",
+              "creator"
+            ],
+            "properties": {
+              "url": { "type": "string" },
+              "browser_download_url": { "type": "string" },
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "label": { "type": "string" },
+              "state": { "type": "string" },
+              "content_type": { "type": "string" },
+              "size": { "type": "integer" },
+              "download_count": { "type": "integer" },
+              "created_at": { "type": "string" },
+              "updated_at": { "type": "string" },
+              "uploader": { "$ref": "common/user.schema.json" }
+            }
           }
         },
         "tarball_url": { "type": "string" },

--- a/payload-schemas/schemas/release/deleted.schema.json
+++ b/payload-schemas/schemas/release/deleted.schema.json
@@ -45,41 +45,37 @@
         "assets": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "url",
-                  "browser_download_url",
-                  "id",
-                  "node_id",
-                  "name",
-                  "label",
-                  "state",
-                  "content_type",
-                  "size",
-                  "download_count",
-                  "created_at",
-                  "updated_at",
-                  "creator"
-                ],
-                "properties": {
-                  "url": { "type": "string" },
-                  "browser_download_url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "name": { "type": "string" },
-                  "label": { "type": "string" },
-                  "state": { "type": "string" },
-                  "content_type": { "type": "string" },
-                  "size": { "type": "integer" },
-                  "download_count": { "type": "integer" },
-                  "created_at": { "type": "string" },
-                  "updated_at": { "type": "string" },
-                  "uploader": { "$ref": "common/user.schema.json" }
-                }
-              }
-            ]
+            "type": "object",
+            "required": [
+              "url",
+              "browser_download_url",
+              "id",
+              "node_id",
+              "name",
+              "label",
+              "state",
+              "content_type",
+              "size",
+              "download_count",
+              "created_at",
+              "updated_at",
+              "creator"
+            ],
+            "properties": {
+              "url": { "type": "string" },
+              "browser_download_url": { "type": "string" },
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "label": { "type": "string" },
+              "state": { "type": "string" },
+              "content_type": { "type": "string" },
+              "size": { "type": "integer" },
+              "download_count": { "type": "integer" },
+              "created_at": { "type": "string" },
+              "updated_at": { "type": "string" },
+              "uploader": { "$ref": "common/user.schema.json" }
+            }
           }
         },
         "tarball_url": { "type": "string" },

--- a/payload-schemas/schemas/release/edited.schema.json
+++ b/payload-schemas/schemas/release/edited.schema.json
@@ -63,41 +63,37 @@
         "assets": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "url",
-                  "browser_download_url",
-                  "id",
-                  "node_id",
-                  "name",
-                  "label",
-                  "state",
-                  "content_type",
-                  "size",
-                  "download_count",
-                  "created_at",
-                  "updated_at",
-                  "creator"
-                ],
-                "properties": {
-                  "url": { "type": "string" },
-                  "browser_download_url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "name": { "type": "string" },
-                  "label": { "type": "string" },
-                  "state": { "type": "string" },
-                  "content_type": { "type": "string" },
-                  "size": { "type": "integer" },
-                  "download_count": { "type": "integer" },
-                  "created_at": { "type": "string" },
-                  "updated_at": { "type": "string" },
-                  "uploader": { "$ref": "common/user.schema.json" }
-                }
-              }
-            ]
+            "type": "object",
+            "required": [
+              "url",
+              "browser_download_url",
+              "id",
+              "node_id",
+              "name",
+              "label",
+              "state",
+              "content_type",
+              "size",
+              "download_count",
+              "created_at",
+              "updated_at",
+              "creator"
+            ],
+            "properties": {
+              "url": { "type": "string" },
+              "browser_download_url": { "type": "string" },
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "label": { "type": "string" },
+              "state": { "type": "string" },
+              "content_type": { "type": "string" },
+              "size": { "type": "integer" },
+              "download_count": { "type": "integer" },
+              "created_at": { "type": "string" },
+              "updated_at": { "type": "string" },
+              "uploader": { "$ref": "common/user.schema.json" }
+            }
           }
         },
         "tarball_url": { "type": "string" },

--- a/payload-schemas/schemas/release/prereleased.schema.json
+++ b/payload-schemas/schemas/release/prereleased.schema.json
@@ -45,41 +45,37 @@
         "assets": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "url",
-                  "browser_download_url",
-                  "id",
-                  "node_id",
-                  "name",
-                  "label",
-                  "state",
-                  "content_type",
-                  "size",
-                  "download_count",
-                  "created_at",
-                  "updated_at",
-                  "creator"
-                ],
-                "properties": {
-                  "url": { "type": "string" },
-                  "browser_download_url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "name": { "type": "string" },
-                  "label": { "type": "string" },
-                  "state": { "type": "string" },
-                  "content_type": { "type": "string" },
-                  "size": { "type": "integer" },
-                  "download_count": { "type": "integer" },
-                  "created_at": { "type": "string" },
-                  "updated_at": { "type": "string" },
-                  "uploader": { "$ref": "common/user.schema.json" }
-                }
-              }
-            ]
+            "type": "object",
+            "required": [
+              "url",
+              "browser_download_url",
+              "id",
+              "node_id",
+              "name",
+              "label",
+              "state",
+              "content_type",
+              "size",
+              "download_count",
+              "created_at",
+              "updated_at",
+              "creator"
+            ],
+            "properties": {
+              "url": { "type": "string" },
+              "browser_download_url": { "type": "string" },
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "label": { "type": "string" },
+              "state": { "type": "string" },
+              "content_type": { "type": "string" },
+              "size": { "type": "integer" },
+              "download_count": { "type": "integer" },
+              "created_at": { "type": "string" },
+              "updated_at": { "type": "string" },
+              "uploader": { "$ref": "common/user.schema.json" }
+            }
           }
         },
         "tarball_url": { "type": "string" },

--- a/payload-schemas/schemas/release/published.schema.json
+++ b/payload-schemas/schemas/release/published.schema.json
@@ -45,41 +45,37 @@
         "assets": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "url",
-                  "browser_download_url",
-                  "id",
-                  "node_id",
-                  "name",
-                  "label",
-                  "state",
-                  "content_type",
-                  "size",
-                  "download_count",
-                  "created_at",
-                  "updated_at",
-                  "creator"
-                ],
-                "properties": {
-                  "url": { "type": "string" },
-                  "browser_download_url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "name": { "type": "string" },
-                  "label": { "type": "string" },
-                  "state": { "type": "string" },
-                  "content_type": { "type": "string" },
-                  "size": { "type": "integer" },
-                  "download_count": { "type": "integer" },
-                  "created_at": { "type": "string" },
-                  "updated_at": { "type": "string" },
-                  "uploader": { "$ref": "common/user.schema.json" }
-                }
-              }
-            ]
+            "type": "object",
+            "required": [
+              "url",
+              "browser_download_url",
+              "id",
+              "node_id",
+              "name",
+              "label",
+              "state",
+              "content_type",
+              "size",
+              "download_count",
+              "created_at",
+              "updated_at",
+              "creator"
+            ],
+            "properties": {
+              "url": { "type": "string" },
+              "browser_download_url": { "type": "string" },
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "label": { "type": "string" },
+              "state": { "type": "string" },
+              "content_type": { "type": "string" },
+              "size": { "type": "integer" },
+              "download_count": { "type": "integer" },
+              "created_at": { "type": "string" },
+              "updated_at": { "type": "string" },
+              "uploader": { "$ref": "common/user.schema.json" }
+            }
           }
         },
         "tarball_url": { "type": "string" },

--- a/payload-schemas/schemas/release/released.schema.json
+++ b/payload-schemas/schemas/release/released.schema.json
@@ -45,41 +45,37 @@
         "assets": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "url",
-                  "browser_download_url",
-                  "id",
-                  "node_id",
-                  "name",
-                  "label",
-                  "state",
-                  "content_type",
-                  "size",
-                  "download_count",
-                  "created_at",
-                  "updated_at",
-                  "creator"
-                ],
-                "properties": {
-                  "url": { "type": "string" },
-                  "browser_download_url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "name": { "type": "string" },
-                  "label": { "type": "string" },
-                  "state": { "type": "string" },
-                  "content_type": { "type": "string" },
-                  "size": { "type": "integer" },
-                  "download_count": { "type": "integer" },
-                  "created_at": { "type": "string" },
-                  "updated_at": { "type": "string" },
-                  "uploader": { "$ref": "common/user.schema.json" }
-                }
-              }
-            ]
+            "type": "object",
+            "required": [
+              "url",
+              "browser_download_url",
+              "id",
+              "node_id",
+              "name",
+              "label",
+              "state",
+              "content_type",
+              "size",
+              "download_count",
+              "created_at",
+              "updated_at",
+              "creator"
+            ],
+            "properties": {
+              "url": { "type": "string" },
+              "browser_download_url": { "type": "string" },
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "label": { "type": "string" },
+              "state": { "type": "string" },
+              "content_type": { "type": "string" },
+              "size": { "type": "integer" },
+              "download_count": { "type": "integer" },
+              "created_at": { "type": "string" },
+              "updated_at": { "type": "string" },
+              "uploader": { "$ref": "common/user.schema.json" }
+            }
           }
         },
         "tarball_url": { "type": "string" },

--- a/payload-schemas/schemas/release/unpublished.schema.json
+++ b/payload-schemas/schemas/release/unpublished.schema.json
@@ -45,41 +45,37 @@
         "assets": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "url",
-                  "browser_download_url",
-                  "id",
-                  "node_id",
-                  "name",
-                  "label",
-                  "state",
-                  "content_type",
-                  "size",
-                  "download_count",
-                  "created_at",
-                  "updated_at",
-                  "creator"
-                ],
-                "properties": {
-                  "url": { "type": "string" },
-                  "browser_download_url": { "type": "string" },
-                  "id": { "type": "integer" },
-                  "node_id": { "type": "string" },
-                  "name": { "type": "string" },
-                  "label": { "type": "string" },
-                  "state": { "type": "string" },
-                  "content_type": { "type": "string" },
-                  "size": { "type": "integer" },
-                  "download_count": { "type": "integer" },
-                  "created_at": { "type": "string" },
-                  "updated_at": { "type": "string" },
-                  "uploader": { "$ref": "common/user.schema.json" }
-                }
-              }
-            ]
+            "type": "object",
+            "required": [
+              "url",
+              "browser_download_url",
+              "id",
+              "node_id",
+              "name",
+              "label",
+              "state",
+              "content_type",
+              "size",
+              "download_count",
+              "created_at",
+              "updated_at",
+              "creator"
+            ],
+            "properties": {
+              "url": { "type": "string" },
+              "browser_download_url": { "type": "string" },
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "name": { "type": "string" },
+              "label": { "type": "string" },
+              "state": { "type": "string" },
+              "content_type": { "type": "string" },
+              "size": { "type": "integer" },
+              "download_count": { "type": "integer" },
+              "created_at": { "type": "string" },
+              "updated_at": { "type": "string" },
+              "uploader": { "$ref": "common/user.schema.json" }
+            }
           }
         },
         "tarball_url": { "type": "string" },

--- a/payload-schemas/schemas/security_advisory/performed.schema.json
+++ b/payload-schemas/schemas/security_advisory/performed.schema.json
@@ -27,30 +27,22 @@
         "identifiers": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["value", "type"],
-                "properties": {
-                  "value": { "type": "string" },
-                  "type": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["value", "type"],
+            "properties": {
+              "value": { "type": "string" },
+              "type": { "type": "string" }
+            },
+            "additionalProperties": false
           }
         },
         "references": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["url"],
-                "properties": { "url": { "type": "string" } },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["url"],
+            "properties": { "url": { "type": "string" } },
+            "additionalProperties": false
           }
         },
         "published_at": { "type": "string" },
@@ -59,42 +51,38 @@
         "vulnerabilities": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
+            "type": "object",
+            "required": [
+              "package",
+              "severity",
+              "vulnerable_version_range",
+              "first_patched_version"
+            ],
+            "properties": {
+              "package": {
                 "type": "object",
-                "required": [
-                  "package",
-                  "severity",
-                  "vulnerable_version_range",
-                  "first_patched_version"
-                ],
+                "required": ["ecosystem", "name"],
                 "properties": {
-                  "package": {
-                    "type": "object",
-                    "required": ["ecosystem", "name"],
-                    "properties": {
-                      "ecosystem": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  },
-                  "severity": { "type": "string" },
-                  "vulnerable_version_range": { "type": "string" },
-                  "first_patched_version": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "required": ["identifier"],
-                        "properties": { "identifier": { "type": "string" } },
-                        "additionalProperties": false
-                      },
-                      { "type": "null" }
-                    ]
-                  }
+                  "ecosystem": { "type": "string" },
+                  "name": { "type": "string" }
                 },
                 "additionalProperties": false
+              },
+              "severity": { "type": "string" },
+              "vulnerable_version_range": { "type": "string" },
+              "first_patched_version": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": ["identifier"],
+                    "properties": { "identifier": { "type": "string" } },
+                    "additionalProperties": false
+                  },
+                  { "type": "null" }
+                ]
               }
-            ]
+            },
+            "additionalProperties": false
           }
         }
       },

--- a/payload-schemas/schemas/security_advisory/published.schema.json
+++ b/payload-schemas/schemas/security_advisory/published.schema.json
@@ -27,30 +27,22 @@
         "identifiers": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["value", "type"],
-                "properties": {
-                  "value": { "type": "string" },
-                  "type": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["value", "type"],
+            "properties": {
+              "value": { "type": "string" },
+              "type": { "type": "string" }
+            },
+            "additionalProperties": false
           }
         },
         "references": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["url"],
-                "properties": { "url": { "type": "string" } },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["url"],
+            "properties": { "url": { "type": "string" } },
+            "additionalProperties": false
           }
         },
         "published_at": { "type": "string" },
@@ -59,42 +51,38 @@
         "vulnerabilities": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
+            "type": "object",
+            "required": [
+              "package",
+              "severity",
+              "vulnerable_version_range",
+              "first_patched_version"
+            ],
+            "properties": {
+              "package": {
                 "type": "object",
-                "required": [
-                  "package",
-                  "severity",
-                  "vulnerable_version_range",
-                  "first_patched_version"
-                ],
+                "required": ["ecosystem", "name"],
                 "properties": {
-                  "package": {
-                    "type": "object",
-                    "required": ["ecosystem", "name"],
-                    "properties": {
-                      "ecosystem": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  },
-                  "severity": { "type": "string" },
-                  "vulnerable_version_range": { "type": "string" },
-                  "first_patched_version": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "required": ["identifier"],
-                        "properties": { "identifier": { "type": "string" } },
-                        "additionalProperties": false
-                      },
-                      { "type": "null" }
-                    ]
-                  }
+                  "ecosystem": { "type": "string" },
+                  "name": { "type": "string" }
                 },
                 "additionalProperties": false
+              },
+              "severity": { "type": "string" },
+              "vulnerable_version_range": { "type": "string" },
+              "first_patched_version": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": ["identifier"],
+                    "properties": { "identifier": { "type": "string" } },
+                    "additionalProperties": false
+                  },
+                  { "type": "null" }
+                ]
               }
-            ]
+            },
+            "additionalProperties": false
           }
         }
       },

--- a/payload-schemas/schemas/security_advisory/updated.schema.json
+++ b/payload-schemas/schemas/security_advisory/updated.schema.json
@@ -27,30 +27,22 @@
         "identifiers": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["value", "type"],
-                "properties": {
-                  "value": { "type": "string" },
-                  "type": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["value", "type"],
+            "properties": {
+              "value": { "type": "string" },
+              "type": { "type": "string" }
+            },
+            "additionalProperties": false
           }
         },
         "references": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": ["url"],
-                "properties": { "url": { "type": "string" } },
-                "additionalProperties": false
-              }
-            ]
+            "type": "object",
+            "required": ["url"],
+            "properties": { "url": { "type": "string" } },
+            "additionalProperties": false
           }
         },
         "published_at": { "type": "string" },
@@ -59,42 +51,38 @@
         "vulnerabilities": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
+            "type": "object",
+            "required": [
+              "package",
+              "severity",
+              "vulnerable_version_range",
+              "first_patched_version"
+            ],
+            "properties": {
+              "package": {
                 "type": "object",
-                "required": [
-                  "package",
-                  "severity",
-                  "vulnerable_version_range",
-                  "first_patched_version"
-                ],
+                "required": ["ecosystem", "name"],
                 "properties": {
-                  "package": {
-                    "type": "object",
-                    "required": ["ecosystem", "name"],
-                    "properties": {
-                      "ecosystem": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  },
-                  "severity": { "type": "string" },
-                  "vulnerable_version_range": { "type": "string" },
-                  "first_patched_version": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "required": ["identifier"],
-                        "properties": { "identifier": { "type": "string" } },
-                        "additionalProperties": false
-                      },
-                      { "type": "null" }
-                    ]
-                  }
+                  "ecosystem": { "type": "string" },
+                  "name": { "type": "string" }
                 },
                 "additionalProperties": false
+              },
+              "severity": { "type": "string" },
+              "vulnerable_version_range": { "type": "string" },
+              "first_patched_version": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": ["identifier"],
+                    "properties": { "identifier": { "type": "string" } },
+                    "additionalProperties": false
+                  },
+                  { "type": "null" }
+                ]
               }
-            ]
+            },
+            "additionalProperties": false
           }
         }
       },

--- a/payload-schemas/schemas/status/event.schema.json
+++ b/payload-schemas/schemas/status/event.schema.json
@@ -222,26 +222,22 @@
     "branches": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
+        "type": "object",
+        "required": ["name", "commit", "protected"],
+        "properties": {
+          "name": { "type": "string" },
+          "commit": {
             "type": "object",
-            "required": ["name", "commit", "protected"],
+            "required": ["sha", "url"],
             "properties": {
-              "name": { "type": "string" },
-              "commit": {
-                "type": "object",
-                "required": ["sha", "url"],
-                "properties": {
-                  "sha": { "type": "string" },
-                  "url": { "type": "string" }
-                },
-                "additionalProperties": false
-              },
-              "protected": { "type": "boolean" }
+              "sha": { "type": "string" },
+              "url": { "type": "string" }
             },
             "additionalProperties": false
-          }
-        ]
+          },
+          "protected": { "type": "boolean" }
+        },
+        "additionalProperties": false
       }
     },
     "created_at": { "type": "string" },


### PR DESCRIPTION
Easy peasy: `"oneOf": [<schema>]` is the same as just `<schema>` 🎉 