### PR TITLE
feat: merge simple types in `oneOf`s

### DIFF
--- a/bin/optimize-schemas.ts
+++ b/bin/optimize-schemas.ts
@@ -2,13 +2,48 @@
 
 import { strict as assert } from "assert";
 import fs from "fs";
-import { JSONSchema7 } from "json-schema";
+import {
+  JSONSchema7,
+  JSONSchema7Definition,
+  JSONSchema7TypeName,
+} from "json-schema";
 import { format } from "prettier";
 
 const payloads = "payload-schemas/schemas";
 
+const isJustType = (
+  object: JSONSchema7Definition
+): object is Pick<Required<JSONSchema7>, "type"> => {
+  if (typeof object === "boolean") {
+    return false;
+  }
+
+  return Object.keys(object).length === 1 && object.type !== undefined;
+};
+
+const ensureArray = <T>(arr: T | T[]): T[] =>
+  Array.isArray(arr) ? arr : [arr];
+
 const isJsonSchemaObject = (object: unknown): object is JSONSchema7 =>
   typeof object === "object" && object !== null && !Array.isArray(object);
+
+const mergeSimpleTypes = (
+  objects: JSONSchema7Definition[]
+): JSONSchema7Definition[] => {
+  const simpleTypes = new Set<JSONSchema7TypeName>();
+
+  return objects
+    .filter((object) => {
+      if (isJustType(object)) {
+        ensureArray(object.type).forEach((type) => simpleTypes.add(type));
+
+        return false;
+      }
+
+      return true;
+    })
+    .concat({ type: Array.from(simpleTypes) });
+};
 
 fs.readdirSync(payloads).forEach((event) => {
   fs.readdirSync(`${payloads}/${event}`).forEach((schema) => {
@@ -31,9 +66,13 @@ fs.readdirSync(payloads).forEach((event) => {
             delete value.anyOf;
           }
 
-          // "oneOf" is redundant if it's only got one schema
-          if (value.oneOf && value.oneOf.length === 1) {
-            return value.oneOf[0];
+          if (value.oneOf) {
+            value.oneOf = mergeSimpleTypes(value.oneOf);
+
+            // "oneOf" is redundant if it's only got one schema
+            if (value.oneOf.length === 1) {
+              return value.oneOf[0];
+            }
           }
 
           return value;

--- a/payload-schemas/schemas/check_run/completed.schema.json
+++ b/payload-schemas/schemas/check_run/completed.schema.json
@@ -37,7 +37,6 @@
         },
         "conclusion": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -49,11 +48,12 @@
                 "action_required",
                 "stale"
               ]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "started_at": { "type": "string" },
-        "completed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "completed_at": { "type": ["null", "string"] },
         "output": {
           "type": "object",
           "required": [
@@ -63,9 +63,9 @@
             "annotations_url"
           ],
           "properties": {
-            "title": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-            "summary": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-            "text": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "title": { "type": ["null", "string"] },
+            "summary": { "type": ["null", "string"] },
+            "text": { "type": ["null", "string"] },
             "annotations_count": { "type": "integer" },
             "annotations_url": { "type": "string" }
           },
@@ -91,14 +91,10 @@
           "properties": {
             "id": { "type": "integer" },
             "node_id": { "type": "string" },
-            "head_branch": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "head_branch": { "type": ["null", "string"] },
             "head_sha": { "type": "string" },
             "status": { "type": "string" },
-            "conclusion": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "conclusion": { "type": ["null", "string"] },
             "url": { "type": "string" },
             "before": { "type": "string" },
             "after": { "type": "string" },
@@ -172,9 +168,7 @@
                 "node_id": { "type": "string" },
                 "owner": { "$ref": "common/user.schema.json" },
                 "name": { "type": "string" },
-                "description": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                },
+                "description": { "type": ["null", "string"] },
                 "external_url": { "type": "string" },
                 "html_url": { "type": "string" },
                 "created_at": { "type": "string" },
@@ -269,9 +263,7 @@
             "node_id": { "type": "string" },
             "owner": { "$ref": "common/user.schema.json" },
             "name": { "type": "string" },
-            "description": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "description": { "type": ["null", "string"] },
             "external_url": { "type": "string" },
             "html_url": { "type": "string" },
             "created_at": { "type": "string" },
@@ -394,12 +386,12 @@
     },
     "requested_action": {
       "oneOf": [
-        { "type": "null" },
         {
           "type": "object",
           "properties": { "identifier": { "type": "string" } },
           "additionalProperties": false
-        }
+        },
+        { "type": ["null"] }
       ]
     },
     "repository": { "$ref": "common/repository.schema.json" },

--- a/payload-schemas/schemas/check_run/created.schema.json
+++ b/payload-schemas/schemas/check_run/created.schema.json
@@ -37,7 +37,6 @@
         },
         "conclusion": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -49,11 +48,12 @@
                 "action_required",
                 "stale"
               ]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "started_at": { "type": "string" },
-        "completed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "completed_at": { "type": ["null", "string"] },
         "output": {
           "type": "object",
           "required": [
@@ -63,9 +63,9 @@
             "annotations_url"
           ],
           "properties": {
-            "title": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-            "summary": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-            "text": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "title": { "type": ["null", "string"] },
+            "summary": { "type": ["null", "string"] },
+            "text": { "type": ["null", "string"] },
             "annotations_count": { "type": "integer" },
             "annotations_url": { "type": "string" }
           },
@@ -91,14 +91,10 @@
           "properties": {
             "id": { "type": "integer" },
             "node_id": { "type": "string" },
-            "head_branch": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "head_branch": { "type": ["null", "string"] },
             "head_sha": { "type": "string" },
             "status": { "type": "string" },
-            "conclusion": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "conclusion": { "type": ["null", "string"] },
             "url": { "type": "string" },
             "before": { "type": "string" },
             "after": { "type": "string" },
@@ -172,9 +168,7 @@
                 "node_id": { "type": "string" },
                 "owner": { "$ref": "common/user.schema.json" },
                 "name": { "type": "string" },
-                "description": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                },
+                "description": { "type": ["null", "string"] },
                 "external_url": { "type": "string" },
                 "html_url": { "type": "string" },
                 "created_at": { "type": "string" },
@@ -269,9 +263,7 @@
             "node_id": { "type": "string" },
             "owner": { "$ref": "common/user.schema.json" },
             "name": { "type": "string" },
-            "description": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "description": { "type": ["null", "string"] },
             "external_url": { "type": "string" },
             "html_url": { "type": "string" },
             "created_at": { "type": "string" },
@@ -394,11 +386,11 @@
     },
     "requested_action": {
       "oneOf": [
-        { "type": "null" },
         {
           "type": "object",
           "properties": { "identifier": { "type": "string" } }
-        }
+        },
+        { "type": ["null"] }
       ]
     },
     "repository": { "$ref": "common/repository.schema.json" },

--- a/payload-schemas/schemas/check_run/requested_action.schema.json
+++ b/payload-schemas/schemas/check_run/requested_action.schema.json
@@ -37,7 +37,6 @@
         },
         "conclusion": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -49,11 +48,12 @@
                 "action_required",
                 "stale"
               ]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "started_at": { "type": "string" },
-        "completed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "completed_at": { "type": ["null", "string"] },
         "output": {
           "type": "object",
           "required": [
@@ -63,9 +63,9 @@
             "annotations_url"
           ],
           "properties": {
-            "title": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-            "summary": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-            "text": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "title": { "type": ["null", "string"] },
+            "summary": { "type": ["null", "string"] },
+            "text": { "type": ["null", "string"] },
             "annotations_count": { "type": "integer" },
             "annotations_url": { "type": "string" }
           },
@@ -91,14 +91,10 @@
           "properties": {
             "id": { "type": "integer" },
             "node_id": { "type": "string" },
-            "head_branch": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "head_branch": { "type": ["null", "string"] },
             "head_sha": { "type": "string" },
             "status": { "type": "string" },
-            "conclusion": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "conclusion": { "type": ["null", "string"] },
             "url": { "type": "string" },
             "before": { "type": "string" },
             "after": { "type": "string" },
@@ -172,9 +168,7 @@
                 "node_id": { "type": "string" },
                 "owner": { "$ref": "common/user.schema.json" },
                 "name": { "type": "string" },
-                "description": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                },
+                "description": { "type": ["null", "string"] },
                 "external_url": { "type": "string" },
                 "html_url": { "type": "string" },
                 "created_at": { "type": "string" },
@@ -269,9 +263,7 @@
             "node_id": { "type": "string" },
             "owner": { "$ref": "common/user.schema.json" },
             "name": { "type": "string" },
-            "description": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "description": { "type": ["null", "string"] },
             "external_url": { "type": "string" },
             "html_url": { "type": "string" },
             "created_at": { "type": "string" },
@@ -394,11 +386,11 @@
     },
     "requested_action": {
       "oneOf": [
-        { "type": "null" },
         {
           "type": "object",
           "properties": { "identifier": { "type": "string" } }
-        }
+        },
+        { "type": ["null"] }
       ]
     },
     "repository": { "$ref": "common/repository.schema.json" },

--- a/payload-schemas/schemas/check_run/rerequested.schema.json
+++ b/payload-schemas/schemas/check_run/rerequested.schema.json
@@ -37,7 +37,6 @@
         },
         "conclusion": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -49,11 +48,12 @@
                 "action_required",
                 "stale"
               ]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "started_at": { "type": "string" },
-        "completed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "completed_at": { "type": ["null", "string"] },
         "output": {
           "type": "object",
           "required": [
@@ -63,9 +63,9 @@
             "annotations_url"
           ],
           "properties": {
-            "title": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-            "summary": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-            "text": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+            "title": { "type": ["null", "string"] },
+            "summary": { "type": ["null", "string"] },
+            "text": { "type": ["null", "string"] },
             "annotations_count": { "type": "integer" },
             "annotations_url": { "type": "string" }
           },
@@ -91,14 +91,10 @@
           "properties": {
             "id": { "type": "integer" },
             "node_id": { "type": "string" },
-            "head_branch": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "head_branch": { "type": ["null", "string"] },
             "head_sha": { "type": "string" },
             "status": { "type": "string" },
-            "conclusion": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "conclusion": { "type": ["null", "string"] },
             "url": { "type": "string" },
             "before": { "type": "string" },
             "after": { "type": "string" },
@@ -172,9 +168,7 @@
                 "node_id": { "type": "string" },
                 "owner": { "$ref": "common/user.schema.json" },
                 "name": { "type": "string" },
-                "description": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                },
+                "description": { "type": ["null", "string"] },
                 "external_url": { "type": "string" },
                 "html_url": { "type": "string" },
                 "created_at": { "type": "string" },
@@ -269,9 +263,7 @@
             "node_id": { "type": "string" },
             "owner": { "$ref": "common/user.schema.json" },
             "name": { "type": "string" },
-            "description": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "description": { "type": ["null", "string"] },
             "external_url": { "type": "string" },
             "html_url": { "type": "string" },
             "created_at": { "type": "string" },
@@ -394,11 +386,11 @@
     },
     "requested_action": {
       "oneOf": [
-        { "type": "null" },
         {
           "type": "object",
           "properties": { "identifier": { "type": "string" } }
-        }
+        },
+        { "type": ["null"] }
       ]
     },
     "repository": { "$ref": "common/repository.schema.json" },

--- a/payload-schemas/schemas/check_suite/completed.schema.json
+++ b/payload-schemas/schemas/check_suite/completed.schema.json
@@ -28,20 +28,19 @@
       "properties": {
         "id": { "type": "integer" },
         "node_id": { "type": "string" },
-        "head_branch": { "oneOf": [{ "type": "string" }, { "type": "null" }] },
+        "head_branch": { "type": ["string", "null"] },
         "head_sha": { "type": "string" },
         "status": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["requested", "in_progress", "completed", "queued"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "conclusion": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -53,7 +52,8 @@
                 "action_required",
                 "stale"
               ]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "url": { "type": "string" },

--- a/payload-schemas/schemas/check_suite/requested.schema.json
+++ b/payload-schemas/schemas/check_suite/requested.schema.json
@@ -28,20 +28,19 @@
       "properties": {
         "id": { "type": "integer" },
         "node_id": { "type": "string" },
-        "head_branch": { "oneOf": [{ "type": "string" }, { "type": "null" }] },
+        "head_branch": { "type": ["string", "null"] },
         "head_sha": { "type": "string" },
         "status": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["requested", "in_progress", "completed", "queued"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "conclusion": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -53,7 +52,8 @@
                 "action_required",
                 "stale"
               ]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "url": { "type": "string" },

--- a/payload-schemas/schemas/check_suite/rerequested.schema.json
+++ b/payload-schemas/schemas/check_suite/rerequested.schema.json
@@ -28,20 +28,19 @@
       "properties": {
         "id": { "type": "integer" },
         "node_id": { "type": "string" },
-        "head_branch": { "oneOf": [{ "type": "string" }, { "type": "null" }] },
+        "head_branch": { "type": ["string", "null"] },
         "head_sha": { "type": "string" },
         "status": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["requested", "in_progress", "completed", "queued"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "conclusion": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": [
@@ -53,7 +52,8 @@
                 "action_required",
                 "stale"
               ]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "url": { "type": "string" },

--- a/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
@@ -48,10 +48,8 @@
         },
         "state": { "type": "string" },
         "dismissed_by": { "type": "null" },
-        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "dismissed_reason": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "dismissed_at": { "type": ["null", "string"] },
+        "dismissed_reason": { "type": ["null", "string"] },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],

--- a/payload-schemas/schemas/code_scanning_alert/closed_by_user.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/closed_by_user.schema.json
@@ -48,10 +48,8 @@
         },
         "state": { "type": "string" },
         "dismissed_by": { "type": "null" },
-        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "dismissed_reason": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "dismissed_at": { "type": ["null", "string"] },
+        "dismissed_reason": { "type": ["null", "string"] },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],

--- a/payload-schemas/schemas/code_scanning_alert/created.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/created.schema.json
@@ -48,10 +48,8 @@
         },
         "state": { "type": "string" },
         "dismissed_by": { "type": "null" },
-        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "dismissed_reason": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "dismissed_at": { "type": ["null", "string"] },
+        "dismissed_reason": { "type": ["null", "string"] },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],

--- a/payload-schemas/schemas/code_scanning_alert/fixed.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/fixed.schema.json
@@ -48,10 +48,8 @@
         },
         "state": { "type": "string" },
         "dismissed_by": { "type": "null" },
-        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "dismissed_reason": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "dismissed_at": { "type": ["null", "string"] },
+        "dismissed_reason": { "type": ["null", "string"] },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],

--- a/payload-schemas/schemas/code_scanning_alert/reopened.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/reopened.schema.json
@@ -48,10 +48,8 @@
         },
         "state": { "type": "string" },
         "dismissed_by": { "type": "null" },
-        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "dismissed_reason": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "dismissed_at": { "type": ["null", "string"] },
+        "dismissed_reason": { "type": ["null", "string"] },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],

--- a/payload-schemas/schemas/code_scanning_alert/reopened_by_user.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/reopened_by_user.schema.json
@@ -48,10 +48,8 @@
         },
         "state": { "type": "string" },
         "dismissed_by": { "type": "null" },
-        "dismissed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "dismissed_reason": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "dismissed_at": { "type": ["null", "string"] },
+        "dismissed_reason": { "type": ["null", "string"] },
         "rule": {
           "type": "object",
           "required": ["id", "severity", "description"],

--- a/payload-schemas/schemas/common/repository.schema.json
+++ b/payload-schemas/schemas/common/repository.schema.json
@@ -107,8 +107,8 @@
       "properties": {
         "login": { "type": "string" },
         "id": { "type": "integer" },
-        "name": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "email": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "name": { "type": ["null", "string"] },
+        "email": { "type": ["null", "string"] },
         "node_id": { "type": "string" },
         "avatar_url": { "type": "string" },
         "gravatar_id": { "type": "string" },
@@ -129,7 +129,7 @@
       "additionalProperties": false
     },
     "html_url": { "type": "string" },
-    "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "description": { "type": ["null", "string"] },
     "fork": { "type": "boolean" },
     "url": { "type": "string" },
     "forks_url": { "type": "string" },
@@ -168,32 +168,30 @@
     "labels_url": { "type": "string" },
     "releases_url": { "type": "string" },
     "deployments_url": { "type": "string" },
-    "created_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+    "created_at": { "type": ["integer", "string"] },
     "updated_at": { "type": "string" },
-    "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+    "pushed_at": { "type": ["integer", "string"] },
     "git_url": { "type": "string" },
     "ssh_url": { "type": "string" },
     "clone_url": { "type": "string" },
     "svn_url": { "type": "string" },
-    "homepage": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "homepage": { "type": ["null", "string"] },
     "size": { "type": "integer" },
     "stargazers_count": { "type": "integer" },
     "watchers_count": { "type": "integer" },
-    "language": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "language": { "type": ["null", "string"] },
     "has_issues": { "type": "boolean" },
     "has_projects": { "type": "boolean" },
     "has_downloads": { "type": "boolean" },
     "has_wiki": { "type": "boolean" },
     "has_pages": { "type": "boolean" },
     "forks_count": { "type": "integer" },
-    "mirror_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "mirror_url": { "type": ["null", "string"] },
     "archived": { "type": "boolean" },
     "disabled": { "type": "boolean" },
     "open_issues_count": { "type": "integer" },
     "license": {
       "oneOf": [
-        { "type": "null" },
-        { "type": "string" },
         {
           "type": "object",
           "required": ["key", "name", "spdx_id", "url", "node_id"],
@@ -205,7 +203,8 @@
             "node_id": { "type": "string" }
           },
           "additionalProperties": false
-        }
+        },
+        { "type": ["null", "string"] }
       ]
     },
     "forks": { "type": "integer" },

--- a/payload-schemas/schemas/create/event.schema.json
+++ b/payload-schemas/schemas/create/event.schema.json
@@ -15,7 +15,7 @@
     "ref": { "type": "string" },
     "ref_type": { "type": "string", "enum": ["tag", "branch"] },
     "master_branch": { "type": "string" },
-    "description": { "oneOf": [{ "type": "string" }, { "type": "null" }] },
+    "description": { "type": ["string", "null"] },
     "pusher_type": { "type": "string" },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/fork/event.schema.json
+++ b/payload-schemas/schemas/fork/event.schema.json
@@ -89,7 +89,7 @@
         "private": { "type": "boolean" },
         "owner": { "$ref": "common/user.schema.json" },
         "html_url": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "fork": { "type": "boolean", "enum": [true] },
         "url": { "type": "string" },
         "forks_url": { "type": "string" },
@@ -128,34 +128,30 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": {
-          "oneOf": [{ "type": "integer" }, { "type": "string" }]
-        },
+        "created_at": { "type": ["integer", "string"] },
         "updated_at": { "type": "string" },
-        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+        "pushed_at": { "type": ["integer", "string"] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },
         "svn_url": { "type": "string" },
-        "homepage": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "homepage": { "type": ["null", "string"] },
         "size": { "type": "integer" },
         "stargazers_count": { "type": "integer" },
         "watchers_count": { "type": "integer" },
-        "language": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "language": { "type": ["null", "string"] },
         "has_issues": { "type": "boolean" },
         "has_projects": { "type": "boolean" },
         "has_downloads": { "type": "boolean" },
         "has_wiki": { "type": "boolean" },
         "has_pages": { "type": "boolean" },
         "forks_count": { "type": "integer" },
-        "mirror_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "mirror_url": { "type": ["null", "string"] },
         "archived": { "type": "boolean" },
         "disabled": { "type": "boolean" },
         "open_issues_count": { "type": "integer" },
         "license": {
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" },
             {
               "type": "object",
               "required": ["key", "name", "spdx_id", "url", "node_id"],
@@ -167,7 +163,8 @@
                 "node_id": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null", "string"] }
           ]
         },
         "forks": { "type": "integer" },

--- a/payload-schemas/schemas/installation/created.schema.json
+++ b/payload-schemas/schemas/installation/created.schema.json
@@ -108,13 +108,11 @@
         "events": { "type": "array", "items": { "type": "string" } },
         "created_at": { "type": "integer" },
         "updated_at": { "type": "integer" },
-        "single_file_name": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "single_file_name": { "type": ["null", "string"] },
         "has_multiple_single_files": { "type": "boolean" },
         "single_file_paths": { "type": "array", "items": {} },
-        "suspended_by": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "suspended_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "suspended_by": { "type": ["null", "string"] },
+        "suspended_at": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/installation/deleted.schema.json
+++ b/payload-schemas/schemas/installation/deleted.schema.json
@@ -108,13 +108,11 @@
         "events": { "type": "array", "items": { "type": "string" } },
         "created_at": { "type": "integer" },
         "updated_at": { "type": "integer" },
-        "single_file_name": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "single_file_name": { "type": ["null", "string"] },
         "has_multiple_single_files": { "type": "boolean" },
         "single_file_paths": { "type": "array", "items": {} },
-        "suspended_by": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "suspended_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "suspended_by": { "type": ["null", "string"] },
+        "suspended_at": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/installation/new_permissions_accepted.schema.json
+++ b/payload-schemas/schemas/installation/new_permissions_accepted.schema.json
@@ -108,13 +108,11 @@
         "events": { "type": "array", "items": { "type": "string" } },
         "created_at": { "type": "integer" },
         "updated_at": { "type": "integer" },
-        "single_file_name": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "single_file_name": { "type": ["null", "string"] },
         "has_multiple_single_files": { "type": "boolean" },
         "single_file_paths": { "type": "array", "items": {} },
-        "suspended_by": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "suspended_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "suspended_by": { "type": ["null", "string"] },
+        "suspended_at": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/installation/suspended.schema.json
+++ b/payload-schemas/schemas/installation/suspended.schema.json
@@ -108,9 +108,7 @@
         "events": { "type": "array", "items": { "type": "string" } },
         "created_at": { "type": "integer" },
         "updated_at": { "type": "integer" },
-        "single_file_name": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "single_file_name": { "type": ["null", "string"] },
         "has_multiple_single_files": { "type": "boolean" },
         "single_file_paths": { "type": "array", "items": {} },
         "suspended_by": { "type": "string" },

--- a/payload-schemas/schemas/installation/unsuspended.schema.json
+++ b/payload-schemas/schemas/installation/unsuspended.schema.json
@@ -108,9 +108,7 @@
         "events": { "type": "array", "items": { "type": "string" } },
         "created_at": { "type": "integer" },
         "updated_at": { "type": "integer" },
-        "single_file_name": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "single_file_name": { "type": ["null", "string"] },
         "has_multiple_single_files": { "type": "boolean" },
         "single_file_paths": { "type": "array", "items": {} },
         "suspended_by": { "type": "null" },

--- a/payload-schemas/schemas/installation_repositories/added.schema.json
+++ b/payload-schemas/schemas/installation_repositories/added.schema.json
@@ -114,9 +114,7 @@
         "events": { "type": "array", "items": {} },
         "created_at": { "type": "integer" },
         "updated_at": { "type": "integer" },
-        "single_file_name": {
-          "oneOf": [{ "type": "string" }, { "type": "null" }]
-        }
+        "single_file_name": { "type": ["string", "null"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/installation_repositories/removed.schema.json
+++ b/payload-schemas/schemas/installation_repositories/removed.schema.json
@@ -114,9 +114,7 @@
         "events": { "type": "array", "items": {} },
         "created_at": { "type": "integer" },
         "updated_at": { "type": "integer" },
-        "single_file_name": {
-          "oneOf": [{ "type": "string" }, { "type": "null" }]
-        }
+        "single_file_name": { "type": ["string", "null"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/issue_comment/created.schema.json
+++ b/payload-schemas/schemas/issue_comment/created.schema.json
@@ -64,7 +64,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -129,11 +129,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "body": { "type": "string" }

--- a/payload-schemas/schemas/issue_comment/deleted.schema.json
+++ b/payload-schemas/schemas/issue_comment/deleted.schema.json
@@ -64,7 +64,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -129,11 +129,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "body": { "type": "string" }

--- a/payload-schemas/schemas/issue_comment/edited.schema.json
+++ b/payload-schemas/schemas/issue_comment/edited.schema.json
@@ -76,7 +76,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -141,11 +141,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "body": { "type": "string" }

--- a/payload-schemas/schemas/issues/assigned.schema.json
+++ b/payload-schemas/schemas/issues/assigned.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/closed.schema.json
+++ b/payload-schemas/schemas/issues/closed.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,7 +107,8 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/deleted.schema.json
+++ b/payload-schemas/schemas/issues/deleted.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/demilestoned.schema.json
+++ b/payload-schemas/schemas/issues/demilestoned.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/edited.schema.json
+++ b/payload-schemas/schemas/issues/edited.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -181,7 +181,7 @@
       "additionalProperties": false
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/labeled.schema.json
+++ b/payload-schemas/schemas/issues/labeled.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/locked.schema.json
+++ b/payload-schemas/schemas/issues/locked.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean", "enum": [true] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -158,7 +158,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/milestoned.schema.json
+++ b/payload-schemas/schemas/issues/milestoned.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/opened.schema.json
+++ b/payload-schemas/schemas/issues/opened.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,7 +107,8 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/pinned.schema.json
+++ b/payload-schemas/schemas/issues/pinned.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/reopened.schema.json
+++ b/payload-schemas/schemas/issues/reopened.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/transferred.schema.json
+++ b/payload-schemas/schemas/issues/transferred.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/unassigned.schema.json
+++ b/payload-schemas/schemas/issues/unassigned.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/unlabeled.schema.json
+++ b/payload-schemas/schemas/issues/unlabeled.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/unlocked.schema.json
+++ b/payload-schemas/schemas/issues/unlocked.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean", "enum": [false] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -155,7 +155,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/issues/unpinned.schema.json
+++ b/payload-schemas/schemas/issues/unpinned.schema.json
@@ -60,7 +60,7 @@
         "state": { "type": "string", "enum": ["open", "closed"] },
         "locked": { "type": "boolean" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -68,7 +68,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -108,13 +107,14 @@
                 "closed_at": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "closed_at": { "type": ["null", "string"] },
         "author_association": {
           "type": "string",
           "enum": [
@@ -130,11 +130,11 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "performed_via_github_app": { "type": "null" },
@@ -163,7 +163,7 @@
       }
     },
     "assignee": {
-      "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
     },
     "assignees": {
       "type": "array",

--- a/payload-schemas/schemas/label/created.schema.json
+++ b/payload-schemas/schemas/label/created.schema.json
@@ -15,7 +15,7 @@
         "name": { "type": "string" },
         "color": { "type": "string" },
         "default": { "type": "boolean" },
-        "description": { "oneOf": [{ "type": "string" }, { "type": "null" }] }
+        "description": { "type": ["string", "null"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/label/deleted.schema.json
+++ b/payload-schemas/schemas/label/deleted.schema.json
@@ -15,7 +15,7 @@
         "name": { "type": "string" },
         "color": { "type": "string" },
         "default": { "type": "boolean" },
-        "description": { "oneOf": [{ "type": "string" }, { "type": "null" }] }
+        "description": { "type": ["string", "null"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/label/edited.schema.json
+++ b/payload-schemas/schemas/label/edited.schema.json
@@ -15,7 +15,7 @@
         "name": { "type": "string" },
         "color": { "type": "string" },
         "default": { "type": "boolean" },
-        "description": { "oneOf": [{ "type": "string" }, { "type": "null" }] }
+        "description": { "type": ["string", "null"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/marketplace_purchase/cancelled.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/cancelled.schema.json
@@ -99,9 +99,7 @@
             "yearly_price_in_cents": { "type": "integer" },
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
-            "unit_name": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "unit_name": { "type": ["null", "string"] },
             "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
@@ -157,9 +155,7 @@
             "yearly_price_in_cents": { "type": "integer" },
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
-            "unit_name": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "unit_name": { "type": ["null", "string"] },
             "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false

--- a/payload-schemas/schemas/marketplace_purchase/changed.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/changed.schema.json
@@ -99,9 +99,7 @@
             "yearly_price_in_cents": { "type": "integer" },
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
-            "unit_name": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "unit_name": { "type": ["null", "string"] },
             "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
@@ -157,9 +155,7 @@
             "yearly_price_in_cents": { "type": "integer" },
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
-            "unit_name": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "unit_name": { "type": ["null", "string"] },
             "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false

--- a/payload-schemas/schemas/marketplace_purchase/purchased.schema.json
+++ b/payload-schemas/schemas/marketplace_purchase/purchased.schema.json
@@ -99,9 +99,7 @@
             "yearly_price_in_cents": { "type": "integer" },
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
-            "unit_name": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "unit_name": { "type": ["null", "string"] },
             "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
@@ -157,9 +155,7 @@
             "yearly_price_in_cents": { "type": "integer" },
             "price_model": { "type": "string" },
             "has_free_trial": { "type": "boolean" },
-            "unit_name": {
-              "oneOf": [{ "type": "null" }, { "type": "string" }]
-            },
+            "unit_name": { "type": ["null", "string"] },
             "bullets": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false

--- a/payload-schemas/schemas/milestone/closed.schema.json
+++ b/payload-schemas/schemas/milestone/closed.schema.json
@@ -41,7 +41,7 @@
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
         "due_on": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "closed_at": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/milestone/created.schema.json
+++ b/payload-schemas/schemas/milestone/created.schema.json
@@ -41,7 +41,7 @@
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
         "due_on": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "closed_at": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/milestone/deleted.schema.json
+++ b/payload-schemas/schemas/milestone/deleted.schema.json
@@ -41,7 +41,7 @@
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
         "due_on": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "closed_at": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/milestone/edited.schema.json
+++ b/payload-schemas/schemas/milestone/edited.schema.json
@@ -65,7 +65,7 @@
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
         "due_on": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "closed_at": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/milestone/opened.schema.json
+++ b/payload-schemas/schemas/milestone/opened.schema.json
@@ -41,7 +41,7 @@
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
         "due_on": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "closed_at": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/public/event.schema.json
+++ b/payload-schemas/schemas/public/event.schema.json
@@ -88,7 +88,7 @@
         "private": { "type": "boolean", "enum": [false] },
         "owner": { "$ref": "common/user.schema.json" },
         "html_url": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "fork": { "type": "boolean" },
         "url": { "type": "string" },
         "forks_url": { "type": "string" },
@@ -127,34 +127,30 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": {
-          "oneOf": [{ "type": "integer" }, { "type": "string" }]
-        },
+        "created_at": { "type": ["integer", "string"] },
         "updated_at": { "type": "string" },
-        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+        "pushed_at": { "type": ["integer", "string"] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },
         "svn_url": { "type": "string" },
-        "homepage": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "homepage": { "type": ["null", "string"] },
         "size": { "type": "integer" },
         "stargazers_count": { "type": "integer" },
         "watchers_count": { "type": "integer" },
-        "language": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "language": { "type": ["null", "string"] },
         "has_issues": { "type": "boolean" },
         "has_projects": { "type": "boolean" },
         "has_downloads": { "type": "boolean" },
         "has_wiki": { "type": "boolean" },
         "has_pages": { "type": "boolean" },
         "forks_count": { "type": "integer" },
-        "mirror_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "mirror_url": { "type": ["null", "string"] },
         "archived": { "type": "boolean" },
         "disabled": { "type": "boolean" },
         "open_issues_count": { "type": "integer" },
         "license": {
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" },
             {
               "type": "object",
               "required": ["key", "name", "spdx_id", "url", "node_id"],
@@ -166,7 +162,8 @@
                 "node_id": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null", "string"] }
           ]
         },
         "forks": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/assigned.schema.json
+++ b/payload-schemas/schemas/pull_request/assigned.schema.json
@@ -73,13 +73,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -108,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -145,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -261,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/closed.schema.json
+++ b/payload-schemas/schemas/pull_request/closed.schema.json
@@ -74,12 +74,10 @@
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
         "closed_at": { "type": "string" },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -108,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -145,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -261,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
+++ b/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
@@ -77,7 +77,7 @@
         "merged_at": { "type": "null" },
         "merge_commit_sha": { "type": "null" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -106,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -143,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -259,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean", "enum": [true] },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/edited.schema.json
+++ b/payload-schemas/schemas/pull_request/edited.schema.json
@@ -98,13 +98,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -133,7 +131,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -170,12 +167,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -286,17 +282,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/labeled.schema.json
+++ b/payload-schemas/schemas/pull_request/labeled.schema.json
@@ -73,13 +73,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -108,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -145,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -261,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/locked.schema.json
+++ b/payload-schemas/schemas/pull_request/locked.schema.json
@@ -73,13 +73,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -108,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -145,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -265,8 +261,8 @@
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/opened.schema.json
+++ b/payload-schemas/schemas/pull_request/opened.schema.json
@@ -77,7 +77,7 @@
         "merged_at": { "type": "null" },
         "merge_commit_sha": { "type": "null" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -106,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -143,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -260,8 +258,8 @@
         "active_lock_reason": { "type": "null" },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/ready_for_review.schema.json
+++ b/payload-schemas/schemas/pull_request/ready_for_review.schema.json
@@ -77,7 +77,7 @@
         "merged_at": { "type": "null" },
         "merge_commit_sha": { "type": "null" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -106,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -143,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -259,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean", "enum": [false] },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/reopened.schema.json
+++ b/payload-schemas/schemas/pull_request/reopened.schema.json
@@ -77,7 +77,7 @@
         "merged_at": { "type": "null" },
         "merge_commit_sha": { "type": "null" },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -106,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -143,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -259,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/review_request_removed.schema.json
+++ b/payload-schemas/schemas/pull_request/review_request_removed.schema.json
@@ -73,13 +73,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -108,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -145,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -261,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/review_requested.schema.json
+++ b/payload-schemas/schemas/pull_request/review_requested.schema.json
@@ -73,13 +73,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -108,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -145,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -261,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/synchronize.schema.json
+++ b/payload-schemas/schemas/pull_request/synchronize.schema.json
@@ -73,13 +73,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -108,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -145,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -261,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/unassigned.schema.json
+++ b/payload-schemas/schemas/pull_request/unassigned.schema.json
@@ -73,13 +73,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -108,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -145,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -261,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/unlabeled.schema.json
+++ b/payload-schemas/schemas/pull_request/unlabeled.schema.json
@@ -73,13 +73,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -108,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -145,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -261,17 +257,17 @@
         },
         "active_lock_reason": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "string",
               "enum": ["resolved", "off-topic", "too heated", "spam"]
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request/unlocked.schema.json
+++ b/payload-schemas/schemas/pull_request/unlocked.schema.json
@@ -73,13 +73,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -108,7 +106,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -145,12 +142,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },
@@ -262,8 +258,8 @@
         "active_lock_reason": { "type": "null" },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },
-        "mergeable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
-        "rebaseable": { "oneOf": [{ "type": "null" }, { "type": "boolean" }] },
+        "mergeable": { "type": ["null", "boolean"] },
+        "rebaseable": { "type": ["null", "boolean"] },
         "mergeable_state": { "type": "string" },
         "merged_by": { "type": "null" },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/pull_request_review/submitted.schema.json
+++ b/payload-schemas/schemas/pull_request_review/submitted.schema.json
@@ -24,7 +24,7 @@
         "id": { "type": "integer" },
         "node_id": { "type": "string" },
         "user": { "$ref": "common/user.schema.json" },
-        "body": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "body": { "type": ["null", "string"] },
         "commit_id": { "type": "string" },
         "submitted_at": { "type": "string" },
         "state": { "type": "string" },
@@ -118,13 +118,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -150,7 +148,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -187,12 +184,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },

--- a/payload-schemas/schemas/pull_request_review_comment/created.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/created.schema.json
@@ -138,13 +138,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -170,7 +168,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -207,12 +204,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },

--- a/payload-schemas/schemas/pull_request_review_comment/deleted.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/deleted.schema.json
@@ -138,13 +138,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -170,7 +168,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -207,12 +204,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },

--- a/payload-schemas/schemas/pull_request_review_comment/edited.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/edited.schema.json
@@ -157,13 +157,11 @@
         "body": { "type": "string" },
         "created_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "closed_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merged_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-        "merge_commit_sha": {
-          "oneOf": [{ "type": "null" }, { "type": "string" }]
-        },
+        "closed_at": { "type": ["null", "string"] },
+        "merged_at": { "type": ["null", "string"] },
+        "merge_commit_sha": { "type": ["null", "string"] },
         "assignee": {
-          "oneOf": [{ "type": "null" }, { "$ref": "common/user.schema.json" }]
+          "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": ["null"] }]
         },
         "assignees": {
           "type": "array",
@@ -189,7 +187,6 @@
         },
         "milestone": {
           "oneOf": [
-            { "type": "null" },
             {
               "type": "object",
               "required": [
@@ -226,12 +223,11 @@
                 "created_at": { "type": "string" },
                 "updated_at": { "type": "string" },
                 "due_on": { "type": "string" },
-                "closed_at": {
-                  "oneOf": [{ "type": "null" }, { "type": "string" }]
-                }
+                "closed_at": { "type": ["null", "string"] }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null"] }
           ]
         },
         "commits_url": { "type": "string" },

--- a/payload-schemas/schemas/push/event.schema.json
+++ b/payload-schemas/schemas/push/event.schema.json
@@ -79,7 +79,6 @@
     },
     "head_commit": {
       "oneOf": [
-        { "type": "null" },
         {
           "type": "object",
           "required": [
@@ -127,7 +126,8 @@
             "modified": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
-        }
+        },
+        { "type": ["null"] }
       ]
     },
     "repository": { "$ref": "common/repository.schema.json" },

--- a/payload-schemas/schemas/release/created.schema.json
+++ b/payload-schemas/schemas/release/created.schema.json
@@ -80,7 +80,7 @@
         },
         "tarball_url": { "type": "string" },
         "zipball_url": { "type": "string" },
-        "body": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "body": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/release/deleted.schema.json
+++ b/payload-schemas/schemas/release/deleted.schema.json
@@ -80,7 +80,7 @@
         },
         "tarball_url": { "type": "string" },
         "zipball_url": { "type": "string" },
-        "body": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "body": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/release/edited.schema.json
+++ b/payload-schemas/schemas/release/edited.schema.json
@@ -98,7 +98,7 @@
         },
         "tarball_url": { "type": "string" },
         "zipball_url": { "type": "string" },
-        "body": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "body": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/release/prereleased.schema.json
+++ b/payload-schemas/schemas/release/prereleased.schema.json
@@ -80,7 +80,7 @@
         },
         "tarball_url": { "type": "string" },
         "zipball_url": { "type": "string" },
-        "body": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "body": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/release/published.schema.json
+++ b/payload-schemas/schemas/release/published.schema.json
@@ -80,7 +80,7 @@
         },
         "tarball_url": { "type": "string" },
         "zipball_url": { "type": "string" },
-        "body": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "body": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/release/released.schema.json
+++ b/payload-schemas/schemas/release/released.schema.json
@@ -80,7 +80,7 @@
         },
         "tarball_url": { "type": "string" },
         "zipball_url": { "type": "string" },
-        "body": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "body": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/release/unpublished.schema.json
+++ b/payload-schemas/schemas/release/unpublished.schema.json
@@ -80,7 +80,7 @@
         },
         "tarball_url": { "type": "string" },
         "zipball_url": { "type": "string" },
-        "body": { "oneOf": [{ "type": "null" }, { "type": "string" }] }
+        "body": { "type": ["null", "string"] }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/repository/archived.schema.json
+++ b/payload-schemas/schemas/repository/archived.schema.json
@@ -89,7 +89,7 @@
         "private": { "type": "boolean" },
         "owner": { "$ref": "common/user.schema.json" },
         "html_url": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "fork": { "type": "boolean" },
         "url": { "type": "string" },
         "forks_url": { "type": "string" },
@@ -128,34 +128,30 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": {
-          "oneOf": [{ "type": "integer" }, { "type": "string" }]
-        },
+        "created_at": { "type": ["integer", "string"] },
         "updated_at": { "type": "string" },
-        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+        "pushed_at": { "type": ["integer", "string"] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },
         "svn_url": { "type": "string" },
-        "homepage": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "homepage": { "type": ["null", "string"] },
         "size": { "type": "integer" },
         "stargazers_count": { "type": "integer" },
         "watchers_count": { "type": "integer" },
-        "language": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "language": { "type": ["null", "string"] },
         "has_issues": { "type": "boolean" },
         "has_projects": { "type": "boolean" },
         "has_downloads": { "type": "boolean" },
         "has_wiki": { "type": "boolean" },
         "has_pages": { "type": "boolean" },
         "forks_count": { "type": "integer" },
-        "mirror_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "mirror_url": { "type": ["null", "string"] },
         "archived": { "type": "boolean", "enum": [true] },
         "disabled": { "type": "boolean" },
         "open_issues_count": { "type": "integer" },
         "license": {
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" },
             {
               "type": "object",
               "required": ["key", "name", "spdx_id", "url", "node_id"],
@@ -167,7 +163,8 @@
                 "node_id": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null", "string"] }
           ]
         },
         "forks": { "type": "integer" },

--- a/payload-schemas/schemas/repository/privatized.schema.json
+++ b/payload-schemas/schemas/repository/privatized.schema.json
@@ -89,7 +89,7 @@
         "private": { "type": "boolean", "enum": [true] },
         "owner": { "$ref": "common/user.schema.json" },
         "html_url": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "fork": { "type": "boolean" },
         "url": { "type": "string" },
         "forks_url": { "type": "string" },
@@ -128,34 +128,30 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": {
-          "oneOf": [{ "type": "integer" }, { "type": "string" }]
-        },
+        "created_at": { "type": ["integer", "string"] },
         "updated_at": { "type": "string" },
-        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+        "pushed_at": { "type": ["integer", "string"] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },
         "svn_url": { "type": "string" },
-        "homepage": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "homepage": { "type": ["null", "string"] },
         "size": { "type": "integer" },
         "stargazers_count": { "type": "integer" },
         "watchers_count": { "type": "integer" },
-        "language": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "language": { "type": ["null", "string"] },
         "has_issues": { "type": "boolean" },
         "has_projects": { "type": "boolean" },
         "has_downloads": { "type": "boolean" },
         "has_wiki": { "type": "boolean" },
         "has_pages": { "type": "boolean" },
         "forks_count": { "type": "integer" },
-        "mirror_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "mirror_url": { "type": ["null", "string"] },
         "archived": { "type": "boolean" },
         "disabled": { "type": "boolean" },
         "open_issues_count": { "type": "integer" },
         "license": {
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" },
             {
               "type": "object",
               "required": ["key", "name", "spdx_id", "url", "node_id"],
@@ -167,7 +163,8 @@
                 "node_id": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null", "string"] }
           ]
         },
         "forks": { "type": "integer" },

--- a/payload-schemas/schemas/repository/publicized.schema.json
+++ b/payload-schemas/schemas/repository/publicized.schema.json
@@ -89,7 +89,7 @@
         "private": { "type": "boolean", "enum": [false] },
         "owner": { "$ref": "common/user.schema.json" },
         "html_url": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "fork": { "type": "boolean" },
         "url": { "type": "string" },
         "forks_url": { "type": "string" },
@@ -128,34 +128,30 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": {
-          "oneOf": [{ "type": "integer" }, { "type": "string" }]
-        },
+        "created_at": { "type": ["integer", "string"] },
         "updated_at": { "type": "string" },
-        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+        "pushed_at": { "type": ["integer", "string"] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },
         "svn_url": { "type": "string" },
-        "homepage": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "homepage": { "type": ["null", "string"] },
         "size": { "type": "integer" },
         "stargazers_count": { "type": "integer" },
         "watchers_count": { "type": "integer" },
-        "language": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "language": { "type": ["null", "string"] },
         "has_issues": { "type": "boolean" },
         "has_projects": { "type": "boolean" },
         "has_downloads": { "type": "boolean" },
         "has_wiki": { "type": "boolean" },
         "has_pages": { "type": "boolean" },
         "forks_count": { "type": "integer" },
-        "mirror_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "mirror_url": { "type": ["null", "string"] },
         "archived": { "type": "boolean" },
         "disabled": { "type": "boolean" },
         "open_issues_count": { "type": "integer" },
         "license": {
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" },
             {
               "type": "object",
               "required": ["key", "name", "spdx_id", "url", "node_id"],
@@ -167,7 +163,8 @@
                 "node_id": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null", "string"] }
           ]
         },
         "forks": { "type": "integer" },

--- a/payload-schemas/schemas/repository/unarchived.schema.json
+++ b/payload-schemas/schemas/repository/unarchived.schema.json
@@ -89,7 +89,7 @@
         "private": { "type": "boolean" },
         "owner": { "$ref": "common/user.schema.json" },
         "html_url": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "fork": { "type": "boolean" },
         "url": { "type": "string" },
         "forks_url": { "type": "string" },
@@ -128,34 +128,30 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": {
-          "oneOf": [{ "type": "integer" }, { "type": "string" }]
-        },
+        "created_at": { "type": ["integer", "string"] },
         "updated_at": { "type": "string" },
-        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+        "pushed_at": { "type": ["integer", "string"] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },
         "svn_url": { "type": "string" },
-        "homepage": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "homepage": { "type": ["null", "string"] },
         "size": { "type": "integer" },
         "stargazers_count": { "type": "integer" },
         "watchers_count": { "type": "integer" },
-        "language": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "language": { "type": ["null", "string"] },
         "has_issues": { "type": "boolean" },
         "has_projects": { "type": "boolean" },
         "has_downloads": { "type": "boolean" },
         "has_wiki": { "type": "boolean" },
         "has_pages": { "type": "boolean" },
         "forks_count": { "type": "integer" },
-        "mirror_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "mirror_url": { "type": ["null", "string"] },
         "archived": { "type": "boolean", "enum": [false] },
         "disabled": { "type": "boolean" },
         "open_issues_count": { "type": "integer" },
         "license": {
           "oneOf": [
-            { "type": "null" },
-            { "type": "string" },
             {
               "type": "object",
               "required": ["key", "name", "spdx_id", "url", "node_id"],
@@ -167,7 +163,8 @@
                 "node_id": { "type": "string" }
               },
               "additionalProperties": false
-            }
+            },
+            { "type": ["null", "string"] }
           ]
         },
         "forks": { "type": "integer" },

--- a/payload-schemas/schemas/security_advisory/performed.schema.json
+++ b/payload-schemas/schemas/security_advisory/performed.schema.json
@@ -47,7 +47,7 @@
         },
         "published_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "withdrawn_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "withdrawn_at": { "type": ["null", "string"] },
         "vulnerabilities": {
           "type": "array",
           "items": {
@@ -78,7 +78,7 @@
                     "properties": { "identifier": { "type": "string" } },
                     "additionalProperties": false
                   },
-                  { "type": "null" }
+                  { "type": ["null"] }
                 ]
               }
             },

--- a/payload-schemas/schemas/security_advisory/published.schema.json
+++ b/payload-schemas/schemas/security_advisory/published.schema.json
@@ -47,7 +47,7 @@
         },
         "published_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "withdrawn_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "withdrawn_at": { "type": ["null", "string"] },
         "vulnerabilities": {
           "type": "array",
           "items": {
@@ -78,7 +78,7 @@
                     "properties": { "identifier": { "type": "string" } },
                     "additionalProperties": false
                   },
-                  { "type": "null" }
+                  { "type": ["null"] }
                 ]
               }
             },

--- a/payload-schemas/schemas/security_advisory/updated.schema.json
+++ b/payload-schemas/schemas/security_advisory/updated.schema.json
@@ -47,7 +47,7 @@
         },
         "published_at": { "type": "string" },
         "updated_at": { "type": "string" },
-        "withdrawn_at": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "withdrawn_at": { "type": ["null", "string"] },
         "vulnerabilities": {
           "type": "array",
           "items": {
@@ -78,7 +78,7 @@
                     "properties": { "identifier": { "type": "string" } },
                     "additionalProperties": false
                   },
-                  { "type": "null" }
+                  { "type": ["null"] }
                 ]
               }
             },

--- a/payload-schemas/schemas/status/event.schema.json
+++ b/payload-schemas/schemas/status/event.schema.json
@@ -21,10 +21,10 @@
     "id": { "type": "integer" },
     "sha": { "type": "string" },
     "name": { "type": "string" },
-    "avatar_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
-    "target_url": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "avatar_url": { "type": ["null", "string"] },
+    "target_url": { "type": ["null", "string"] },
     "context": { "type": "string" },
-    "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+    "description": { "type": ["null", "string"] },
     "state": {
       "type": "string",
       "enum": ["pending", "success", "failure", "error"]
@@ -112,12 +112,8 @@
                     "valid"
                   ]
                 },
-                "signature": {
-                  "oneOf": [{ "type": "string" }, { "type": "null" }]
-                },
-                "payload": {
-                  "oneOf": [{ "type": "string" }, { "type": "null" }]
-                }
+                "signature": { "type": ["string", "null"] },
+                "payload": { "type": ["string", "null"] }
               },
               "additionalProperties": false
             }

--- a/payload-schemas/schemas/team/added_to_repository.schema.json
+++ b/payload-schemas/schemas/team/added_to_repository.schema.json
@@ -25,7 +25,7 @@
         "id": { "type": "integer" },
         "node_id": { "type": "string" },
         "slug": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "privacy": { "type": "string" },
         "url": { "type": "string" },
         "html_url": { "type": "string" },

--- a/payload-schemas/schemas/team/created.schema.json
+++ b/payload-schemas/schemas/team/created.schema.json
@@ -25,7 +25,7 @@
         "id": { "type": "integer" },
         "node_id": { "type": "string" },
         "slug": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "privacy": { "type": "string" },
         "url": { "type": "string" },
         "html_url": { "type": "string" },

--- a/payload-schemas/schemas/team/deleted.schema.json
+++ b/payload-schemas/schemas/team/deleted.schema.json
@@ -25,7 +25,7 @@
         "id": { "type": "integer" },
         "node_id": { "type": "string" },
         "slug": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "privacy": { "type": "string" },
         "url": { "type": "string" },
         "html_url": { "type": "string" },

--- a/payload-schemas/schemas/team/edited.schema.json
+++ b/payload-schemas/schemas/team/edited.schema.json
@@ -73,7 +73,7 @@
         "id": { "type": "integer" },
         "node_id": { "type": "string" },
         "slug": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "privacy": { "type": "string" },
         "url": { "type": "string" },
         "html_url": { "type": "string" },

--- a/payload-schemas/schemas/team/removed_from_repository.schema.json
+++ b/payload-schemas/schemas/team/removed_from_repository.schema.json
@@ -25,7 +25,7 @@
         "id": { "type": "integer" },
         "node_id": { "type": "string" },
         "slug": { "type": "string" },
-        "description": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "description": { "type": ["null", "string"] },
         "privacy": { "type": "string" },
         "url": { "type": "string" },
         "html_url": { "type": "string" },

--- a/payload-schemas/schemas/workflow_run/event.schema.json
+++ b/payload-schemas/schemas/workflow_run/event.schema.json
@@ -75,7 +75,7 @@
         "artifacts_url": { "type": "string" },
         "cancel_url": { "type": "string" },
         "check_suite_url": { "type": "string" },
-        "conclusion": { "oneOf": [{ "type": "null" }, { "type": "string" }] },
+        "conclusion": { "type": ["null", "string"] },
         "created_at": { "type": "string" },
         "event": { "type": "string" },
         "head_branch": { "type": "string" },


### PR DESCRIPTION
`oneOf: [{ type: "x" }, { type: "y" }]` is the same as `oneOf: [{ type: ["x", "y"] }]` if `x` and `y` are both simple types (i.e not objects, array, or enums).

We can actually merge enums, but that'll be in another PR.
Directly following this PR will be one sorting the types so they're all in consistent order, and other small tweaks.