### PR TITLE
fix: unmerge union of types that are not null

### DIFF
--- a/bin/optimize-schemas.ts
+++ b/bin/optimize-schemas.ts
@@ -2,11 +2,7 @@
 
 import { strict as assert } from "assert";
 import fs from "fs";
-import {
-  JSONSchema7,
-  JSONSchema7Definition,
-  JSONSchema7TypeName,
-} from "json-schema";
+import { JSONSchema7, JSONSchema7TypeName } from "json-schema";
 import { format } from "prettier";
 
 const JSONSchema7TypeNameOrder = [
@@ -21,19 +17,6 @@ const JSONSchema7TypeNameOrder = [
 
 const payloads = "payload-schemas/schemas";
 
-const isJustType = (
-  object: JSONSchema7Definition
-): object is Pick<Required<JSONSchema7>, "type"> => {
-  if (typeof object === "boolean") {
-    return false;
-  }
-
-  return Object.keys(object).length === 1 && object.type !== undefined;
-};
-
-const ensureArray = <T>(arr: T | T[]): T[] =>
-  Array.isArray(arr) ? arr : [arr];
-
 const isJsonSchemaObject = (object: unknown): object is JSONSchema7 =>
   typeof object === "object" && object !== null && !Array.isArray(object);
 
@@ -45,24 +28,6 @@ const standardizeTypeProperty = (
   }
 
   return JSONSchema7TypeNameOrder.filter((type) => types.includes(type));
-};
-
-const mergeSimpleTypes = (
-  objects: JSONSchema7Definition[]
-): JSONSchema7Definition[] => {
-  const simpleTypes = new Set<JSONSchema7TypeName>();
-
-  return objects
-    .filter((object) => {
-      if (isJustType(object)) {
-        ensureArray(object.type).forEach((type) => simpleTypes.add(type));
-
-        return false;
-      }
-
-      return true;
-    })
-    .concat({ type: standardizeTypeProperty(Array.from(simpleTypes)) });
 };
 
 fs.readdirSync(payloads).forEach((event) => {
@@ -91,8 +56,6 @@ fs.readdirSync(payloads).forEach((event) => {
           }
 
           if (value.oneOf) {
-            value.oneOf = mergeSimpleTypes(value.oneOf);
-
             // "oneOf" is redundant if it's only got one schema
             if (value.oneOf.length === 1) {
               return value.oneOf[0];

--- a/payload-schemas/schemas/common/repository.schema.json
+++ b/payload-schemas/schemas/common/repository.schema.json
@@ -168,9 +168,9 @@
     "labels_url": { "type": "string" },
     "releases_url": { "type": "string" },
     "deployments_url": { "type": "string" },
-    "created_at": { "type": ["string", "integer"] },
+    "created_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
     "updated_at": { "type": "string" },
-    "pushed_at": { "type": ["string", "integer"] },
+    "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
     "git_url": { "type": "string" },
     "ssh_url": { "type": "string" },
     "clone_url": { "type": "string" },
@@ -204,7 +204,8 @@
           },
           "additionalProperties": false
         },
-        { "type": ["string", "null"] }
+        { "type": "string" },
+        { "type": "null" }
       ]
     },
     "forks": { "type": "integer" },

--- a/payload-schemas/schemas/fork/event.schema.json
+++ b/payload-schemas/schemas/fork/event.schema.json
@@ -128,9 +128,11 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": { "type": ["string", "integer"] },
+        "created_at": {
+          "oneOf": [{ "type": "integer" }, { "type": "string" }]
+        },
         "updated_at": { "type": "string" },
-        "pushed_at": { "type": ["string", "integer"] },
+        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },

--- a/payload-schemas/schemas/public/event.schema.json
+++ b/payload-schemas/schemas/public/event.schema.json
@@ -127,9 +127,11 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": { "type": ["string", "integer"] },
+        "created_at": {
+          "oneOf": [{ "type": "integer" }, { "type": "string" }]
+        },
         "updated_at": { "type": "string" },
-        "pushed_at": { "type": ["string", "integer"] },
+        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },

--- a/payload-schemas/schemas/repository/archived.schema.json
+++ b/payload-schemas/schemas/repository/archived.schema.json
@@ -128,9 +128,11 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": { "type": ["string", "integer"] },
+        "created_at": {
+          "oneOf": [{ "type": "integer" }, { "type": "string" }]
+        },
         "updated_at": { "type": "string" },
-        "pushed_at": { "type": ["string", "integer"] },
+        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },

--- a/payload-schemas/schemas/repository/privatized.schema.json
+++ b/payload-schemas/schemas/repository/privatized.schema.json
@@ -128,9 +128,11 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": { "type": ["string", "integer"] },
+        "created_at": {
+          "oneOf": [{ "type": "integer" }, { "type": "string" }]
+        },
         "updated_at": { "type": "string" },
-        "pushed_at": { "type": ["string", "integer"] },
+        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },

--- a/payload-schemas/schemas/repository/publicized.schema.json
+++ b/payload-schemas/schemas/repository/publicized.schema.json
@@ -128,9 +128,11 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": { "type": ["string", "integer"] },
+        "created_at": {
+          "oneOf": [{ "type": "integer" }, { "type": "string" }]
+        },
         "updated_at": { "type": "string" },
-        "pushed_at": { "type": ["string", "integer"] },
+        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },

--- a/payload-schemas/schemas/repository/unarchived.schema.json
+++ b/payload-schemas/schemas/repository/unarchived.schema.json
@@ -128,9 +128,11 @@
         "labels_url": { "type": "string" },
         "releases_url": { "type": "string" },
         "deployments_url": { "type": "string" },
-        "created_at": { "type": ["string", "integer"] },
+        "created_at": {
+          "oneOf": [{ "type": "integer" }, { "type": "string" }]
+        },
         "updated_at": { "type": "string" },
-        "pushed_at": { "type": ["string", "integer"] },
+        "pushed_at": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
         "git_url": { "type": "string" },
         "ssh_url": { "type": "string" },
         "clone_url": { "type": "string" },


### PR DESCRIPTION
Reverts part of #271, and removed the implementation of that optimization - I'll be landing a better one that merges just `null` straight afterwards.

The reason for the revert is that while its an optimization on paper, it's considered [not strict by ajv](https://github.com/ajv-validator/ajv/blob/master/docs/strict-mode.md#strict-types) due to it being a confusing union, which I agree with.