### PR TITLE
refactor: merge `null` unions in schemas

### DIFF
--- a/payload-schemas/schemas/check_run/completed.schema.json
+++ b/payload-schemas/schemas/check_run/completed.schema.json
@@ -36,20 +36,16 @@
           "enum": ["queued", "in_progress", "completed"]
         },
         "conclusion": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "success",
-                "failure",
-                "neutral",
-                "cancelled",
-                "timed_out",
-                "action_required",
-                "stale"
-              ]
-            },
-            { "type": "null" }
+          "type": ["string", "null"],
+          "enum": [
+            "success",
+            "failure",
+            "neutral",
+            "cancelled",
+            "timed_out",
+            "action_required",
+            "stale",
+            null
           ]
         },
         "started_at": { "type": "string" },
@@ -385,14 +381,9 @@
       "additionalProperties": false
     },
     "requested_action": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": { "identifier": { "type": "string" } },
-          "additionalProperties": false
-        },
-        { "type": "null" }
-      ]
+      "type": ["object", "null"],
+      "properties": { "identifier": { "type": "string" } },
+      "additionalProperties": false
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/check_run/created.schema.json
+++ b/payload-schemas/schemas/check_run/created.schema.json
@@ -36,20 +36,16 @@
           "enum": ["queued", "in_progress", "completed"]
         },
         "conclusion": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "success",
-                "failure",
-                "neutral",
-                "cancelled",
-                "timed_out",
-                "action_required",
-                "stale"
-              ]
-            },
-            { "type": "null" }
+          "type": ["string", "null"],
+          "enum": [
+            "success",
+            "failure",
+            "neutral",
+            "cancelled",
+            "timed_out",
+            "action_required",
+            "stale",
+            null
           ]
         },
         "started_at": { "type": "string" },
@@ -385,13 +381,8 @@
       "additionalProperties": false
     },
     "requested_action": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": { "identifier": { "type": "string" } }
-        },
-        { "type": "null" }
-      ]
+      "type": ["object", "null"],
+      "properties": { "identifier": { "type": "string" } }
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/check_run/requested_action.schema.json
+++ b/payload-schemas/schemas/check_run/requested_action.schema.json
@@ -36,20 +36,16 @@
           "enum": ["queued", "in_progress", "completed"]
         },
         "conclusion": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "success",
-                "failure",
-                "neutral",
-                "cancelled",
-                "timed_out",
-                "action_required",
-                "stale"
-              ]
-            },
-            { "type": "null" }
+          "type": ["string", "null"],
+          "enum": [
+            "success",
+            "failure",
+            "neutral",
+            "cancelled",
+            "timed_out",
+            "action_required",
+            "stale",
+            null
           ]
         },
         "started_at": { "type": "string" },
@@ -385,13 +381,8 @@
       "additionalProperties": false
     },
     "requested_action": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": { "identifier": { "type": "string" } }
-        },
-        { "type": "null" }
-      ]
+      "type": ["object", "null"],
+      "properties": { "identifier": { "type": "string" } }
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/check_run/rerequested.schema.json
+++ b/payload-schemas/schemas/check_run/rerequested.schema.json
@@ -36,20 +36,16 @@
           "enum": ["queued", "in_progress", "completed"]
         },
         "conclusion": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "success",
-                "failure",
-                "neutral",
-                "cancelled",
-                "timed_out",
-                "action_required",
-                "stale"
-              ]
-            },
-            { "type": "null" }
+          "type": ["string", "null"],
+          "enum": [
+            "success",
+            "failure",
+            "neutral",
+            "cancelled",
+            "timed_out",
+            "action_required",
+            "stale",
+            null
           ]
         },
         "started_at": { "type": "string" },
@@ -385,13 +381,8 @@
       "additionalProperties": false
     },
     "requested_action": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": { "identifier": { "type": "string" } }
-        },
-        { "type": "null" }
-      ]
+      "type": ["object", "null"],
+      "properties": { "identifier": { "type": "string" } }
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/check_suite/completed.schema.json
+++ b/payload-schemas/schemas/check_suite/completed.schema.json
@@ -31,29 +31,20 @@
         "head_branch": { "type": ["string", "null"] },
         "head_sha": { "type": "string" },
         "status": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["requested", "in_progress", "completed", "queued"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["requested", "in_progress", "completed", "queued", null]
         },
         "conclusion": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "success",
-                "failure",
-                "neutral",
-                "cancelled",
-                "timed_out",
-                "action_required",
-                "stale"
-              ]
-            },
-            { "type": "null" }
+          "type": ["string", "null"],
+          "enum": [
+            "success",
+            "failure",
+            "neutral",
+            "cancelled",
+            "timed_out",
+            "action_required",
+            "stale",
+            null
           ]
         },
         "url": { "type": "string" },

--- a/payload-schemas/schemas/check_suite/requested.schema.json
+++ b/payload-schemas/schemas/check_suite/requested.schema.json
@@ -31,29 +31,20 @@
         "head_branch": { "type": ["string", "null"] },
         "head_sha": { "type": "string" },
         "status": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["requested", "in_progress", "completed", "queued"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["requested", "in_progress", "completed", "queued", null]
         },
         "conclusion": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "success",
-                "failure",
-                "neutral",
-                "cancelled",
-                "timed_out",
-                "action_required",
-                "stale"
-              ]
-            },
-            { "type": "null" }
+          "type": ["string", "null"],
+          "enum": [
+            "success",
+            "failure",
+            "neutral",
+            "cancelled",
+            "timed_out",
+            "action_required",
+            "stale",
+            null
           ]
         },
         "url": { "type": "string" },

--- a/payload-schemas/schemas/check_suite/rerequested.schema.json
+++ b/payload-schemas/schemas/check_suite/rerequested.schema.json
@@ -31,29 +31,20 @@
         "head_branch": { "type": ["string", "null"] },
         "head_sha": { "type": "string" },
         "status": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["requested", "in_progress", "completed", "queued"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["requested", "in_progress", "completed", "queued", null]
         },
         "conclusion": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": [
-                "success",
-                "failure",
-                "neutral",
-                "cancelled",
-                "timed_out",
-                "action_required",
-                "stale"
-              ]
-            },
-            { "type": "null" }
+          "type": ["string", "null"],
+          "enum": [
+            "success",
+            "failure",
+            "neutral",
+            "cancelled",
+            "timed_out",
+            "action_required",
+            "stale",
+            null
           ]
         },
         "url": { "type": "string" },

--- a/payload-schemas/schemas/common/repository.schema.json
+++ b/payload-schemas/schemas/common/repository.schema.json
@@ -191,22 +191,16 @@
     "disabled": { "type": "boolean" },
     "open_issues_count": { "type": "integer" },
     "license": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": ["key", "name", "spdx_id", "url", "node_id"],
-          "properties": {
-            "key": { "type": "string" },
-            "name": { "type": "string" },
-            "spdx_id": { "type": "string" },
-            "url": { "type": "string" },
-            "node_id": { "type": "string" }
-          },
-          "additionalProperties": false
-        },
-        { "type": "string" },
-        { "type": "null" }
-      ]
+      "type": ["object", "null"],
+      "required": ["key", "name", "spdx_id", "url", "node_id"],
+      "properties": {
+        "key": { "type": "string" },
+        "name": { "type": "string" },
+        "spdx_id": { "type": "string" },
+        "url": { "type": "string" },
+        "node_id": { "type": "string" }
+      },
+      "additionalProperties": false
     },
     "forks": { "type": "integer" },
     "open_issues": { "type": "integer" },

--- a/payload-schemas/schemas/issue_comment/created.schema.json
+++ b/payload-schemas/schemas/issue_comment/created.schema.json
@@ -128,13 +128,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "body": { "type": "string" }
       },

--- a/payload-schemas/schemas/issue_comment/deleted.schema.json
+++ b/payload-schemas/schemas/issue_comment/deleted.schema.json
@@ -128,13 +128,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "body": { "type": "string" }
       },

--- a/payload-schemas/schemas/issue_comment/edited.schema.json
+++ b/payload-schemas/schemas/issue_comment/edited.schema.json
@@ -140,13 +140,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "body": { "type": "string" }
       },

--- a/payload-schemas/schemas/issues/assigned.schema.json
+++ b/payload-schemas/schemas/issues/assigned.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/closed.schema.json
+++ b/payload-schemas/schemas/issues/closed.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/deleted.schema.json
+++ b/payload-schemas/schemas/issues/deleted.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/demilestoned.schema.json
+++ b/payload-schemas/schemas/issues/demilestoned.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/edited.schema.json
+++ b/payload-schemas/schemas/issues/edited.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/labeled.schema.json
+++ b/payload-schemas/schemas/issues/labeled.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/locked.schema.json
+++ b/payload-schemas/schemas/issues/locked.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },

--- a/payload-schemas/schemas/issues/milestoned.schema.json
+++ b/payload-schemas/schemas/issues/milestoned.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/opened.schema.json
+++ b/payload-schemas/schemas/issues/opened.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/pinned.schema.json
+++ b/payload-schemas/schemas/issues/pinned.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/reopened.schema.json
+++ b/payload-schemas/schemas/issues/reopened.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/transferred.schema.json
+++ b/payload-schemas/schemas/issues/transferred.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/unassigned.schema.json
+++ b/payload-schemas/schemas/issues/unassigned.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/unlabeled.schema.json
+++ b/payload-schemas/schemas/issues/unlabeled.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/issues/unlocked.schema.json
+++ b/payload-schemas/schemas/issues/unlocked.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },

--- a/payload-schemas/schemas/issues/unpinned.schema.json
+++ b/payload-schemas/schemas/issues/unpinned.schema.json
@@ -67,49 +67,44 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": "string" }
+          },
+          "additionalProperties": false
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string" },
@@ -129,13 +124,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "performed_via_github_app": { "type": "null" },
         "pull_request": {

--- a/payload-schemas/schemas/pull_request/assigned.schema.json
+++ b/payload-schemas/schemas/pull_request/assigned.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/closed.schema.json
+++ b/payload-schemas/schemas/pull_request/closed.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
+++ b/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean", "enum": [true] },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/edited.schema.json
+++ b/payload-schemas/schemas/pull_request/edited.schema.json
@@ -130,49 +130,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -281,13 +276,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/labeled.schema.json
+++ b/payload-schemas/schemas/pull_request/labeled.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/locked.schema.json
+++ b/payload-schemas/schemas/pull_request/locked.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },

--- a/payload-schemas/schemas/pull_request/opened.schema.json
+++ b/payload-schemas/schemas/pull_request/opened.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },

--- a/payload-schemas/schemas/pull_request/ready_for_review.schema.json
+++ b/payload-schemas/schemas/pull_request/ready_for_review.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean", "enum": [false] },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/reopened.schema.json
+++ b/payload-schemas/schemas/pull_request/reopened.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/review_request_removed.schema.json
+++ b/payload-schemas/schemas/pull_request/review_request_removed.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/review_requested.schema.json
+++ b/payload-schemas/schemas/pull_request/review_requested.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/synchronize.schema.json
+++ b/payload-schemas/schemas/pull_request/synchronize.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/unassigned.schema.json
+++ b/payload-schemas/schemas/pull_request/unassigned.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/unlabeled.schema.json
+++ b/payload-schemas/schemas/pull_request/unlabeled.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },
@@ -256,13 +251,8 @@
           ]
         },
         "active_lock_reason": {
-          "oneOf": [
-            {
-              "type": "string",
-              "enum": ["resolved", "off-topic", "too heated", "spam"]
-            },
-            { "type": "null" }
-          ]
+          "type": ["string", "null"],
+          "enum": ["resolved", "off-topic", "too heated", "spam", null]
         },
         "draft": { "type": "boolean" },
         "merged": { "type": "boolean" },

--- a/payload-schemas/schemas/pull_request/unlocked.schema.json
+++ b/payload-schemas/schemas/pull_request/unlocked.schema.json
@@ -105,49 +105,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },

--- a/payload-schemas/schemas/pull_request_review/submitted.schema.json
+++ b/payload-schemas/schemas/pull_request_review/submitted.schema.json
@@ -147,49 +147,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },

--- a/payload-schemas/schemas/pull_request_review_comment/created.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/created.schema.json
@@ -167,49 +167,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },

--- a/payload-schemas/schemas/pull_request_review_comment/deleted.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/deleted.schema.json
@@ -167,49 +167,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },

--- a/payload-schemas/schemas/pull_request_review_comment/edited.schema.json
+++ b/payload-schemas/schemas/pull_request_review_comment/edited.schema.json
@@ -186,49 +186,44 @@
           }
         },
         "milestone": {
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "url",
-                "html_url",
-                "labels_url",
-                "id",
-                "node_id",
-                "number",
-                "title",
-                "description",
-                "creator",
-                "open_issues",
-                "closed_issues",
-                "state",
-                "created_at",
-                "updated_at",
-                "due_on",
-                "closed_at"
-              ],
-              "properties": {
-                "url": { "type": "string" },
-                "html_url": { "type": "string" },
-                "labels_url": { "type": "string" },
-                "id": { "type": "integer" },
-                "node_id": { "type": "string" },
-                "number": { "type": "integer" },
-                "title": { "type": "string" },
-                "description": { "type": "string" },
-                "creator": { "$ref": "common/user.schema.json" },
-                "open_issues": { "type": "integer" },
-                "closed_issues": { "type": "integer" },
-                "state": { "type": "string" },
-                "created_at": { "type": "string" },
-                "updated_at": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": ["string", "null"] }
-              },
-              "additionalProperties": false
-            },
-            { "type": "null" }
-          ]
+          "type": ["object", "null"],
+          "required": [
+            "url",
+            "html_url",
+            "labels_url",
+            "id",
+            "node_id",
+            "number",
+            "title",
+            "description",
+            "creator",
+            "open_issues",
+            "closed_issues",
+            "state",
+            "created_at",
+            "updated_at",
+            "due_on",
+            "closed_at"
+          ],
+          "properties": {
+            "url": { "type": "string" },
+            "html_url": { "type": "string" },
+            "labels_url": { "type": "string" },
+            "id": { "type": "integer" },
+            "node_id": { "type": "string" },
+            "number": { "type": "integer" },
+            "title": { "type": "string" },
+            "description": { "type": "string" },
+            "creator": { "$ref": "common/user.schema.json" },
+            "open_issues": { "type": "integer" },
+            "closed_issues": { "type": "integer" },
+            "state": { "type": "string" },
+            "created_at": { "type": "string" },
+            "updated_at": { "type": "string" },
+            "due_on": { "type": "string" },
+            "closed_at": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
         },
         "commits_url": { "type": "string" },
         "review_comments_url": { "type": "string" },

--- a/payload-schemas/schemas/push/event.schema.json
+++ b/payload-schemas/schemas/push/event.schema.json
@@ -78,57 +78,52 @@
       }
     },
     "head_commit": {
-      "oneOf": [
-        {
+      "type": ["object", "null"],
+      "required": [
+        "id",
+        "tree_id",
+        "distinct",
+        "message",
+        "timestamp",
+        "url",
+        "author",
+        "committer",
+        "added",
+        "removed",
+        "modified"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "tree_id": { "type": "string" },
+        "distinct": { "type": "boolean" },
+        "message": { "type": "string" },
+        "timestamp": { "type": "string" },
+        "url": { "type": "string" },
+        "author": {
           "type": "object",
-          "required": [
-            "id",
-            "tree_id",
-            "distinct",
-            "message",
-            "timestamp",
-            "url",
-            "author",
-            "committer",
-            "added",
-            "removed",
-            "modified"
-          ],
+          "required": ["name", "email", "username"],
           "properties": {
-            "id": { "type": "string" },
-            "tree_id": { "type": "string" },
-            "distinct": { "type": "boolean" },
-            "message": { "type": "string" },
-            "timestamp": { "type": "string" },
-            "url": { "type": "string" },
-            "author": {
-              "type": "object",
-              "required": ["name", "email", "username"],
-              "properties": {
-                "name": { "type": "string" },
-                "email": { "type": "string" },
-                "username": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            "committer": {
-              "type": "object",
-              "required": ["name", "email", "username"],
-              "properties": {
-                "name": { "type": "string" },
-                "email": { "type": "string" },
-                "username": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            "added": { "type": "array", "items": { "type": "string" } },
-            "removed": { "type": "array", "items": { "type": "string" } },
-            "modified": { "type": "array", "items": { "type": "string" } }
+            "name": { "type": "string" },
+            "email": { "type": "string" },
+            "username": { "type": "string" }
           },
           "additionalProperties": false
         },
-        { "type": "null" }
-      ]
+        "committer": {
+          "type": "object",
+          "required": ["name", "email", "username"],
+          "properties": {
+            "name": { "type": "string" },
+            "email": { "type": "string" },
+            "username": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "added": { "type": "array", "items": { "type": "string" } },
+        "removed": { "type": "array", "items": { "type": "string" } },
+        "modified": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "pusher": {

--- a/payload-schemas/schemas/security_advisory/performed.schema.json
+++ b/payload-schemas/schemas/security_advisory/performed.schema.json
@@ -71,15 +71,10 @@
               "severity": { "type": "string" },
               "vulnerable_version_range": { "type": "string" },
               "first_patched_version": {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "required": ["identifier"],
-                    "properties": { "identifier": { "type": "string" } },
-                    "additionalProperties": false
-                  },
-                  { "type": "null" }
-                ]
+                "type": ["object", "null"],
+                "required": ["identifier"],
+                "properties": { "identifier": { "type": "string" } },
+                "additionalProperties": false
               }
             },
             "additionalProperties": false

--- a/payload-schemas/schemas/security_advisory/published.schema.json
+++ b/payload-schemas/schemas/security_advisory/published.schema.json
@@ -71,15 +71,10 @@
               "severity": { "type": "string" },
               "vulnerable_version_range": { "type": "string" },
               "first_patched_version": {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "required": ["identifier"],
-                    "properties": { "identifier": { "type": "string" } },
-                    "additionalProperties": false
-                  },
-                  { "type": "null" }
-                ]
+                "type": ["object", "null"],
+                "required": ["identifier"],
+                "properties": { "identifier": { "type": "string" } },
+                "additionalProperties": false
               }
             },
             "additionalProperties": false

--- a/payload-schemas/schemas/security_advisory/updated.schema.json
+++ b/payload-schemas/schemas/security_advisory/updated.schema.json
@@ -71,15 +71,10 @@
               "severity": { "type": "string" },
               "vulnerable_version_range": { "type": "string" },
               "first_patched_version": {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "required": ["identifier"],
-                    "properties": { "identifier": { "type": "string" } },
-                    "additionalProperties": false
-                  },
-                  { "type": "null" }
-                ]
+                "type": ["object", "null"],
+                "required": ["identifier"],
+                "properties": { "identifier": { "type": "string" } },
+                "additionalProperties": false
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
Branched off #273

Null can be merged into as a union if its the one other type in the `oneOf`.