### PR TITLE
fix: don't validate array as a tuple

### DIFF
--- a/payload-schemas/schemas/issues/unpinned.schema.json
+++ b/payload-schemas/schemas/issues/unpinned.schema.json
@@ -167,7 +167,7 @@
     },
     "assignees": {
       "type": "array",
-      "items": [{ "$ref": "common/user.schema.json" }]
+      "items": { "$ref": "common/user.schema.json" }
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },


### PR DESCRIPTION
Technically we could probably set `maxItems` to 15 since iirc thats the current limit in GH, but there's not a lot of value.

This will let us enable strictMode in ajv 🎉