### PR TITLE
chore: improve validation script

### DIFF
--- a/bin/validate-payload-examples.ts
+++ b/bin/validate-payload-examples.ts
@@ -3,7 +3,6 @@
 import fs from "fs";
 import { ajv, validate } from "../payload-schemas";
 
-let hasErrors = false as boolean;
 const payloads = `./payload-examples/api.github.com`;
 
 const continueOnError = process.argv.includes("--continue-on-error");
@@ -22,7 +21,7 @@ fs.readdirSync(payloads).forEach((event) => {
             `❌ Payload '${event}/${filename}' does not match schema`
           );
           console.error(ajv.errors);
-          hasErrors = true;
+          process.exitCode = 1;
         } else {
           console.log(`✅ Payload '${event}/${filename}' matches schema`);
         }
@@ -34,11 +33,7 @@ fs.readdirSync(payloads).forEach((event) => {
         console.error(
           `💥 Payload '${event}/${filename}' errored: ${err.message}`
         );
-        hasErrors = true;
+        process.exitCode = 1;
       }
     });
 });
-
-if (hasErrors) {
-  process.exit(1);
-}

--- a/bin/validate-payload-examples.ts
+++ b/bin/validate-payload-examples.ts
@@ -6,6 +6,8 @@ import { ajv, validate } from "../payload-schemas";
 let hasErrors = false as boolean;
 const payloads = `./payload-examples/api.github.com`;
 
+const continueOnError = process.argv.includes("--continue-on-error");
+
 fs.readdirSync(payloads).forEach((event) => {
   fs.readdirSync(`${payloads}/${event}`)
     .filter((filename) => filename.endsWith(".json"))
@@ -25,7 +27,13 @@ fs.readdirSync(payloads).forEach((event) => {
           console.log(`✅ Payload '${event}/${filename}' matches schema`);
         }
       } catch (err) {
-        console.error(`Missing schema for event '${event}'`);
+        if (!continueOnError) {
+          throw err;
+        }
+
+        console.error(
+          `💥 Payload '${event}/${filename}' errored: ${err.message}`
+        );
         hasErrors = true;
       }
     });


### PR DESCRIPTION
Fixes #250

I figured there's some use in either behaviour depending on what the actual error is, and defaulted to exiting at the first error as that'll make it less explody when you're not expecting an error (since i.e it could be a strict-mode error in one of the common schemas, so every schema that uses it will throw).