### PR TITLE
feat: create `repo-ref` common schema

### DIFF
--- a/bin/ref-common-schemas.ts
+++ b/bin/ref-common-schemas.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env ts-node-transpile-only
+
+import deepEqual from "fast-deep-equal";
+import fs from "fs";
+import { JSONSchema7 } from "json-schema";
+import { format } from "prettier";
+
+const pathToSchemas = "payload-schemas/schemas";
+
+const metaProperties = [
+  "$schema", //
+  "$id",
+  "title",
+  "description",
+];
+
+const isJsonSchemaObject = (object: unknown): object is JSONSchema7 =>
+  typeof object === "object" && object !== null && !Array.isArray(object);
+
+const ensureArray = <T>(arr: T | T[]): T[] =>
+  Array.isArray(arr) ? arr : [arr];
+
+const normalizeSchema = (schema: JSONSchema7): JSONSchema7 => {
+  try {
+    return JSON.parse(
+      JSON.stringify(schema, (key, value: unknown) => {
+        if (metaProperties.includes(key)) {
+          return undefined;
+        }
+
+        if (key === "type") {
+          return ensureArray(value);
+        }
+
+        if (Array.isArray(value)) {
+          return [...value].sort();
+        }
+
+        if (isJsonSchemaObject(value)) {
+          if (value.const !== undefined) {
+            value.enum = [value.const];
+          }
+        }
+
+        return value;
+      })
+    ) as JSONSchema7;
+  } catch (error) {
+    console.log(schema);
+
+    throw error;
+  }
+};
+
+const commonSchemas = fs
+  .readdirSync(`${pathToSchemas}/common`)
+  .map<[name: string, schema: JSONSchema7]>((commonSchema) => [
+    commonSchema,
+    normalizeSchema(
+      require(`../${pathToSchemas}/common/${commonSchema}`) as JSONSchema7
+    ),
+  ]);
+
+const findCommonSchema = (object: JSONSchema7) => {
+  const normalisedSchema = normalizeSchema(object);
+
+  const [schema] = commonSchemas.find(([, commonSchema]) =>
+    deepEqual(commonSchema, normalisedSchema)
+  ) ?? [null];
+
+  return schema;
+};
+
+const splitIntoObjectAndNull = (
+  object: Readonly<JSONSchema7>
+): [JSONSchema7, { type: "null" } | null] => {
+  // if the object cannot be null, just return the object
+  if (!ensureArray(object.type).includes("null")) {
+    return [object, null];
+  }
+
+  const newObject = { ...object };
+
+  if (Array.isArray(newObject.type)) {
+    newObject.type = newObject.type.filter((type) => type !== "null");
+  }
+
+  if (newObject.enum) {
+    newObject.enum = newObject.enum.filter((v) => v !== null);
+  }
+
+  return [newObject, { type: "null" }];
+};
+
+fs.readdirSync(pathToSchemas).forEach((eventName) => {
+  if (eventName === "common") {
+    return; // "common" is not an event
+  }
+
+  fs.readdirSync(`${pathToSchemas}/${eventName}`).forEach((file) => {
+    const schema = JSON.parse(
+      fs.readFileSync(`${pathToSchemas}/${eventName}/${file}`, "utf-8")
+    ) as JSONSchema7;
+
+    fs.writeFileSync(
+      `${pathToSchemas}/${eventName}/${file}`,
+      format(
+        JSON.stringify(schema, (key, value) => {
+          if (typeof value === "object" && value !== null) {
+            const [object, nullType] = splitIntoObjectAndNull(value);
+
+            const commonSchema = findCommonSchema(object);
+
+            if (commonSchema) {
+              const commonRef = { $ref: `common/${commonSchema}` };
+
+              if (nullType) {
+                return { oneOf: [commonRef, nullType] };
+              }
+
+              return commonRef;
+            }
+          }
+
+          return value;
+        }),
+        { parser: "json" }
+      )
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/yargs": "^15.0.12",
     "ajv": "^7.0.0",
     "cheerio": "^1.0.0-rc.2",
+    "fast-deep-equal": "^3.1.3",
     "json-diff": "^0.5.3",
     "json-schema-to-typescript": "^10.1.2",
     "prettier": "^2.0.5",

--- a/payload-schemas/schemas/check_run/completed.schema.json
+++ b/payload-schemas/schemas/check_run/completed.schema.json
@@ -109,16 +109,7 @@
                     "properties": {
                       "ref": { "type": "string" },
                       "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "repo": { "$ref": "common/repo-ref.schema.json" }
                     },
                     "additionalProperties": false
                   },
@@ -128,16 +119,7 @@
                     "properties": {
                       "ref": { "type": "string" },
                       "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "repo": { "$ref": "common/repo-ref.schema.json" }
                     },
                     "additionalProperties": false
                   }
@@ -341,16 +323,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               },
@@ -360,16 +333,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               }

--- a/payload-schemas/schemas/check_run/created.schema.json
+++ b/payload-schemas/schemas/check_run/created.schema.json
@@ -109,16 +109,7 @@
                     "properties": {
                       "ref": { "type": "string" },
                       "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "repo": { "$ref": "common/repo-ref.schema.json" }
                     },
                     "additionalProperties": false
                   },
@@ -128,16 +119,7 @@
                     "properties": {
                       "ref": { "type": "string" },
                       "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "repo": { "$ref": "common/repo-ref.schema.json" }
                     },
                     "additionalProperties": false
                   }
@@ -341,16 +323,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               },
@@ -360,16 +333,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               }

--- a/payload-schemas/schemas/check_run/requested_action.schema.json
+++ b/payload-schemas/schemas/check_run/requested_action.schema.json
@@ -109,16 +109,7 @@
                     "properties": {
                       "ref": { "type": "string" },
                       "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "repo": { "$ref": "common/repo-ref.schema.json" }
                     },
                     "additionalProperties": false
                   },
@@ -128,16 +119,7 @@
                     "properties": {
                       "ref": { "type": "string" },
                       "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "repo": { "$ref": "common/repo-ref.schema.json" }
                     },
                     "additionalProperties": false
                   }
@@ -341,16 +323,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               },
@@ -360,16 +333,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               }

--- a/payload-schemas/schemas/check_run/rerequested.schema.json
+++ b/payload-schemas/schemas/check_run/rerequested.schema.json
@@ -109,16 +109,7 @@
                     "properties": {
                       "ref": { "type": "string" },
                       "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "repo": { "$ref": "common/repo-ref.schema.json" }
                     },
                     "additionalProperties": false
                   },
@@ -128,16 +119,7 @@
                     "properties": {
                       "ref": { "type": "string" },
                       "sha": { "type": "string" },
-                      "repo": {
-                        "type": "object",
-                        "required": ["id", "url", "name"],
-                        "properties": {
-                          "id": { "type": "integer" },
-                          "url": { "type": "string" },
-                          "name": { "type": "string" }
-                        },
-                        "additionalProperties": false
-                      }
+                      "repo": { "$ref": "common/repo-ref.schema.json" }
                     },
                     "additionalProperties": false
                   }
@@ -341,16 +323,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               },
@@ -360,16 +333,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               }

--- a/payload-schemas/schemas/check_suite/completed.schema.json
+++ b/payload-schemas/schemas/check_suite/completed.schema.json
@@ -65,16 +65,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               },
@@ -84,16 +75,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               }

--- a/payload-schemas/schemas/check_suite/requested.schema.json
+++ b/payload-schemas/schemas/check_suite/requested.schema.json
@@ -65,16 +65,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               },
@@ -84,16 +75,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               }

--- a/payload-schemas/schemas/check_suite/rerequested.schema.json
+++ b/payload-schemas/schemas/check_suite/rerequested.schema.json
@@ -65,16 +65,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               },
@@ -84,16 +75,7 @@
                 "properties": {
                   "ref": { "type": "string" },
                   "sha": { "type": "string" },
-                  "repo": {
-                    "type": "object",
-                    "required": ["id", "url", "name"],
-                    "properties": {
-                      "id": { "type": "integer" },
-                      "url": { "type": "string" },
-                      "name": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
+                  "repo": { "$ref": "common/repo-ref.schema.json" }
                 },
                 "additionalProperties": false
               }

--- a/payload-schemas/schemas/common/repo-ref.schema.json
+++ b/payload-schemas/schemas/common/repo-ref.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "common/repo-ref.schema.json",
+  "type": "object",
+  "required": ["id", "url", "name"],
+  "properties": {
+    "id": { "type": "integer" },
+    "url": { "type": "string" },
+    "name": { "type": "string" }
+  },
+  "additionalProperties": false,
+  "title": "Repo Ref"
+}

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -272,20 +272,12 @@ export interface CheckRunCompletedEvent {
         head: {
           ref: string;
           sha: string;
-          repo: {
-            id: number;
-            url: string;
-            name: string;
-          };
+          repo: RepoRef;
         };
         base: {
           ref: string;
           sha: string;
-          repo: {
-            id: number;
-            url: string;
-            name: string;
-          };
+          repo: RepoRef;
         };
       }[];
       app: {
@@ -367,20 +359,12 @@ export interface CheckRunCompletedEvent {
       head: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
       base: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
     }[];
   };
@@ -391,6 +375,11 @@ export interface CheckRunCompletedEvent {
   sender: User;
   installation?: Installation;
   organization?: Organization;
+}
+export interface RepoRef {
+  id: number;
+  url: string;
+  name: string;
 }
 export interface User {
   login: string;
@@ -594,20 +583,12 @@ export interface CheckRunCreatedEvent {
         head: {
           ref: string;
           sha: string;
-          repo: {
-            id: number;
-            url: string;
-            name: string;
-          };
+          repo: RepoRef;
         };
         base: {
           ref: string;
           sha: string;
-          repo: {
-            id: number;
-            url: string;
-            name: string;
-          };
+          repo: RepoRef;
         };
       }[];
       app: {
@@ -689,20 +670,12 @@ export interface CheckRunCreatedEvent {
       head: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
       base: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
     }[];
   };
@@ -761,20 +734,12 @@ export interface CheckRunRequestedActionEvent {
         head: {
           ref: string;
           sha: string;
-          repo: {
-            id: number;
-            url: string;
-            name: string;
-          };
+          repo: RepoRef;
         };
         base: {
           ref: string;
           sha: string;
-          repo: {
-            id: number;
-            url: string;
-            name: string;
-          };
+          repo: RepoRef;
         };
       }[];
       app: {
@@ -856,20 +821,12 @@ export interface CheckRunRequestedActionEvent {
       head: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
       base: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
     }[];
   };
@@ -928,20 +885,12 @@ export interface CheckRunRerequestedEvent {
         head: {
           ref: string;
           sha: string;
-          repo: {
-            id: number;
-            url: string;
-            name: string;
-          };
+          repo: RepoRef;
         };
         base: {
           ref: string;
           sha: string;
-          repo: {
-            id: number;
-            url: string;
-            name: string;
-          };
+          repo: RepoRef;
         };
       }[];
       app: {
@@ -1023,20 +972,12 @@ export interface CheckRunRerequestedEvent {
       head: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
       base: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
     }[];
   };
@@ -1075,20 +1016,12 @@ export interface CheckSuiteCompletedEvent {
       head: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
       base: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
     }[];
     app: {
@@ -1177,20 +1110,12 @@ export interface CheckSuiteRequestedEvent {
       head: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
       base: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
     }[];
     app: {
@@ -1279,20 +1204,12 @@ export interface CheckSuiteRerequestedEvent {
       head: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
       base: {
         ref: string;
         sha: string;
-        repo: {
-          id: number;
-          url: string;
-          name: string;
-        };
+        repo: RepoRef;
       };
     }[];
     app: {


### PR DESCRIPTION
Here it is - the `ref-common-schemas` script.

It loads all the schemas in `common`, and compares every value of every key in every schema against those schemas to see if they match, and if they do it replaces them with a reference to the matched common schema.

Before comparing, the script attempts to normalize the values as best it can by removing common "meta" keys (such as `description`), sorting all arrays so they're always in the same order, and ensuring `type` is always an array.

The script also accounts for `null` unions: before comparing a value to the common schemas, it checks if `type` includes `"null"` - if it does then the value is "split" into a tuple of the type without null and `{ "type": "null" }`. The comparison is then done against the "type without null" and if they're equal it returns a `oneOf` of the `$ref` and null type, to ensure they'll still a `<type> | null` union.

One thing this *won't* account for is if a type might match if it was a bit looser - it'd be cool to have, but I couldn't find any libraries that let me grab any form of extra details about the comparison and so I've shelved it as a thing to look into later.

(I think this could be useful as its own tool, so we'll see what happens)

------

This PR has just the script + a small basic new common schema to show it off. I've already got a bunch of new common schemas I'll PR after this, since they can be done on their own.