### PR TITLE
feat: export `WebhookEvent` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,16 @@ import SCHEMA from "@octokit/webhooks-definitions/schema.json";
 This package ships with types for the webhook events generated from the respective json schemas, which you can use like so:
 
 ```typescript
-import { IssuesOpenedEvent } from "@octokit/webhooks-definitions/schema";
+import {
+  WebhookEvent,
+  IssuesOpenedEvent,
+} from "@octokit/webhooks-definitions/schema";
+
+const handleWebhookEvent = (event: WebhookEvent) => {
+  if ("action" in event && event.action === "completed") {
+    console.log(`${event.sender.login} completed something!`);
+  }
+};
 
 const handleIssuesOpenedEvent = (event: IssuesOpenedEvent) => {
   console.log(

--- a/bin/octokit-types.ts
+++ b/bin/octokit-types.ts
@@ -44,22 +44,17 @@ const buildEventPayloadMap = (schema: Schema): string => {
   return ["export interface EventPayloadMap {", ...properties, "}"].join("\n");
 };
 
-const addEventPayloadMap = (ts: string, schema: Schema): string => {
-  const payloadMap = buildEventPayloadMap(schema);
-
-  return `${ts}${payloadMap}`;
-};
-
 const getSchema = async () =>
   JSON.parse(await fs.readFile("./schema.json", "utf-8")) as Schema;
 
 const run = async () => {
   const schema = await getSchema();
 
-  const ts = addEventPayloadMap(
+  const ts = [
     await compileFromFile("./schema.json", { format: false }),
-    schema
-  );
+    buildEventPayloadMap(schema),
+    "export type WebhookEvent = Schema;",
+  ].join("\n\n");
 
   await fs.writeFile("./schema.d.ts", format(ts, { parser: "typescript" }));
 };

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -9607,6 +9607,7 @@ export interface WorkflowRunEvent {
   };
   installation?: Installation;
 }
+
 export interface EventPayloadMap {
   check_run: CheckRunEvent;
   check_suite: CheckSuiteEvent;
@@ -9662,3 +9663,5 @@ export interface EventPayloadMap {
   workflow_dispatch: WorkflowDispatchEvent;
   workflow_run: WorkflowRunEvent;
 }
+
+export type WebhookEvent = Schema;


### PR DESCRIPTION
I think this name makes much more sense as it's literally what it is, but I've kept the original `Schema` type as then it's technically not breaking & matches closer to the fact that it's typing `schema.json` 🤷 