### PR TITLE
feat: generate `WebhookEventMap` & `WebhookEventName` type aliases

### DIFF
--- a/bin/octokit-types.ts
+++ b/bin/octokit-types.ts
@@ -53,8 +53,11 @@ const run = async () => {
   const ts = [
     await compileFromFile("./schema.json", { format: false }),
     buildEventPayloadMap(schema),
+    "",
     "export type WebhookEvent = Schema;",
-  ].join("\n\n");
+    "export type WebhookEventMap = EventPayloadMap;",
+    "export type WebhookEventName = keyof EventPayloadMap;",
+  ].join("\n");
 
   await fs.writeFile("./schema.d.ts", format(ts, { parser: "typescript" }));
 };

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -9738,3 +9738,5 @@ export interface EventPayloadMap {
 }
 
 export type WebhookEvent = Schema;
+export type WebhookEventMap = EventPayloadMap;
+export type WebhookEventName = keyof EventPayloadMap;


### PR DESCRIPTION
Just so that things are nice and consistent