### PR TITLE
Create common schema extractor

### DIFF
--- a/bin/extract-common-schema.ts
+++ b/bin/extract-common-schema.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env ts-node-transpile-only
+
+import { strict as assert } from "assert";
+import fs from "fs";
+import { JSONSchema7 } from "json-schema";
+import { format } from "prettier";
+
+const pathToSchemas = "payload-schemas/schemas";
+
+const [interfacePropertyPath, interfaceName] = process.argv.slice(2);
+
+assert.ok(
+  interfacePropertyPath,
+  "first argument must be path to a property on an interface to extract into a common schema"
+);
+assert.ok(
+  interfaceName,
+  "second argument must be name of the interface the new common schema should generate"
+);
+
+const titleCase = (str: string) => `${str[0].toUpperCase()}${str.substring(1)}`;
+
+const guessAtInterfaceName = (schema: JSONSchema7): string => {
+  const str = schema.title || schema.$id;
+
+  assert.ok(str, "unable to guess interface name");
+
+  return str
+    .split(/[$_ -]/u)
+    .map(titleCase)
+    .join("");
+};
+
+const ensureArray = <T>(arr: T | T[]): T[] =>
+  Array.isArray(arr) ? arr : [arr];
+
+type InterfaceNameAndSchema = [interfaceName: string, schema: JSONSchema7];
+
+const loadSchemas = (directory: string): InterfaceNameAndSchema[] => {
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .flatMap((entity) => {
+      const pathToEntity = `${directory}/${entity.name}`;
+
+      if (entity.isDirectory()) {
+        return loadSchemas(pathToEntity);
+      }
+
+      const schema = JSON.parse(
+        fs.readFileSync(pathToEntity, "utf-8")
+      ) as JSONSchema7;
+
+      return [[guessAtInterfaceName(schema), schema]];
+    });
+};
+
+const RequiredSchemaProperties = [
+  "$id",
+  "title",
+  "$schema",
+  "type",
+  "required",
+  "properties",
+  "additionalProperties",
+] as const;
+
+type CommonSchema = Required<
+  Pick<JSONSchema7, typeof RequiredSchemaProperties[number]>
+> &
+  JSONSchema7;
+
+function assertHasRequiredProperties(
+  schema: JSONSchema7
+): asserts schema is CommonSchema {
+  const missingProperties = RequiredSchemaProperties.filter(
+    (property) => schema[property] === undefined
+  ).join(", ");
+
+  assert.ok(
+    missingProperties.length === 0,
+    `schema is missing the following required properties: ${missingProperties}`
+  );
+}
+
+const writeNewCommonSchema = (name: string, schema: JSONSchema7) => {
+  const pathToSchema = `${pathToSchemas}/common/${name}.schema.json`;
+
+  assertHasRequiredProperties(schema);
+
+  fs.writeFileSync(
+    pathToSchema,
+    format(
+      JSON.stringify(schema, (key, value: unknown) => {
+        if (
+          key === "$ref" &&
+          typeof value === "string" &&
+          value.startsWith("common/") &&
+          value.endsWith(".schema.json")
+        ) {
+          return value.substring("common/".length);
+        }
+
+        return value;
+      }),
+      { parser: "json" }
+    ),
+    { flag: "wx" }
+  );
+};
+
+const extractFromSchema = (schema: JSONSchema7, name: string): JSONSchema7 => {
+  if (ensureArray(schema.type).includes("object")) {
+    assert.ok(
+      schema.properties,
+      "cannot extract from an object-type schema that lacks properties"
+    );
+
+    const value = schema.properties[name];
+
+    assert.ok(typeof value !== "boolean", "this is not what you want");
+
+    return value;
+  }
+
+  if (ensureArray(schema.type).includes("array")) {
+    assert.ok(schema.items);
+  }
+
+  if (schema.oneOf) {
+    throw new Error("extracting schemas from unions is not supported");
+  }
+
+  throw new Error(
+    `schemas can only be extracted from objects or arrays (got ${schema.type})`
+  );
+};
+
+const schemas = Object.fromEntries(loadSchemas(pathToSchemas));
+const segments = interfacePropertyPath.split(".");
+
+const rawSchema = segments.reduce<JSONSchema7>(
+  (schema, segment) => extractFromSchema(schema, segment),
+  { type: "object", properties: schemas }
+);
+
+const fileName = interfaceName.replace(/(?!^)([A-Z])/gu, "-$1").toLowerCase();
+const title = interfaceName.replace(/(?!^)([A-Z])/gu, " $1");
+
+const commonSchema: CommonSchema = {
+  $schema: "http://json-schema.org/draft-07/schema",
+  $id: `common/${fileName}.schema.json`,
+  required: [],
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+  ...rawSchema,
+  title,
+};
+
+writeNewCommonSchema(fileName, commonSchema);

--- a/payload-schemas/schemas/common/sponsorship-tier.schema.json
+++ b/payload-schemas/schemas/common/sponsorship-tier.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "common/sponsorship-tier.schema.json",
+  "required": [
+    "node_id",
+    "created_at",
+    "description",
+    "monthly_price_in_cents",
+    "monthly_price_in_dollars",
+    "name"
+  ],
+  "type": "object",
+  "properties": {
+    "node_id": { "type": "string" },
+    "created_at": { "type": "string" },
+    "description": { "type": "string" },
+    "monthly_price_in_cents": { "type": "integer" },
+    "monthly_price_in_dollars": { "type": "integer" },
+    "name": { "type": "string" }
+  },
+  "additionalProperties": false,
+  "title": "Sponsorship Tier"
+}

--- a/payload-schemas/schemas/sponsorship/cancelled.schema.json
+++ b/payload-schemas/schemas/sponsorship/cancelled.schema.json
@@ -21,26 +21,7 @@
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },
-        "tier": {
-          "type": "object",
-          "required": [
-            "node_id",
-            "created_at",
-            "description",
-            "monthly_price_in_cents",
-            "monthly_price_in_dollars",
-            "name"
-          ],
-          "properties": {
-            "node_id": { "type": "string" },
-            "created_at": { "type": "string" },
-            "description": { "type": "string" },
-            "monthly_price_in_cents": { "type": "integer" },
-            "monthly_price_in_dollars": { "type": "integer" },
-            "name": { "type": "string" }
-          },
-          "additionalProperties": false
-        }
+        "tier": { "$ref": "common/sponsorship-tier.schema.json" }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/sponsorship/created.schema.json
+++ b/payload-schemas/schemas/sponsorship/created.schema.json
@@ -21,26 +21,7 @@
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },
-        "tier": {
-          "type": "object",
-          "required": [
-            "node_id",
-            "created_at",
-            "description",
-            "monthly_price_in_cents",
-            "monthly_price_in_dollars",
-            "name"
-          ],
-          "properties": {
-            "node_id": { "type": "string" },
-            "created_at": { "type": "string" },
-            "description": { "type": "string" },
-            "monthly_price_in_cents": { "type": "integer" },
-            "monthly_price_in_dollars": { "type": "integer" },
-            "name": { "type": "string" }
-          },
-          "additionalProperties": false
-        }
+        "tier": { "$ref": "common/sponsorship-tier.schema.json" }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/sponsorship/edited.schema.json
+++ b/payload-schemas/schemas/sponsorship/edited.schema.json
@@ -21,26 +21,7 @@
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },
-        "tier": {
-          "type": "object",
-          "required": [
-            "node_id",
-            "created_at",
-            "description",
-            "monthly_price_in_cents",
-            "monthly_price_in_dollars",
-            "name"
-          ],
-          "properties": {
-            "node_id": { "type": "string" },
-            "created_at": { "type": "string" },
-            "description": { "type": "string" },
-            "monthly_price_in_cents": { "type": "integer" },
-            "monthly_price_in_dollars": { "type": "integer" },
-            "name": { "type": "string" }
-          },
-          "additionalProperties": false
-        }
+        "tier": { "$ref": "common/sponsorship-tier.schema.json" }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/sponsorship/pending_cancellation.schema.json
+++ b/payload-schemas/schemas/sponsorship/pending_cancellation.schema.json
@@ -21,26 +21,7 @@
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },
-        "tier": {
-          "type": "object",
-          "required": [
-            "node_id",
-            "created_at",
-            "description",
-            "monthly_price_in_cents",
-            "monthly_price_in_dollars",
-            "name"
-          ],
-          "properties": {
-            "node_id": { "type": "string" },
-            "created_at": { "type": "string" },
-            "description": { "type": "string" },
-            "monthly_price_in_cents": { "type": "integer" },
-            "monthly_price_in_dollars": { "type": "integer" },
-            "name": { "type": "string" }
-          },
-          "additionalProperties": false
-        }
+        "tier": { "$ref": "common/sponsorship-tier.schema.json" }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/schemas/sponsorship/pending_tier_change.schema.json
+++ b/payload-schemas/schemas/sponsorship/pending_tier_change.schema.json
@@ -21,26 +21,7 @@
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },
-        "tier": {
-          "type": "object",
-          "required": [
-            "node_id",
-            "created_at",
-            "description",
-            "monthly_price_in_cents",
-            "monthly_price_in_dollars",
-            "name"
-          ],
-          "properties": {
-            "node_id": { "type": "string" },
-            "created_at": { "type": "string" },
-            "description": { "type": "string" },
-            "monthly_price_in_cents": { "type": "integer" },
-            "monthly_price_in_dollars": { "type": "integer" },
-            "name": { "type": "string" }
-          },
-          "additionalProperties": false
-        }
+        "tier": { "$ref": "common/sponsorship-tier.schema.json" }
       },
       "additionalProperties": false
     },
@@ -53,26 +34,7 @@
           "type": "object",
           "required": ["from"],
           "properties": {
-            "from": {
-              "type": "object",
-              "required": [
-                "node_id",
-                "created_at",
-                "description",
-                "monthly_price_in_cents",
-                "monthly_price_in_dollars",
-                "name"
-              ],
-              "properties": {
-                "node_id": { "type": "string" },
-                "created_at": { "type": "string" },
-                "description": { "type": "string" },
-                "monthly_price_in_cents": { "type": "integer" },
-                "monthly_price_in_dollars": { "type": "integer" },
-                "name": { "type": "string" }
-              },
-              "additionalProperties": false
-            }
+            "from": { "$ref": "common/sponsorship-tier.schema.json" }
           },
           "additionalProperties": false
         }

--- a/payload-schemas/schemas/sponsorship/tier_changed.schema.json
+++ b/payload-schemas/schemas/sponsorship/tier_changed.schema.json
@@ -21,26 +21,7 @@
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },
-        "tier": {
-          "type": "object",
-          "required": [
-            "node_id",
-            "created_at",
-            "description",
-            "monthly_price_in_cents",
-            "monthly_price_in_dollars",
-            "name"
-          ],
-          "properties": {
-            "node_id": { "type": "string" },
-            "created_at": { "type": "string" },
-            "description": { "type": "string" },
-            "monthly_price_in_cents": { "type": "integer" },
-            "monthly_price_in_dollars": { "type": "integer" },
-            "name": { "type": "string" }
-          },
-          "additionalProperties": false
-        }
+        "tier": { "$ref": "common/sponsorship-tier.schema.json" }
       },
       "additionalProperties": false
     },
@@ -52,26 +33,7 @@
           "type": "object",
           "required": ["from"],
           "properties": {
-            "from": {
-              "type": "object",
-              "required": [
-                "node_id",
-                "created_at",
-                "description",
-                "monthly_price_in_cents",
-                "monthly_price_in_dollars",
-                "name"
-              ],
-              "properties": {
-                "node_id": { "type": "string" },
-                "created_at": { "type": "string" },
-                "description": { "type": "string" },
-                "monthly_price_in_cents": { "type": "integer" },
-                "monthly_price_in_dollars": { "type": "integer" },
-                "name": { "type": "string" }
-              },
-              "additionalProperties": false
-            }
+            "from": { "$ref": "common/sponsorship-tier.schema.json" }
           },
           "additionalProperties": false
         }

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -8963,16 +8963,17 @@ export interface SponsorshipCancelledEvent {
     sponsorable: User;
     sponsor: User;
     privacy_level: string;
-    tier: {
-      node_id: string;
-      created_at: string;
-      description: string;
-      monthly_price_in_cents: number;
-      monthly_price_in_dollars: number;
-      name: string;
-    };
+    tier: SponsorshipTier;
   };
   sender: User;
+}
+export interface SponsorshipTier {
+  node_id: string;
+  created_at: string;
+  description: string;
+  monthly_price_in_cents: number;
+  monthly_price_in_dollars: number;
+  name: string;
 }
 export interface SponsorshipCreatedEvent {
   action: "created";
@@ -8982,14 +8983,7 @@ export interface SponsorshipCreatedEvent {
     sponsorable: User;
     sponsor: User;
     privacy_level: string;
-    tier: {
-      node_id: string;
-      created_at: string;
-      description: string;
-      monthly_price_in_cents: number;
-      monthly_price_in_dollars: number;
-      name: string;
-    };
+    tier: SponsorshipTier;
   };
   sender: User;
 }
@@ -9001,14 +8995,7 @@ export interface SponsorshipEditedEvent {
     sponsorable: User;
     sponsor: User;
     privacy_level: string;
-    tier: {
-      node_id: string;
-      created_at: string;
-      description: string;
-      monthly_price_in_cents: number;
-      monthly_price_in_dollars: number;
-      name: string;
-    };
+    tier: SponsorshipTier;
   };
   changes: {
     privacy_level?: {
@@ -9025,14 +9012,7 @@ export interface SponsorshipPendingCancellationEvent {
     sponsorable: User;
     sponsor: User;
     privacy_level: string;
-    tier: {
-      node_id: string;
-      created_at: string;
-      description: string;
-      monthly_price_in_cents: number;
-      monthly_price_in_dollars: number;
-      name: string;
-    };
+    tier: SponsorshipTier;
   };
   effective_date?: string;
   sender: User;
@@ -9045,26 +9025,12 @@ export interface SponsorshipPendingTierChangeEvent {
     sponsorable: User;
     sponsor: User;
     privacy_level: string;
-    tier: {
-      node_id: string;
-      created_at: string;
-      description: string;
-      monthly_price_in_cents: number;
-      monthly_price_in_dollars: number;
-      name: string;
-    };
+    tier: SponsorshipTier;
   };
   effective_date?: string;
   changes: {
     tier: {
-      from: {
-        node_id: string;
-        created_at: string;
-        description: string;
-        monthly_price_in_cents: number;
-        monthly_price_in_dollars: number;
-        name: string;
-      };
+      from: SponsorshipTier;
     };
   };
   sender: User;
@@ -9077,25 +9043,11 @@ export interface SponsorshipTierChangedEvent {
     sponsorable: User;
     sponsor: User;
     privacy_level: string;
-    tier: {
-      node_id: string;
-      created_at: string;
-      description: string;
-      monthly_price_in_cents: number;
-      monthly_price_in_dollars: number;
-      name: string;
-    };
+    tier: SponsorshipTier;
   };
   changes: {
     tier: {
-      from: {
-        node_id: string;
-        created_at: string;
-        description: string;
-        monthly_price_in_cents: number;
-        monthly_price_in_dollars: number;
-        name: string;
-      };
+      from: SponsorshipTier;
     };
   };
   sender: User;


### PR DESCRIPTION
Ok this one I'm pretty proud of - because it takes far too much time to copy a JSON schema into its own file, I made a script to do it.

Here's what you do:

* look over `schema.d.ts` and notice a property with an object type that's repeated a few times
* run `scripts/extract-common-schema.ts <name of the interface that has the property>.<dot-path to the property> <name of the interface that the common schema should generate>`
  * i.e for this commit I did `bin/extract-common-schema.ts SponsorshipEditedEvent.sponsorship.tier SponsorshipTier`
* run `scripts/ref-common-schemas.ts` to have all instances of that schema in the payload schemas replaced with a ref to your new common schema
* commit the results
* ???
* profit
