### PR TITLE
feat: create `Committer` common schema

### DIFF
--- a/payload-schemas/schemas/check_suite/completed.schema.json
+++ b/payload-schemas/schemas/check_suite/completed.schema.json
@@ -215,24 +215,8 @@
             "tree_id": { "type": "string" },
             "message": { "type": "string" },
             "timestamp": { "type": "string" },
-            "author": {
-              "type": "object",
-              "required": ["name", "email"],
-              "properties": {
-                "name": { "type": "string" },
-                "email": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            "committer": {
-              "type": "object",
-              "required": ["name", "email"],
-              "properties": {
-                "name": { "type": "string" },
-                "email": { "type": "string" }
-              },
-              "additionalProperties": false
-            }
+            "author": { "$ref": "common/committer.schema.json" },
+            "committer": { "$ref": "common/committer.schema.json" }
           },
           "additionalProperties": false
         }

--- a/payload-schemas/schemas/check_suite/requested.schema.json
+++ b/payload-schemas/schemas/check_suite/requested.schema.json
@@ -215,24 +215,8 @@
             "tree_id": { "type": "string" },
             "message": { "type": "string" },
             "timestamp": { "type": "string" },
-            "author": {
-              "type": "object",
-              "required": ["name", "email"],
-              "properties": {
-                "name": { "type": "string" },
-                "email": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            "committer": {
-              "type": "object",
-              "required": ["name", "email"],
-              "properties": {
-                "name": { "type": "string" },
-                "email": { "type": "string" }
-              },
-              "additionalProperties": false
-            }
+            "author": { "$ref": "common/committer.schema.json" },
+            "committer": { "$ref": "common/committer.schema.json" }
           },
           "additionalProperties": false
         }

--- a/payload-schemas/schemas/check_suite/rerequested.schema.json
+++ b/payload-schemas/schemas/check_suite/rerequested.schema.json
@@ -215,24 +215,8 @@
             "tree_id": { "type": "string" },
             "message": { "type": "string" },
             "timestamp": { "type": "string" },
-            "author": {
-              "type": "object",
-              "required": ["name", "email"],
-              "properties": {
-                "name": { "type": "string" },
-                "email": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            "committer": {
-              "type": "object",
-              "required": ["name", "email"],
-              "properties": {
-                "name": { "type": "string" },
-                "email": { "type": "string" }
-              },
-              "additionalProperties": false
-            }
+            "author": { "$ref": "common/committer.schema.json" },
+            "committer": { "$ref": "common/committer.schema.json" }
           },
           "additionalProperties": false
         }

--- a/payload-schemas/schemas/common/committer.schema.json
+++ b/payload-schemas/schemas/common/committer.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "common/committer.schema.json",
+  "required": ["email", "name"],
+  "type": "object",
+  "properties": { "email": { "type": "string" }, "name": { "type": "string" } },
+  "additionalProperties": false,
+  "title": "Committer"
+}

--- a/payload-schemas/schemas/push/event.schema.json
+++ b/payload-schemas/schemas/push/event.schema.json
@@ -126,15 +126,7 @@
       "additionalProperties": false
     },
     "repository": { "$ref": "common/repository.schema.json" },
-    "pusher": {
-      "type": "object",
-      "required": ["name", "email"],
-      "properties": {
-        "name": { "type": "string" },
-        "email": { "type": "string" }
-      },
-      "additionalProperties": false
-    },
+    "pusher": { "$ref": "common/committer.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" }

--- a/payload-schemas/schemas/workflow_run/completed.schema.json
+++ b/payload-schemas/schemas/workflow_run/completed.schema.json
@@ -90,24 +90,8 @@
             "tree_id"
           ],
           "properties": {
-            "author": {
-              "type": "object",
-              "required": ["email", "name"],
-              "properties": {
-                "email": { "type": "string" },
-                "name": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            "committer": {
-              "type": "object",
-              "required": ["email", "name"],
-              "properties": {
-                "email": { "type": "string" },
-                "name": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
+            "author": { "$ref": "common/committer.schema.json" },
+            "committer": { "$ref": "common/committer.schema.json" },
             "id": { "type": "string" },
             "message": { "type": "string" },
             "timestamp": { "type": "string" },

--- a/payload-schemas/schemas/workflow_run/requested.schema.json
+++ b/payload-schemas/schemas/workflow_run/requested.schema.json
@@ -90,24 +90,8 @@
             "tree_id"
           ],
           "properties": {
-            "author": {
-              "type": "object",
-              "required": ["email", "name"],
-              "properties": {
-                "email": { "type": "string" },
-                "name": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
-            "committer": {
-              "type": "object",
-              "required": ["email", "name"],
-              "properties": {
-                "email": { "type": "string" },
-                "name": { "type": "string" }
-              },
-              "additionalProperties": false
-            },
+            "author": { "$ref": "common/committer.schema.json" },
+            "committer": { "$ref": "common/committer.schema.json" },
             "id": { "type": "string" },
             "message": { "type": "string" },
             "timestamp": { "type": "string" },

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -1072,20 +1072,18 @@ export interface CheckSuiteCompletedEvent {
       tree_id: string;
       message: string;
       timestamp: string;
-      author: {
-        name: string;
-        email: string;
-      };
-      committer: {
-        name: string;
-        email: string;
-      };
+      author: Committer;
+      committer: Committer;
     };
   };
   repository: Repository;
   sender: User;
   installation?: Installation;
   organization?: Organization;
+}
+export interface Committer {
+  email: string;
+  name: string;
 }
 export interface CheckSuiteRequestedEvent {
   action: "requested";
@@ -1166,14 +1164,8 @@ export interface CheckSuiteRequestedEvent {
       tree_id: string;
       message: string;
       timestamp: string;
-      author: {
-        name: string;
-        email: string;
-      };
-      committer: {
-        name: string;
-        email: string;
-      };
+      author: Committer;
+      committer: Committer;
     };
   };
   repository: Repository;
@@ -1260,14 +1252,8 @@ export interface CheckSuiteRerequestedEvent {
       tree_id: string;
       message: string;
       timestamp: string;
-      author: {
-        name: string;
-        email: string;
-      };
-      committer: {
-        name: string;
-        email: string;
-      };
+      author: Committer;
+      committer: Committer;
     };
   };
   repository: Repository;
@@ -8067,10 +8053,7 @@ export interface PushEvent {
     modified: string[];
   } | null;
   repository: Repository;
-  pusher: {
-    name: string;
-    email: string;
-  };
+  pusher: Committer;
   sender: User;
   installation?: Installation;
   organization?: Organization;
@@ -9402,14 +9385,8 @@ export interface WorkflowRunCompletedEvent {
     event: string;
     head_branch: string;
     head_commit: {
-      author: {
-        email: string;
-        name: string;
-      };
-      committer: {
-        email: string;
-        name: string;
-      };
+      author: Committer;
+      committer: Committer;
       id: string;
       message: string;
       timestamp: string;
@@ -9554,14 +9531,8 @@ export interface WorkflowRunRequestedEvent {
     event: string;
     head_branch: string;
     head_commit: {
-      author: {
-        email: string;
-        name: string;
-      };
-      committer: {
-        email: string;
-        name: string;
-      };
+      author: Committer;
+      committer: Committer;
       id: string;
       message: string;
       timestamp: string;


### PR DESCRIPTION
I suspect these might have some optional fields, namely `date` & `username` as there are other instances of this structure but with extra fields.

i.e.

* `StatusEvent.commit.commit` has the same `author` and `committer` properties as `Committer` but with a `date` field too
* `PushEvent.commits` has the same `author` and `committer` properties as `Committer` but with a `username` field too

Would be cool if someone could check if it's our payloads that are outdated.