### PR TITLE
Adjust scripts

### DIFF
--- a/bin/extract-common-schema.ts
+++ b/bin/extract-common-schema.ts
@@ -143,6 +143,13 @@ const rawSchema = segments.reduce<JSONSchema7>(
   { type: "object", properties: schemas }
 );
 
+if (
+  rawSchema.$ref ||
+  rawSchema.oneOf?.some((object) => typeof object !== "boolean" && object.$ref)
+) {
+  throw new Error("schema is already a ref");
+}
+
 const fileName = interfaceName.replace(/(?!^)([A-Z])/gu, "-$1").toLowerCase();
 const title = interfaceName.replace(/(?!^)([A-Z])/gu, " $1");
 

--- a/bin/extract-common-schema.ts
+++ b/bin/extract-common-schema.ts
@@ -188,3 +188,5 @@ if (Array.isArray(commonSchema.type) && commonSchema.type.includes("null")) {
 }
 
 writeNewCommonSchema(fileName, commonSchema);
+
+console.log(`wrote extracted schema to ${fileName}`);

--- a/bin/extract-common-schema.ts
+++ b/bin/extract-common-schema.ts
@@ -7,7 +7,22 @@ import { format } from "prettier";
 
 const pathToSchemas = "payload-schemas/schemas";
 
-const [interfacePropertyPath, interfaceName] = process.argv.slice(2);
+const parseArgv = (argv: string[]): [args: string[], flags: string[]] => {
+  const flags: string[] = [];
+  const args: string[] = [];
+
+  argv.forEach((arg) => {
+    arg.startsWith("--") ? flags.push(arg) : args.push(arg);
+  });
+
+  return [args, flags];
+};
+
+const [[interfacePropertyPath, interfaceName], flags] = parseArgv(
+  process.argv.slice(2)
+);
+
+const overwriteIfExists = flags.includes("--overwrite");
 
 assert.ok(
   interfacePropertyPath,
@@ -104,7 +119,7 @@ const writeNewCommonSchema = (name: string, schema: JSONSchema7) => {
       }),
       { parser: "json" }
     ),
-    { flag: "wx" }
+    { flag: overwriteIfExists ? "w" : "wx" }
   );
 };
 

--- a/bin/ref-common-schemas.ts
+++ b/bin/ref-common-schemas.ts
@@ -101,6 +101,8 @@ const splitIntoObjectAndNull = (
   return [newObject, { type: "null" }];
 };
 
+let count = 0;
+
 fs.readdirSync(pathToSchemas).forEach((eventName) => {
   if (eventName === "common") {
     return; // "common" is not an event
@@ -127,6 +129,8 @@ fs.readdirSync(pathToSchemas).forEach((eventName) => {
                 return { oneOf: [commonRef, nullType] };
               }
 
+              count += 1;
+
               return commonRef;
             }
           }
@@ -138,3 +142,7 @@ fs.readdirSync(pathToSchemas).forEach((eventName) => {
     );
   });
 });
+
+console.log(
+  `replaced ${count} ${count === 1 ? "property" : "properties"} with $ref`
+);


### PR DESCRIPTION
Not having them print anything at all made me a little eh when running my `script.sh`:

```
#!/usr/bin/env bash

set -e

bin/extract-common-schema.ts "$@"
bin/ref-common-schemas.ts
npm run --silent build:schema
npm run --silent build:types
```

As I had no idea what it was doing until it reached the `npm run`s.

Also added basic flag support to the extractor script to allow overwriting existing files if desired.