### PR TITLE
chore: clone schemas before normalizing & improve `type` property check

### DIFF
--- a/bin/ref-common-schemas.ts
+++ b/bin/ref-common-schemas.ts
@@ -14,6 +14,9 @@ const metaProperties = [
   "description",
 ];
 
+const cloneObject = <TObject extends object>(object: TObject): TObject =>
+  JSON.parse(JSON.stringify(object)) as TObject;
+
 const isJsonSchemaObject = (object: unknown): object is JSONSchema7 =>
   typeof object === "object" && object !== null && !Array.isArray(object);
 
@@ -23,7 +26,7 @@ const ensureArray = <T>(arr: T | T[]): T[] =>
 const normalizeSchema = (schema: JSONSchema7): JSONSchema7 => {
   try {
     return JSON.parse(
-      JSON.stringify(schema, (key, value: unknown) => {
+      JSON.stringify(cloneObject(schema), (key, value: unknown) => {
         if (metaProperties.includes(key)) {
           return undefined;
         }

--- a/bin/ref-common-schemas.ts
+++ b/bin/ref-common-schemas.ts
@@ -40,15 +40,15 @@ const normalizeSchema = (schema: JSONSchema7): JSONSchema7 => {
           return `common/${value}`;
         }
 
-        if (key === "type") {
-          return ensureArray(value);
-        }
-
         if (Array.isArray(value)) {
           return [...value].sort();
         }
 
         if (isJsonSchemaObject(value)) {
+          if (value.type) {
+            value.type = ensureArray(value.type);
+          }
+
           if (value.const !== undefined) {
             value.enum = [value.const];
           }


### PR DESCRIPTION
It makes total sense in hindsight: the replacer gets passed *references* to the properties of the object being stringified, meaning actions on objects and arrays mutate the original schema.

This means currently `ref-common-schema` will end up modifying our schemas even if it doesn't update anything to reference a common schema.

This currently doesn't actually occur as we've already optimized, but making this change now because it's cheap and might as well :)

Also, realised that doing `key === 'type'` is silly because we have schemas that have a property called `type` - while they still will match because we're turning *all* instances of that property into an array, I've adjusted the script to be more correct anyway.