### PR TITLE
fix: improve usage of `milestone` common schema

### DIFF
--- a/payload-schemas/index.ts
+++ b/payload-schemas/index.ts
@@ -25,6 +25,8 @@ const requireSchema = (
   return keyName;
 };
 
+ajv.addKeyword("tsAdditionalProperties");
+
 readdirSync(`${schemaDir}/common`).forEach((filename) =>
   requireSchema("common", filename)
 );

--- a/payload-schemas/schemas/common/simple-pull-request.schema.json
+++ b/payload-schemas/schemas/common/simple-pull-request.schema.json
@@ -77,54 +77,23 @@
     },
     "labels": { "type": "array", "items": { "$ref": "label.schema.json" } },
     "milestone": {
-      "type": ["object", "null"],
-      "required": [
-        "url",
-        "html_url",
-        "labels_url",
-        "id",
-        "node_id",
-        "number",
-        "title",
-        "description",
-        "creator",
-        "open_issues",
-        "closed_issues",
-        "state",
-        "created_at",
-        "updated_at",
-        "due_on",
-        "closed_at"
-      ],
-      "properties": {
-        "url": { "type": "string", "format": "uri" },
-        "html_url": { "type": "string", "format": "uri" },
-        "labels_url": { "type": "string", "format": "uri" },
-        "id": { "type": "integer" },
-        "node_id": { "type": "string" },
-        "number": {
-          "type": "integer",
-          "description": "The number of the milestone."
-        },
-        "title": {
-          "type": "string",
-          "description": "The title of the milestone."
-        },
-        "description": { "type": ["string", "null"] },
-        "creator": { "$ref": "user.schema.json" },
-        "open_issues": { "type": "integer" },
-        "closed_issues": { "type": "integer" },
-        "state": {
-          "type": "string",
-          "enum": ["open", "closed"],
-          "description": "The state of the milestone."
-        },
-        "created_at": { "type": ["string", "null"], "format": "date-time" },
-        "updated_at": { "type": ["string", "null"], "format": "date-time" },
-        "due_on": { "type": ["string", "null"], "format": "date-time" },
-        "closed_at": { "type": ["string", "null"], "format": "date-time" }
-      },
-      "additionalProperties": false
+      "oneOf": [
+        { "type": "null" },
+        {
+          "allOf": [
+            { "$ref": "milestone.schema.json" },
+            {
+              "type": "object",
+              "required": ["state", "closed_at"],
+              "properties": {
+                "state": { "type": "string", "enum": ["closed"] },
+                "closed_at": { "type": "string" }
+              },
+              "tsAdditionalProperties": false
+            }
+          ]
+        }
+      ]
     },
     "draft": { "type": "boolean" },
     "commits_url": { "type": "string" },

--- a/payload-schemas/schemas/issue_comment/deleted.schema.json
+++ b/payload-schemas/schemas/issue_comment/deleted.schema.json
@@ -67,44 +67,19 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "type": "object",
-          "required": [
-            "url",
-            "html_url",
-            "labels_url",
-            "id",
-            "node_id",
-            "number",
-            "title",
-            "description",
-            "creator",
-            "open_issues",
-            "closed_issues",
-            "state",
-            "created_at",
-            "updated_at",
-            "due_on",
-            "closed_at"
-          ],
-          "properties": {
-            "url": { "type": "string" },
-            "html_url": { "type": "string" },
-            "labels_url": { "type": "string" },
-            "id": { "type": "integer" },
-            "node_id": { "type": "string" },
-            "number": { "type": "integer" },
-            "title": { "type": "string" },
-            "description": { "type": "string" },
-            "creator": { "$ref": "common/user.schema.json" },
-            "open_issues": { "type": "integer" },
-            "closed_issues": { "type": "integer" },
-            "state": { "type": "string" },
-            "created_at": { "type": "string" },
-            "updated_at": { "type": "string" },
-            "due_on": { "type": "string" },
-            "closed_at": { "type": "string" }
-          },
-          "additionalProperties": false
+          "allOf": [
+            { "$ref": "common/milestone.schema.json" },
+            {
+              "type": "object",
+              "required": ["description", "due_on", "closed_at"],
+              "properties": {
+                "description": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
+              },
+              "tsAdditionalProperties": false
+            }
+          ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string", "format": "date-time" },

--- a/payload-schemas/schemas/issue_comment/edited.schema.json
+++ b/payload-schemas/schemas/issue_comment/edited.schema.json
@@ -79,44 +79,19 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "type": "object",
-          "required": [
-            "url",
-            "html_url",
-            "labels_url",
-            "id",
-            "node_id",
-            "number",
-            "title",
-            "description",
-            "creator",
-            "open_issues",
-            "closed_issues",
-            "state",
-            "created_at",
-            "updated_at",
-            "due_on",
-            "closed_at"
-          ],
-          "properties": {
-            "url": { "type": "string" },
-            "html_url": { "type": "string" },
-            "labels_url": { "type": "string" },
-            "id": { "type": "integer" },
-            "node_id": { "type": "string" },
-            "number": { "type": "integer" },
-            "title": { "type": "string" },
-            "description": { "type": "string" },
-            "creator": { "$ref": "common/user.schema.json" },
-            "open_issues": { "type": "integer" },
-            "closed_issues": { "type": "integer" },
-            "state": { "type": "string" },
-            "created_at": { "type": "string" },
-            "updated_at": { "type": "string" },
-            "due_on": { "type": "string" },
-            "closed_at": { "type": "string" }
-          },
-          "additionalProperties": false
+          "allOf": [
+            { "$ref": "common/milestone.schema.json" },
+            {
+              "type": "object",
+              "required": ["description", "due_on", "closed_at"],
+              "properties": {
+                "description": { "type": "string" },
+                "due_on": { "type": "string" },
+                "closed_at": { "type": "string" }
+              },
+              "tsAdditionalProperties": false
+            }
+          ]
         },
         "comments": { "type": "integer" },
         "created_at": { "type": "string", "format": "date-time" },

--- a/payload-schemas/schemas/milestone/closed.schema.json
+++ b/payload-schemas/schemas/milestone/closed.schema.json
@@ -6,55 +6,18 @@
   "properties": {
     "action": { "type": "string", "enum": ["closed"] },
     "milestone": {
-      "description": "A collection of related issues and pull requests.",
-      "type": "object",
-      "required": [
-        "url",
-        "html_url",
-        "labels_url",
-        "id",
-        "node_id",
-        "number",
-        "title",
-        "description",
-        "creator",
-        "open_issues",
-        "closed_issues",
-        "state",
-        "created_at",
-        "updated_at",
-        "due_on",
-        "closed_at"
-      ],
-      "properties": {
-        "url": { "type": "string", "format": "uri" },
-        "html_url": { "type": "string", "format": "uri" },
-        "labels_url": { "type": "string", "format": "uri" },
-        "id": { "type": "integer" },
-        "node_id": { "type": "string" },
-        "number": {
-          "type": "integer",
-          "description": "The number of the milestone."
-        },
-        "title": {
-          "type": "string",
-          "description": "The title of the milestone."
-        },
-        "description": { "type": ["string", "null"] },
-        "creator": { "$ref": "common/user.schema.json" },
-        "open_issues": { "type": "integer" },
-        "closed_issues": { "type": "integer" },
-        "state": {
-          "type": "string",
-          "enum": ["closed"],
-          "description": "The state of the milestone."
-        },
-        "created_at": { "type": "string", "format": "date-time" },
-        "updated_at": { "type": "string", "format": "date-time" },
-        "due_on": { "type": ["string", "null"], "format": "date-time" },
-        "closed_at": { "type": "string", "format": "date-time" }
-      },
-      "additionalProperties": false
+      "allOf": [
+        { "$ref": "common/milestone.schema.json" },
+        {
+          "type": "object",
+          "required": ["state", "closed_at"],
+          "properties": {
+            "state": { "type": "string", "enum": ["closed"] },
+            "closed_at": { "type": "string" }
+          },
+          "tsAdditionalProperties": false
+        }
+      ]
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/milestone/created.schema.json
+++ b/payload-schemas/schemas/milestone/created.schema.json
@@ -6,54 +6,18 @@
   "properties": {
     "action": { "type": "string", "enum": ["created"] },
     "milestone": {
-      "type": "object",
-      "required": [
-        "url",
-        "html_url",
-        "labels_url",
-        "id",
-        "node_id",
-        "number",
-        "title",
-        "description",
-        "creator",
-        "open_issues",
-        "closed_issues",
-        "state",
-        "created_at",
-        "updated_at",
-        "due_on",
-        "closed_at"
-      ],
-      "properties": {
-        "url": { "type": "string", "format": "uri" },
-        "html_url": { "type": "string", "format": "uri" },
-        "labels_url": { "type": "string", "format": "uri" },
-        "id": { "type": "integer" },
-        "node_id": { "type": "string" },
-        "number": {
-          "type": "integer",
-          "description": "The number of the milestone."
-        },
-        "title": {
-          "type": "string",
-          "description": "The title of the milestone."
-        },
-        "description": { "type": ["string", "null"] },
-        "creator": { "$ref": "common/user.schema.json" },
-        "open_issues": { "type": "integer" },
-        "closed_issues": { "type": "integer" },
-        "state": {
-          "type": "string",
-          "enum": ["open"],
-          "description": "The state of the milestone."
-        },
-        "created_at": { "type": "string", "format": "date-time" },
-        "updated_at": { "type": "string", "format": "date-time" },
-        "due_on": { "type": ["string", "null"], "format": "date-time" },
-        "closed_at": { "type": "null" }
-      },
-      "additionalProperties": false
+      "allOf": [
+        { "$ref": "common/milestone.schema.json" },
+        {
+          "type": "object",
+          "required": ["state", "closed_at"],
+          "properties": {
+            "state": { "type": "string", "enum": ["open"] },
+            "closed_at": { "type": "null" }
+          },
+          "tsAdditionalProperties": false
+        }
+      ]
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/milestone/opened.schema.json
+++ b/payload-schemas/schemas/milestone/opened.schema.json
@@ -6,54 +6,18 @@
   "properties": {
     "action": { "type": "string", "enum": ["opened"] },
     "milestone": {
-      "type": "object",
-      "required": [
-        "url",
-        "html_url",
-        "labels_url",
-        "id",
-        "node_id",
-        "number",
-        "title",
-        "description",
-        "creator",
-        "open_issues",
-        "closed_issues",
-        "state",
-        "created_at",
-        "updated_at",
-        "due_on",
-        "closed_at"
-      ],
-      "properties": {
-        "url": { "type": "string", "format": "uri" },
-        "html_url": { "type": "string", "format": "uri" },
-        "labels_url": { "type": "string", "format": "uri" },
-        "id": { "type": "integer" },
-        "node_id": { "type": "string" },
-        "number": {
-          "type": "integer",
-          "description": "The number of the milestone."
-        },
-        "title": {
-          "type": "string",
-          "description": "The title of the milestone."
-        },
-        "description": { "type": ["string", "null"] },
-        "creator": { "$ref": "common/user.schema.json" },
-        "open_issues": { "type": "integer" },
-        "closed_issues": { "type": "integer" },
-        "state": {
-          "type": "string",
-          "enum": ["open"],
-          "description": "The state of the milestone."
-        },
-        "created_at": { "type": "string", "format": "date-time" },
-        "updated_at": { "type": "string", "format": "date-time" },
-        "due_on": { "type": ["string", "null"], "format": "date-time" },
-        "closed_at": { "type": "null" }
-      },
-      "additionalProperties": false
+      "allOf": [
+        { "$ref": "common/milestone.schema.json" },
+        {
+          "type": "object",
+          "required": ["state", "closed_at"],
+          "properties": {
+            "state": { "type": "string", "enum": ["open"] },
+            "closed_at": { "type": "null" }
+          },
+          "tsAdditionalProperties": false
+        }
+      ]
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -2252,21 +2252,8 @@ export interface IssueCommentDeletedEvent {
     locked: boolean;
     assignee: User | null;
     assignees: User[];
-    milestone: {
-      url: string;
-      html_url: string;
-      labels_url: string;
-      id: number;
-      node_id: string;
-      number: number;
-      title: string;
+    milestone: Milestone & {
       description: string;
-      creator: User;
-      open_issues: number;
-      closed_issues: number;
-      state: string;
-      created_at: string;
-      updated_at: string;
       due_on: string;
       closed_at: string;
     };
@@ -2347,21 +2334,8 @@ export interface IssueCommentEditedEvent {
     locked: boolean;
     assignee: User | null;
     assignees: User[];
-    milestone: {
-      url: string;
-      html_url: string;
-      labels_url: string;
-      id: number;
-      node_id: string;
-      number: number;
-      title: string;
+    milestone: Milestone & {
       description: string;
-      creator: User;
-      open_issues: number;
-      closed_issues: number;
-      state: string;
-      created_at: string;
-      updated_at: string;
       due_on: string;
       closed_at: string;
     };
@@ -3814,34 +3788,8 @@ export interface MetaDeletedEvent {
 }
 export interface MilestoneClosedEvent {
   action: "closed";
-  /**
-   * A collection of related issues and pull requests.
-   */
-  milestone: {
-    url: string;
-    html_url: string;
-    labels_url: string;
-    id: number;
-    node_id: string;
-    /**
-     * The number of the milestone.
-     */
-    number: number;
-    /**
-     * The title of the milestone.
-     */
-    title: string;
-    description: string | null;
-    creator: User;
-    open_issues: number;
-    closed_issues: number;
-    /**
-     * The state of the milestone.
-     */
+  milestone: Milestone & {
     state: "closed";
-    created_at: string;
-    updated_at: string;
-    due_on: string | null;
     closed_at: string;
   };
   repository: Repository;
@@ -3851,31 +3799,8 @@ export interface MilestoneClosedEvent {
 }
 export interface MilestoneCreatedEvent {
   action: "created";
-  milestone: {
-    url: string;
-    html_url: string;
-    labels_url: string;
-    id: number;
-    node_id: string;
-    /**
-     * The number of the milestone.
-     */
-    number: number;
-    /**
-     * The title of the milestone.
-     */
-    title: string;
-    description: string | null;
-    creator: User;
-    open_issues: number;
-    closed_issues: number;
-    /**
-     * The state of the milestone.
-     */
+  milestone: Milestone & {
     state: "open";
-    created_at: string;
-    updated_at: string;
-    due_on: string | null;
     closed_at: null;
   };
   repository: Repository;
@@ -3912,31 +3837,8 @@ export interface MilestoneEditedEvent {
 }
 export interface MilestoneOpenedEvent {
   action: "opened";
-  milestone: {
-    url: string;
-    html_url: string;
-    labels_url: string;
-    id: number;
-    node_id: string;
-    /**
-     * The number of the milestone.
-     */
-    number: number;
-    /**
-     * The title of the milestone.
-     */
-    title: string;
-    description: string | null;
-    creator: User;
-    open_issues: number;
-    closed_issues: number;
-    /**
-     * The state of the milestone.
-     */
+  milestone: Milestone & {
     state: "open";
-    created_at: string;
-    updated_at: string;
-    due_on: string | null;
     closed_at: null;
   };
   repository: Repository;
@@ -5531,33 +5433,12 @@ export interface SimplePullRequest {
   requested_reviewers: (User | Team)[];
   requested_teams: Team[];
   labels: Label[];
-  milestone: {
-    url: string;
-    html_url: string;
-    labels_url: string;
-    id: number;
-    node_id: string;
-    /**
-     * The number of the milestone.
-     */
-    number: number;
-    /**
-     * The title of the milestone.
-     */
-    title: string;
-    description: string | null;
-    creator: User;
-    open_issues: number;
-    closed_issues: number;
-    /**
-     * The state of the milestone.
-     */
-    state: "open" | "closed";
-    created_at: string | null;
-    updated_at: string | null;
-    due_on: string | null;
-    closed_at: string | null;
-  } | null;
+  milestone:
+    | null
+    | (Milestone & {
+        state: "closed";
+        closed_at: string;
+      });
   draft: boolean;
   commits_url: string;
   review_comments_url: string;


### PR DESCRIPTION
When present, `tsAdditionalProperties` is used as the value for `additionalProperties` only when compiling a given schema to TypeScript, which allows us to use `allOf` to "extend" a common schema without weakening our types.

This is required because we have to allow additionalProperties in the extending schema type (the schema in index `1` of the `allOf` array) since it's only a subset of the properties defined in the parent schema. However if `additionalProperties` is not set to `false` when generating the types it adds `[key: string]: unknown`, which makes the type an open object which is incorrect.

The drive behind this is that ideally the common schemas/types should represent the *general* state of a particular type rather than the state of the type for only a specific subset of schemas, with the rest having to inline the type as that's the natural thing to expect. (aka, we want common schemas to represent the superset of all possible states of a given common schema)

(this is actually approaching a similar state to what the schemas were originally in with their actions, which isn't a bad thing - it could make sense down the line to make the common schemas even more specific with `oneOf`s, but they're probably not going to be big enough for it to be worth it, vs just using `allOf` inline).

This method of extending should cover most of the common use-cases, so long as the properties being modified exist on the parent schema. I've got ideas on how to improve this which I'll probably land later on :)