### PR TITLE
fix: mark `milestone` property as possibly `null` on `issue_comment`

### DIFF
--- a/payload-schemas/schemas/issue_comment/deleted.schema.json
+++ b/payload-schemas/schemas/issue_comment/deleted.schema.json
@@ -67,18 +67,9 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "allOf": [
+          "oneOf": [
             { "$ref": "common/milestone.schema.json" },
-            {
-              "type": "object",
-              "required": ["description", "due_on", "closed_at"],
-              "properties": {
-                "description": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "tsAdditionalProperties": false
-            }
+            { "type": "null" }
           ]
         },
         "comments": { "type": "integer" },

--- a/payload-schemas/schemas/issue_comment/edited.schema.json
+++ b/payload-schemas/schemas/issue_comment/edited.schema.json
@@ -79,18 +79,9 @@
           "items": { "$ref": "common/user.schema.json" }
         },
         "milestone": {
-          "allOf": [
+          "oneOf": [
             { "$ref": "common/milestone.schema.json" },
-            {
-              "type": "object",
-              "required": ["description", "due_on", "closed_at"],
-              "properties": {
-                "description": { "type": "string" },
-                "due_on": { "type": "string" },
-                "closed_at": { "type": "string" }
-              },
-              "tsAdditionalProperties": false
-            }
+            { "type": "null" }
           ]
         },
         "comments": { "type": "integer" },

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -2245,11 +2245,7 @@ export interface IssueCommentDeletedEvent {
     locked: boolean;
     assignee: User | null;
     assignees: User[];
-    milestone: Milestone & {
-      description: string;
-      due_on: string;
-      closed_at: string;
-    };
+    milestone: Milestone | null;
     comments: number;
     created_at: string;
     updated_at: string;
@@ -2327,11 +2323,7 @@ export interface IssueCommentEditedEvent {
     locked: boolean;
     assignee: User | null;
     assignees: User[];
-    milestone: Milestone & {
-      description: string;
-      due_on: string;
-      closed_at: string;
-    };
+    milestone: Milestone | null;
     comments: number;
     created_at: string;
     updated_at: string;


### PR DESCRIPTION
Originally this was just marking `milestone` as possibly `null`, but then I realised that there isn't a reason why `description`, `due_on`, or `closed_at` should never be `null` for the events in question.