### PR TITLE
fix: update schema for `milestone` property on `simple-pull-request`

### DIFF
--- a/payload-schemas/schemas/common/simple-pull-request.schema.json
+++ b/payload-schemas/schemas/common/simple-pull-request.schema.json
@@ -77,23 +77,7 @@
     },
     "labels": { "type": "array", "items": { "$ref": "label.schema.json" } },
     "milestone": {
-      "oneOf": [
-        { "type": "null" },
-        {
-          "allOf": [
-            { "$ref": "milestone.schema.json" },
-            {
-              "type": "object",
-              "required": ["state", "closed_at"],
-              "properties": {
-                "state": { "type": "string", "enum": ["closed"] },
-                "closed_at": { "type": "string" }
-              },
-              "tsAdditionalProperties": false
-            }
-          ]
-        }
-      ]
+      "oneOf": [{ "$ref": "milestone.schema.json" }, { "type": "null" }]
     },
     "draft": { "type": "boolean" },
     "commits_url": { "type": "string" },

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -5310,12 +5310,7 @@ export interface SimplePullRequest {
   requested_reviewers: (User | Team)[];
   requested_teams: Team[];
   labels: Label[];
-  milestone:
-    | null
-    | (Milestone & {
-        state: "closed";
-        closed_at: string;
-      });
+  milestone: Milestone | null;
   draft: boolean;
   commits_url: string;
   review_comments_url: string;


### PR DESCRIPTION
Ideally I'd like to combine this with `pull-request`, but it'll need some extra work to make the types come out nice.

The best way to do that'll probably be to make this schema `pull-request` w/ all the properties, and then rename the other to `pull-request-complete` as an `allOf` of this + the extra properties being marked as required 🤔 