### PR TITLE
refactor: move common functions in bin scripts into utils folder

### DIFF
--- a/bin/diff-interface-schemas.ts
+++ b/bin/diff-interface-schemas.ts
@@ -1,30 +1,14 @@
 #!/usr/bin/env ts-node-transpile-only
 
 import { strict as assert } from "assert";
-import fs from "fs";
 import { diffString } from "json-diff";
 import { JSONSchema7 } from "json-schema";
-
-const pathToSchemas = "payload-schemas/schemas";
-
-const metaProperties = [
-  "$schema", //
-  "$id",
-  "title",
-  "description",
-  "format",
-];
-
-const parseArgv = (argv: string[]): [args: string[], flags: string[]] => {
-  const flags: string[] = [];
-  const args: string[] = [];
-
-  argv.forEach((arg) => {
-    arg.startsWith("--") ? flags.push(arg) : args.push(arg);
-  });
-
-  return [args, flags];
-};
+import {
+  getSchemaFromPath,
+  loadMapOfSchemas,
+  normalizeSchema,
+  parseArgv,
+} from "./utils";
 
 const [[interfacePropertyPath1, interfacePropertyPath2], flags] = parseArgv(
   process.argv.slice(2)
@@ -42,125 +26,10 @@ assert.ok(
   "second argument must be path to a property on an interface to compare the schema of"
 );
 
-const titleCase = (str: string) => `${str[0].toUpperCase()}${str.substring(1)}`;
+const schemas = loadMapOfSchemas();
 
-const guessAtInterfaceName = (schema: JSONSchema7): string => {
-  const str = schema.title || schema.$id;
-
-  assert.ok(str, "unable to guess interface name");
-
-  return str
-    .split(/[$_ -]/u)
-    .map(titleCase)
-    .join("");
-};
-
-const ensureArray = <T>(arr: T | T[]): T[] =>
-  Array.isArray(arr) ? arr : [arr];
-
-type InterfaceNameAndSchema = [interfaceName: string, schema: JSONSchema7];
-
-const loadSchemas = (directory: string): InterfaceNameAndSchema[] => {
-  return fs
-    .readdirSync(directory, { withFileTypes: true })
-    .flatMap((entity) => {
-      const pathToEntity = `${directory}/${entity.name}`;
-
-      if (entity.isDirectory()) {
-        return loadSchemas(pathToEntity);
-      }
-
-      const schema = JSON.parse(
-        fs.readFileSync(pathToEntity, "utf-8")
-      ) as JSONSchema7;
-
-      return [[guessAtInterfaceName(schema), schema]];
-    });
-};
-
-const extractFromSchema = (schema: JSONSchema7, name: string): JSONSchema7 => {
-  if (ensureArray(schema.type).includes("object")) {
-    assert.ok(
-      schema.properties,
-      "cannot extract from an object-type schema that lacks properties"
-    );
-
-    const value = schema.properties[name];
-
-    assert.ok(typeof value !== "boolean", "this is not what you want");
-
-    return value;
-  }
-
-  if (ensureArray(schema.type).includes("array")) {
-    assert.ok(schema.items);
-  }
-
-  if (schema.oneOf) {
-    throw new Error("extracting schemas from unions is not supported");
-  }
-
-  throw new Error(
-    `schemas can only be extracted from objects or arrays (got ${schema.type})`
-  );
-};
-
-const cloneObject = <TObject extends object>(object: TObject): TObject =>
-  JSON.parse(JSON.stringify(object)) as TObject;
-
-const isJsonSchemaObject = (object: unknown): object is JSONSchema7 =>
-  typeof object === "object" && object !== null && !Array.isArray(object);
-
-const normalizeSchema = (schema: JSONSchema7): JSONSchema7 => {
-  try {
-    return JSON.parse(
-      JSON.stringify(cloneObject(schema), (key, value: unknown) => {
-        if (metaProperties.includes(key)) {
-          return undefined;
-        }
-
-        if (
-          key === "$ref" &&
-          typeof value === "string" &&
-          !value.startsWith("common/") &&
-          value.endsWith(".schema.json")
-        ) {
-          return `common/${value}`;
-        }
-
-        if (Array.isArray(value)) {
-          return [...value].sort();
-        }
-
-        if (isJsonSchemaObject(value)) {
-          if (value.type) {
-            value.type = ensureArray(value.type);
-          }
-
-          if (value.const !== undefined) {
-            value.enum = [value.const];
-          }
-        }
-
-        return value;
-      })
-    ) as JSONSchema7;
-  } catch (error) {
-    console.log(schema);
-
-    throw error;
-  }
-};
-
-const schemas = Object.fromEntries(loadSchemas(pathToSchemas));
-
-const getSchemaFromPath = (interfacePropertyPath: string) => {
-  const schema = interfacePropertyPath
-    .split(".")
-    .reduce<JSONSchema7>(
-      (schema, segment) => extractFromSchema(schema, segment),
-      { type: "object", properties: schemas }
-    );
+const getSchema = (interfacePath: string): JSONSchema7 => {
+  const schema = getSchemaFromPath(interfacePath, schemas);
 
   if (skipNormalizingSchema) {
     return schema;
@@ -169,7 +38,7 @@ const getSchemaFromPath = (interfacePropertyPath: string) => {
   return normalizeSchema(schema);
 };
 
-const firstSchema = getSchemaFromPath(interfacePropertyPath1);
-const secondSchema = getSchemaFromPath(interfacePropertyPath2);
+const firstSchema = getSchema(interfacePropertyPath1);
+const secondSchema = getSchema(interfacePropertyPath2);
 
 console.log(diffString(firstSchema, secondSchema));

--- a/bin/format-with-prettier.ts
+++ b/bin/format-with-prettier.ts
@@ -3,37 +3,32 @@
 import fs from "fs";
 import { JSONSchema7 } from "json-schema";
 import { format } from "prettier";
+import { forEachJsonFile, pathToPayloads, pathToSchemas } from "./utils";
 
 const checkOnly = process.argv.includes("--check");
 
 const formatJsonInDirectory = (pathToJsons: string) => {
-  fs.readdirSync(pathToJsons).forEach((jsonName) => {
-    const folderPath = `${pathToJsons}/${jsonName}`;
+  forEachJsonFile(pathToJsons, (filePath) => {
+    const contentsBefore = fs.readFileSync(filePath, "utf-8");
+    const contentsAfter = format(
+      JSON.stringify(JSON.parse(contentsBefore) as JSONSchema7),
+      { parser: "json" }
+    );
 
-    fs.readdirSync(folderPath).forEach((file) => {
-      const filePath = `${folderPath}/${file}`;
+    if (contentsBefore === contentsAfter) {
+      return;
+    }
 
-      const contentsBefore = fs.readFileSync(filePath, "utf-8");
-      const contentsAfter = format(
-        JSON.stringify(JSON.parse(contentsBefore) as JSONSchema7),
-        { parser: "json" }
-      );
+    if (checkOnly) {
+      console.warn(`${filePath} needs to be formatted`);
+      process.exitCode = 1;
 
-      if (contentsBefore === contentsAfter) {
-        return;
-      }
+      return;
+    }
 
-      if (checkOnly) {
-        console.warn(`${filePath} needs to be formatted`);
-        process.exitCode = 1;
-
-        return;
-      }
-
-      fs.writeFileSync(filePath, contentsAfter);
-    });
+    fs.writeFileSync(filePath, contentsAfter);
   });
 };
 
-formatJsonInDirectory("payload-examples/api.github.com");
-formatJsonInDirectory("payload-schemas/schemas");
+formatJsonInDirectory(pathToPayloads);
+formatJsonInDirectory(pathToSchemas);

--- a/bin/octokit-schema.ts
+++ b/bin/octokit-schema.ts
@@ -5,8 +5,7 @@ import fs from "fs";
 import { JSONSchema7 } from "json-schema";
 import path from "path";
 import { format } from "prettier";
-
-const pathToWebhookSchemas = "payload-schemas/schemas";
+import { pathToSchemas } from "./utils";
 
 const removeExtension = (fileName: string, ext: string): string => {
   assert.ok(fileName.endsWith(ext), `"${fileName}" does not end with "${ext}"`);
@@ -15,20 +14,20 @@ const removeExtension = (fileName: string, ext: string): string => {
 };
 
 const buildCommonSchemasDefinitionSchema = (): Record<string, JSONSchema7> => {
-  const commonSchemas = fs.readdirSync(`${pathToWebhookSchemas}/common`);
+  const commonSchemas = fs.readdirSync(`${pathToSchemas}/common`);
   const definitions: Record<string, JSONSchema7> = {};
 
   commonSchemas.forEach((schema) => {
     definitions[
       removeExtension(schema, ".schema.json")
-    ] = require(`../${pathToWebhookSchemas}/common/${schema}`);
+    ] = require(`../${pathToSchemas}/common/${schema}`);
   });
 
   return definitions;
 };
 
 const listEvents = () => {
-  const directoryEntities = fs.readdirSync(pathToWebhookSchemas, {
+  const directoryEntities = fs.readdirSync(pathToSchemas, {
     withFileTypes: true,
   });
 
@@ -51,11 +50,11 @@ const combineEventSchemas = () => {
   const events = listEvents();
 
   events.forEach((event) => {
-    const schemas = fs.readdirSync(`${pathToWebhookSchemas}/${event}`);
+    const schemas = fs.readdirSync(`${pathToSchemas}/${event}`);
 
     if (schemas.length === 1 && schemas[0] === "event.schema.json") {
       // schemas without any actions are just called "event"
-      const schema = require(`../${pathToWebhookSchemas}/${event}/event.schema.json`) as JSONSchema7;
+      const schema = require(`../${pathToSchemas}/${event}/event.schema.json`) as JSONSchema7;
       const eventName = schema.$id;
 
       assert.ok(eventName, `${event}/event.schema.json does not have an $id`);
@@ -74,7 +73,7 @@ const combineEventSchemas = () => {
     }
 
     const eventActions = schemas.map((schemaName) => {
-      const schema = require(`../${pathToWebhookSchemas}/${event}/${schemaName}`) as JSONSchema7;
+      const schema = require(`../${pathToSchemas}/${event}/${schemaName}`) as JSONSchema7;
       const actionEventName = schema.$id;
 
       assert.ok(actionEventName, `${event}/${schemaName} does not have an $id`);

--- a/bin/octokit-types.ts
+++ b/bin/octokit-types.ts
@@ -5,11 +5,7 @@ import { promises as fs } from "fs";
 import { JSONSchema4, JSONSchema7 } from "json-schema";
 import { compile } from "json-schema-to-typescript";
 import { format } from "prettier";
-
-const titleCase = (str: string) => `${str[0].toUpperCase()}${str.substring(1)}`;
-
-const guessAtInterfaceName = (str: string) =>
-  str.split("_").map(titleCase).join("");
+import { guessAtInterfaceName, isJsonSchemaObject } from "./utils";
 
 const getEventName = (ref: string): string => {
   assert.ok(
@@ -36,7 +32,7 @@ interface Schema extends JSONSchema7 {
 const buildEventPayloadMap = (schema: Schema): string => {
   const properties = schema.oneOf.map(({ $ref }) => {
     const eventName = getEventName($ref);
-    const interfaceName = guessAtInterfaceName(`${eventName}_event`);
+    const interfaceName = guessAtInterfaceName({ $id: `${eventName}_event` });
 
     return `"${eventName}": ${interfaceName}`;
   });
@@ -46,9 +42,6 @@ const buildEventPayloadMap = (schema: Schema): string => {
 
 const getSchema = async () =>
   JSON.parse(await fs.readFile("./schema.json", "utf-8")) as Schema;
-
-const isJsonSchemaObject = (object: unknown): object is JSONSchema7 =>
-  typeof object === "object" && object !== null && !Array.isArray(object);
 
 declare module "json-schema" {
   interface JSONSchema7 {

--- a/bin/optimize-schemas.ts
+++ b/bin/optimize-schemas.ts
@@ -8,6 +8,12 @@ import {
   JSONSchema7TypeName,
 } from "json-schema";
 import { format } from "prettier";
+import {
+  pathToSchemas,
+  ensureArray,
+  isJsonSchemaObject,
+  forEachJsonFile,
+} from "./utils";
 
 const JSONSchema7TypeNameOrder = [
   "string",
@@ -18,14 +24,6 @@ const JSONSchema7TypeNameOrder = [
   "array",
   "null",
 ] as const;
-
-const payloads = "payload-schemas/schemas";
-
-const ensureArray = <T>(arr: T | T[]): T[] =>
-  Array.isArray(arr) ? arr : [arr];
-
-const isJsonSchemaObject = (object: unknown): object is JSONSchema7 =>
-  typeof object === "object" && object !== null && !Array.isArray(object);
 
 const standardizeTypeProperty = (
   types: JSONSchema7TypeName[]
@@ -67,69 +65,66 @@ const addNullToObject = (object: JSONSchema7) => {
   }
 };
 
-fs.readdirSync(payloads).forEach((event) => {
-  fs.readdirSync(`${payloads}/${event}`).forEach((schema) => {
-    const pathToSchema = `${payloads}/${event}/${schema}`;
-    const contents = JSON.parse(fs.readFileSync(pathToSchema, "utf-8"));
+forEachJsonFile(pathToSchemas, (pathToSchema) => {
+  const contents = JSON.parse(fs.readFileSync(pathToSchema, "utf-8"));
 
-    fs.writeFileSync(
-      pathToSchema,
-      format(
-        JSON.stringify(contents, (key, value: unknown | JSONSchema7) => {
-          if (!isJsonSchemaObject(value)) {
-            return value;
-          }
-
-          if (value.type) {
-            if (Array.isArray(value.type)) {
-              value.type = standardizeTypeProperty(value.type);
-            }
-
-            if (
-              ensureArray(value.type).includes("object") &&
-              !("tsAdditionalProperties" in value)
-            ) {
-              value.additionalProperties ||= false;
-            }
-          }
-
-          if (value.anyOf) {
-            assert.ok(!value.oneOf, "object has both oneOf & anyOf");
-
-            // we don't have any use for anyOf, while oneOf is stricter
-            value.oneOf = value.anyOf;
-            delete value.anyOf;
-          }
-
-          if (value.oneOf) {
-            // { "type": "null" } & { ... } can be combined as "type" supports an array
-            if (value.oneOf.some(isNullType)) {
-              const [notNullType] = value.oneOf.filter(
-                (object) => !isNullType(object)
-              );
-
-              assert.ok(
-                typeof notNullType !== "boolean",
-                "unexpected boolean in oneOf"
-              );
-
-              if (!notNullType.$ref && !notNullType.allOf) {
-                addNullToObject(notNullType);
-
-                return notNullType;
-              }
-            }
-
-            // "oneOf" is redundant if it's only got one schema
-            if (value.oneOf.length === 1) {
-              return value.oneOf[0];
-            }
-          }
-
+  fs.writeFileSync(
+    pathToSchema,
+    format(
+      JSON.stringify(contents, (key, value: unknown | JSONSchema7) => {
+        if (!isJsonSchemaObject(value)) {
           return value;
-        }),
-        { parser: "json" }
-      )
-    );
-  });
+        }
+
+        if (value.type) {
+          if (Array.isArray(value.type)) {
+            value.type = standardizeTypeProperty(value.type);
+          }
+
+          if (
+            ensureArray(value.type).includes("object") &&
+            !("tsAdditionalProperties" in value)
+          ) {
+            value.additionalProperties ||= false;
+          }
+        }
+
+        if (value.anyOf) {
+          assert.ok(!value.oneOf, "object has both oneOf & anyOf");
+
+          // we don't have any use for anyOf, while oneOf is stricter
+          value.oneOf = value.anyOf;
+          delete value.anyOf;
+        }
+
+        if (value.oneOf) {
+          // { "type": "null" } & { ... } can be combined as "type" supports an array
+          if (value.oneOf.some(isNullType)) {
+            const [notNullType] = value.oneOf.filter(
+              (object) => !isNullType(object)
+            );
+
+            assert.ok(
+              typeof notNullType !== "boolean",
+              "unexpected boolean in oneOf"
+            );
+
+            if (!notNullType.$ref && !notNullType.allOf) {
+              addNullToObject(notNullType);
+
+              return notNullType;
+            }
+          }
+
+          // "oneOf" is redundant if it's only got one schema
+          if (value.oneOf.length === 1) {
+            return value.oneOf[0];
+          }
+        }
+
+        return value;
+      }),
+      { parser: "json" }
+    )
+  );
 });

--- a/bin/ref-common-schemas.ts
+++ b/bin/ref-common-schemas.ts
@@ -4,66 +4,12 @@ import deepEqual from "fast-deep-equal";
 import fs from "fs";
 import { JSONSchema7 } from "json-schema";
 import { format } from "prettier";
-
-const pathToSchemas = "payload-schemas/schemas";
-
-const metaProperties = [
-  "$schema", //
-  "$id",
-  "title",
-  "description",
-  "format",
-];
-
-const cloneObject = <TObject extends object>(object: TObject): TObject =>
-  JSON.parse(JSON.stringify(object)) as TObject;
-
-const isJsonSchemaObject = (object: unknown): object is JSONSchema7 =>
-  typeof object === "object" && object !== null && !Array.isArray(object);
-
-const ensureArray = <T>(arr: T | T[]): T[] =>
-  Array.isArray(arr) ? arr : [arr];
-
-const normalizeSchema = (schema: JSONSchema7): JSONSchema7 => {
-  try {
-    return JSON.parse(
-      JSON.stringify(cloneObject(schema), (key, value: unknown) => {
-        if (metaProperties.includes(key)) {
-          return undefined;
-        }
-
-        if (
-          key === "$ref" &&
-          typeof value === "string" &&
-          !value.startsWith("common/") &&
-          value.endsWith(".schema.json")
-        ) {
-          return `common/${value}`;
-        }
-
-        if (Array.isArray(value)) {
-          return [...value].sort();
-        }
-
-        if (isJsonSchemaObject(value)) {
-          if (value.type) {
-            value.type = ensureArray(value.type);
-          }
-
-          if (value.const !== undefined) {
-            value.enum = [value.const];
-          }
-        }
-
-        return value;
-      })
-    ) as JSONSchema7;
-  } catch (error) {
-    console.log(schema);
-
-    throw error;
-  }
-};
+import {
+  pathToSchemas,
+  ensureArray,
+  normalizeSchema,
+  forEachJsonFile,
+} from "./utils";
 
 const commonSchemas = fs
   .readdirSync(`${pathToSchemas}/common`)
@@ -107,44 +53,40 @@ const splitIntoObjectAndNull = (
 
 let count = 0;
 
-fs.readdirSync(pathToSchemas).forEach((eventName) => {
-  if (eventName === "common") {
-    return; // "common" is not an event
+forEachJsonFile(pathToSchemas, (filePath) => {
+  if (filePath.includes("/common/")) {
+    return;
   }
 
-  fs.readdirSync(`${pathToSchemas}/${eventName}`).forEach((file) => {
-    const schema = JSON.parse(
-      fs.readFileSync(`${pathToSchemas}/${eventName}/${file}`, "utf-8")
-    ) as JSONSchema7;
+  const schema = JSON.parse(fs.readFileSync(filePath, "utf-8")) as JSONSchema7;
 
-    fs.writeFileSync(
-      `${pathToSchemas}/${eventName}/${file}`,
-      format(
-        JSON.stringify(schema, (key, value) => {
-          if (typeof value === "object" && value !== null) {
-            const [object, nullType] = splitIntoObjectAndNull(value);
+  fs.writeFileSync(
+    filePath,
+    format(
+      JSON.stringify(schema, (key, value) => {
+        if (typeof value === "object" && value !== null) {
+          const [object, nullType] = splitIntoObjectAndNull(value);
 
-            const commonSchema = findCommonSchema(object);
+          const commonSchema = findCommonSchema(object);
 
-            if (commonSchema) {
-              const commonRef = { $ref: `common/${commonSchema}` };
+          if (commonSchema) {
+            const commonRef = { $ref: `common/${commonSchema}` };
 
-              if (nullType) {
-                return { oneOf: [commonRef, nullType] };
-              }
-
-              count += 1;
-
-              return commonRef;
+            if (nullType) {
+              return { oneOf: [commonRef, nullType] };
             }
-          }
 
-          return value;
-        }),
-        { parser: "json" }
-      )
-    );
-  });
+            count += 1;
+
+            return commonRef;
+          }
+        }
+
+        return value;
+      }),
+      { parser: "json" }
+    )
+  );
 });
 
 console.log(

--- a/bin/utils/argv.ts
+++ b/bin/utils/argv.ts
@@ -1,0 +1,12 @@
+export const parseArgv = (
+  argv: string[]
+): [args: string[], flags: string[]] => {
+  const flags: string[] = [];
+  const args: string[] = [];
+
+  argv.forEach((arg) => {
+    arg.startsWith("--") ? flags.push(arg) : args.push(arg);
+  });
+
+  return [args, flags];
+};

--- a/bin/utils/forEachJsonFile.ts
+++ b/bin/utils/forEachJsonFile.ts
@@ -1,0 +1,16 @@
+import fs from "fs";
+
+export const forEachJsonFile = (
+  directory: string,
+  callback: (pathToFile: string) => void
+) => {
+  fs.readdirSync(directory, { withFileTypes: true }).forEach((entity) => {
+    const pathToEntity = `${directory}/${entity.name}`;
+
+    if (entity.isDirectory()) {
+      return forEachJsonFile(pathToEntity, callback);
+    }
+
+    callback(pathToEntity);
+  });
+};

--- a/bin/utils/getSchemaFromPath.ts
+++ b/bin/utils/getSchemaFromPath.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from "assert";
+import { JSONSchema7 } from "json-schema";
+import { ensureArray } from ".";
+
+const extractFromSchema = (schema: JSONSchema7, name: string): JSONSchema7 => {
+  if (ensureArray(schema.type).includes("object")) {
+    assert.ok(
+      schema.properties,
+      "cannot extract from an object-type schema that lacks properties"
+    );
+
+    const value = schema.properties[name];
+
+    assert.ok(typeof value !== "boolean", "this is not what you want");
+
+    return value;
+  }
+
+  if (ensureArray(schema.type).includes("array")) {
+    assert.ok(schema.items);
+  }
+
+  if (schema.oneOf) {
+    throw new Error("extracting schemas from unions is not supported");
+  }
+
+  throw new Error(
+    `schemas can only be extracted from objects or arrays (got ${schema.type})`
+  );
+};
+
+export const getSchemaFromPath = (
+  interfacePropertyPath: string,
+  schemas: Record<string, JSONSchema7>
+): JSONSchema7 =>
+  interfacePropertyPath
+    .split(".")
+    .reduce<JSONSchema7>(
+      (schema, segment) => extractFromSchema(schema, segment),
+      { type: "object", properties: schemas }
+    );

--- a/bin/utils/index.ts
+++ b/bin/utils/index.ts
@@ -1,0 +1,9 @@
+export * from "./getSchemaFromPath";
+export * from "./forEachJsonFile";
+export * from "./loadMapOfSchemas";
+export * from "./normalizeSchema";
+export * from "./misc";
+export * from "./argv";
+
+export const pathToPayloads = "payload-examples/api.github.com";
+export const pathToSchemas = "payload-schemas/schemas";

--- a/bin/utils/loadMapOfSchemas.ts
+++ b/bin/utils/loadMapOfSchemas.ts
@@ -1,0 +1,19 @@
+import fs from "fs";
+import { JSONSchema7 } from "json-schema";
+import { forEachJsonFile, guessAtInterfaceName, pathToSchemas } from ".";
+
+type InterfaceNameAndSchema = [interfaceName: string, schema: JSONSchema7];
+
+export const loadMapOfSchemas = (): Record<string, JSONSchema7> => {
+  const entries: InterfaceNameAndSchema[] = [];
+
+  forEachJsonFile(pathToSchemas, (pathToSchema) => {
+    const schema = JSON.parse(
+      fs.readFileSync(pathToSchema, "utf-8")
+    ) as JSONSchema7;
+
+    entries.push([guessAtInterfaceName(schema), schema]);
+  });
+
+  return Object.fromEntries(entries);
+};

--- a/bin/utils/misc.ts
+++ b/bin/utils/misc.ts
@@ -1,0 +1,22 @@
+import { strict as assert } from "assert";
+import { JSONSchema7 } from "json-schema";
+
+const capitalize = (str: string) =>
+  `${str[0].toUpperCase()}${str.substring(1)}`;
+
+export const guessAtInterfaceName = (schema: JSONSchema7): string => {
+  const str = schema.title || schema.$id;
+
+  assert.ok(str, "unable to guess interface name");
+
+  return str
+    .split(/[$_ -]/u)
+    .map(capitalize)
+    .join("");
+};
+
+export const ensureArray = <T>(arr: T | T[]): T[] =>
+  Array.isArray(arr) ? arr : [arr];
+
+export const isJsonSchemaObject = (object: unknown): object is JSONSchema7 =>
+  typeof object === "object" && object !== null && !Array.isArray(object);

--- a/bin/utils/normalizeSchema.ts
+++ b/bin/utils/normalizeSchema.ts
@@ -1,0 +1,49 @@
+import { JSONSchema7 } from "json-schema";
+import { ensureArray, isJsonSchemaObject } from ".";
+
+const metaProperties = [
+  "$schema", //
+  "$id",
+  "title",
+  "description",
+  "format",
+];
+
+export const normalizeSchema = (schema: JSONSchema7): JSONSchema7 => {
+  try {
+    return JSON.parse(JSON.stringify(schema), (key, value: unknown) => {
+      if (metaProperties.includes(key)) {
+        return undefined;
+      }
+
+      if (
+        key === "$ref" &&
+        typeof value === "string" &&
+        !value.startsWith("common/") &&
+        value.endsWith(".schema.json")
+      ) {
+        return `common/${value}`;
+      }
+
+      if (Array.isArray(value)) {
+        return [...value].sort();
+      }
+
+      if (isJsonSchemaObject(value)) {
+        if (value.type) {
+          value.type = ensureArray(value.type);
+        }
+
+        if (value.const !== undefined) {
+          value.enum = [value.const];
+        }
+      }
+
+      return value;
+    }) as JSONSchema7;
+  } catch (error) {
+    console.log(schema);
+
+    throw error;
+  }
+};

--- a/bin/validate-payload-examples.ts
+++ b/bin/validate-payload-examples.ts
@@ -1,11 +1,10 @@
 #!/usr/bin/env ts-node-transpile-only
 
 import { DefinedError, ErrorObject } from "ajv";
-import fs from "fs";
-import { ajv, validate } from "../payload-schemas";
+import path from "path";
 import { inspect } from "util";
-
-const payloads = `./payload-examples/api.github.com`;
+import { ajv, validate } from "../payload-schemas";
+import { forEachJsonFile, pathToPayloads } from "./utils";
 
 const continueOnError = process.argv.includes("--continue-on-error");
 
@@ -29,33 +28,28 @@ const printAjvErrors = () => {
   console.error(inspect(finalErrors, { depth: Infinity, colors: true }));
 };
 
-fs.readdirSync(payloads).forEach((event) => {
-  fs.readdirSync(`${payloads}/${event}`)
-    .filter((filename) => filename.endsWith(".json"))
-    .forEach((filename) => {
-      const file = require(`../${payloads}/${event}/${filename}`) as unknown;
+forEachJsonFile(pathToPayloads, (filePath) => {
+  const file = require(`../${filePath}`) as unknown;
+  const { dir: event, base: filename } = path.parse(
+    path.relative(pathToPayloads, filePath)
+  );
 
-      try {
-        const validationResult = validate(event, file);
+  try {
+    const validationResult = validate(event, file);
 
-        if (!validationResult) {
-          console.error(
-            `❌ Payload '${event}/${filename}' does not match schema`
-          );
-          printAjvErrors();
-          process.exitCode = 1;
-        } else {
-          console.log(`✅ Payload '${event}/${filename}' matches schema`);
-        }
-      } catch (err) {
-        if (!continueOnError) {
-          throw err;
-        }
+    if (!validationResult) {
+      console.error(`❌ Payload '${event}/${filename}' does not match schema`);
+      printAjvErrors();
+      process.exitCode = 1;
+    } else {
+      console.log(`✅ Payload '${event}/${filename}' matches schema`);
+    }
+  } catch (err) {
+    if (!continueOnError) {
+      throw err;
+    }
 
-        console.error(
-          `💥 Payload '${event}/${filename}' errored: ${err.message}`
-        );
-        process.exitCode = 1;
-      }
-    });
+    console.error(`💥 Payload '${event}/${filename}' errored: ${err.message}`);
+    process.exitCode = 1;
+  }
 });


### PR DESCRIPTION
Have I gone a little overboard? Maybe
Have I got a follow-up PR refactoring argv parsing that's probably overboard? Yup 😁
Does it have `--help` doc support? 💯

----

This does what it says in the title - the majority of the refactoring is moving things into `utils/` wholesale, with a sprinkle of name and code refactoring based on reducing duplication and such.