### PR TITLE
Update Codescanning Alert Payload Schemas to Include a Sender Field

### DIFF
--- a/index.json
+++ b/index.json
@@ -4979,6 +4979,26 @@
         "installation": {
           "id": 1,
           "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMQ=="
+        },
+        "sender": {
+          "login": "Codertocat",
+          "id": 21031067,
+          "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+          "avatar_url": "https://avatars1.githubusercontent.com/u/21031067?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/Codertocat",
+          "html_url": "https://github.com/Codertocat",
+          "followers_url": "https://api.github.com/users/Codertocat/followers",
+          "following_url": "https://api.github.com/users/Codertocat/following{/other_user}",
+          "gists_url": "https://api.github.com/users/Codertocat/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/Codertocat/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/Codertocat/subscriptions",
+          "organizations_url": "https://api.github.com/users/Codertocat/orgs",
+          "repos_url": "https://api.github.com/users/Codertocat/repos",
+          "events_url": "https://api.github.com/users/Codertocat/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/Codertocat/received_events",
+          "type": "User",
+          "site_admin": false
         }
       }
     ]

--- a/index.json
+++ b/index.json
@@ -4815,6 +4815,26 @@
           "public_members_url": "https://api.github.com/orgs/Octocoders/public_members{/member}",
           "avatar_url": "https://avatars0.githubusercontent.com/u/6?",
           "description": ""
+        },
+        "sender": {
+          "login": "Codertocat",
+          "id": 21031067,
+          "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+          "avatar_url": "https://avatars1.githubusercontent.com/u/21031067?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/Codertocat",
+          "html_url": "https://github.com/Codertocat",
+          "followers_url": "https://api.github.com/users/Codertocat/followers",
+          "following_url": "https://api.github.com/users/Codertocat/following{/other_user}",
+          "gists_url": "https://api.github.com/users/Codertocat/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/Codertocat/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/Codertocat/subscriptions",
+          "organizations_url": "https://api.github.com/users/Codertocat/orgs",
+          "repos_url": "https://api.github.com/users/Codertocat/repos",
+          "events_url": "https://api.github.com/users/Codertocat/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/Codertocat/received_events",
+          "type": "User",
+          "site_admin": false
         }
       },
       {

--- a/payload-examples/api.github.com/code_scanning_alert/reopened.payload.json
+++ b/payload-examples/api.github.com/code_scanning_alert/reopened.payload.json
@@ -133,5 +133,25 @@
     "public_members_url": "https://api.github.com/orgs/Octocoders/public_members{/member}",
     "avatar_url": "https://avatars0.githubusercontent.com/u/6?",
     "description": ""
+  },
+  "sender": {
+    "login": "Codertocat",
+    "id": 21031067,
+    "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/21031067?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/Codertocat",
+    "html_url": "https://github.com/Codertocat",
+    "followers_url": "https://api.github.com/users/Codertocat/followers",
+    "following_url": "https://api.github.com/users/Codertocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/Codertocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/Codertocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/Codertocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/Codertocat/orgs",
+    "repos_url": "https://api.github.com/users/Codertocat/repos",
+    "events_url": "https://api.github.com/users/Codertocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/Codertocat/received_events",
+    "type": "User",
+    "site_admin": false
   }
 }

--- a/payload-examples/api.github.com/code_scanning_alert/reopened.with-organization.payload.json
+++ b/payload-examples/api.github.com/code_scanning_alert/reopened.with-organization.payload.json
@@ -137,5 +137,25 @@
   "installation": {
     "id": 1,
     "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMQ=="
+  },
+  "sender": {
+    "login": "Codertocat",
+    "id": 21031067,
+    "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+    "avatar_url": "https://avatars1.githubusercontent.com/u/21031067?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/Codertocat",
+    "html_url": "https://github.com/Codertocat",
+    "followers_url": "https://api.github.com/users/Codertocat/followers",
+    "following_url": "https://api.github.com/users/Codertocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/Codertocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/Codertocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/Codertocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/Codertocat/orgs",
+    "repos_url": "https://api.github.com/users/Codertocat/repos",
+    "events_url": "https://api.github.com/users/Codertocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/Codertocat/received_events",
+    "type": "User",
+    "site_admin": false
   }
 }

--- a/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "code_scanning_alert$appeared_in_branch",
   "type": "object",
-  "required": ["action", "alert", "ref", "commit_oid", "repository"],
+  "required": ["action", "alert", "ref", "commit_oid", "repository", "sender"],
   "properties": {
     "action": { "type": "string", "enum": ["appeared_in_branch"] },
     "alert": {
@@ -125,6 +125,7 @@
     },
     "commit_oid": { "type": "string" },
     "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" }
   },

--- a/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/appeared_in_branch.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "code_scanning_alert$appeared_in_branch",
   "type": "object",
-  "required": ["action", "alert", "ref", "commit_oid", "repository", "sender"],
+  "required": ["action", "alert", "ref", "commit_oid", "repository"],
   "properties": {
     "action": { "type": "string", "enum": ["appeared_in_branch"] },
     "alert": {
@@ -125,7 +125,6 @@
     },
     "commit_oid": { "type": "string" },
     "repository": { "$ref": "common/repository.schema.json" },
-    "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" }
   },

--- a/payload-schemas/schemas/code_scanning_alert/created.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/created.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "code_scanning_alert$created",
   "type": "object",
-  "required": ["action", "alert", "ref", "commit_oid", "repository"],
+  "required": ["action", "alert", "ref", "commit_oid", "repository", "sender"],
   "properties": {
     "action": { "type": "string", "enum": ["created"] },
     "alert": {
@@ -121,6 +121,7 @@
     },
     "commit_oid": { "type": "string" },
     "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" }
   },

--- a/payload-schemas/schemas/code_scanning_alert/fixed.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/fixed.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "code_scanning_alert$fixed",
   "type": "object",
-  "required": ["action", "alert", "ref", "commit_oid", "repository"],
+  "required": ["action", "alert", "ref", "commit_oid", "repository", "sender"],
   "properties": {
     "action": { "type": "string", "enum": ["fixed"] },
     "alert": {
@@ -125,6 +125,7 @@
     },
     "commit_oid": { "type": "string" },
     "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" }
   },

--- a/payload-schemas/schemas/code_scanning_alert/reopened.schema.json
+++ b/payload-schemas/schemas/code_scanning_alert/reopened.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "code_scanning_alert$reopened",
   "type": "object",
-  "required": ["action", "alert", "ref", "commit_oid", "repository"],
+  "required": ["action", "alert", "ref", "commit_oid", "repository", "sender"],
   "properties": {
     "action": { "type": "string", "enum": ["reopened"] },
     "alert": {
@@ -121,6 +121,7 @@
     },
     "commit_oid": { "type": "string" },
     "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" }
   },

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -1194,6 +1194,7 @@ export interface CodeScanningAlertAppearedInBranchEvent {
   ref: string;
   commit_oid: string;
   repository: Repository;
+  sender: User;
   installation?: InstallationLite;
   organization?: Organization;
 }
@@ -1357,6 +1358,7 @@ export interface CodeScanningAlertCreatedEvent {
   ref: string;
   commit_oid: string;
   repository: Repository;
+  sender: User;
   installation?: InstallationLite;
   organization?: Organization;
 }
@@ -1438,6 +1440,7 @@ export interface CodeScanningAlertFixedEvent {
   ref: string;
   commit_oid: string;
   repository: Repository;
+  sender: User;
   installation?: InstallationLite;
   organization?: Organization;
 }
@@ -1519,6 +1522,7 @@ export interface CodeScanningAlertReopenedEvent {
   ref: string;
   commit_oid: string;
   repository: Repository;
+  sender: User;
   installation?: InstallationLite;
   organization?: Organization;
 }


### PR DESCRIPTION
Hi there 👋 

I'm from the codescanning Team at GitHub and we're doing a slight update. Previously:


sender | object | If the action is reopened_by_user or closed_by_user, the sender object will be the user that triggered the event. The sender object is empty for all other actions.
-- | -- | --

See here for more info: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#code_scanning_alert

Now, we'll include a default sender object instead of having that field be empty. 

We basically want to update the payload schemas to look like the `closed_by_user` schema by having the sender field be required, so we're just adding two lines of code to all the schemas in the code-scanning-alert folder:

1. https://github.com/octokit/webhooks/blob/03b633b2aed02709c55e3df897747f278ad24397/payload-schemas/schemas/code_scanning_alert/closed_by_user.schema.json#L5

2. https://github.com/octokit/webhooks/blob/03b633b2aed02709c55e3df897747f278ad24397/payload-schemas/schemas/code_scanning_alert/closed_by_user.schema.json#L126

cc/ @bogdanap @anaarmas @krukow


@bogdanap What do you think about defaulting to github as the sender here in the example? 
