### PR TITLE
chore(bin): use npx to call ts-node

### DIFF
--- a/bin/diff-interface-schemas.ts
+++ b/bin/diff-interface-schemas.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-transpile-only
+#!/usr/bin/env npx ts-node-transpile-only
 
 import { diffString } from "json-diff";
 import { JSONSchema7 } from "json-schema";

--- a/bin/extract-common-schema.ts
+++ b/bin/extract-common-schema.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-transpile-only
+#!/usr/bin/env npx ts-node-transpile-only
 
 import { strict as assert } from "assert";
 import fs from "fs";

--- a/bin/format-with-prettier.ts
+++ b/bin/format-with-prettier.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-transpile-only
+#!/usr/bin/env npx ts-node-transpile-only
 
 import fs from "fs";
 import { JSONSchema7 } from "json-schema";

--- a/bin/octokit-schema.ts
+++ b/bin/octokit-schema.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-transpile-only
+#!/usr/bin/env npx ts-node-transpile-only
 
 import { strict as assert } from "assert";
 import fs from "fs";

--- a/bin/octokit-types.ts
+++ b/bin/octokit-types.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-transpile-only
+#!/usr/bin/env npx ts-node-transpile-only
 
 import { strict as assert } from "assert";
 import { promises as fs } from "fs";

--- a/bin/octokit-webhooks.ts
+++ b/bin/octokit-webhooks.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-transpile-only
+#!/usr/bin/env npx ts-node-transpile-only
 
 import yargs from "yargs";
 import { checkOrUpdateWebhooks } from "../lib";

--- a/bin/optimize-schemas.ts
+++ b/bin/optimize-schemas.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-transpile-only
+#!/usr/bin/env npx ts-node-transpile-only
 
 import { strict as assert } from "assert";
 import fs from "fs";

--- a/bin/ref-common-schemas.ts
+++ b/bin/ref-common-schemas.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-transpile-only
+#!/usr/bin/env npx ts-node-transpile-only
 
 import deepEqual from "fast-deep-equal";
 import fs from "fs";

--- a/bin/validate-payload-examples.ts
+++ b/bin/validate-payload-examples.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-transpile-only
+#!/usr/bin/env npx ts-node-transpile-only
 
 import { DefinedError, ErrorObject } from "ajv";
 import path from "path";


### PR DESCRIPTION
This makes it so we don't have to rely on people having `node_modules/.bin` in their `PATH`