### PR TITLE
🚧 chore(schemas): add enterprise schema

### DIFF
--- a/payload-schemas/schemas/common/enterprise.schema.json
+++ b/payload-schemas/schemas/common/enterprise.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "common/enterprise.schema.json",
+  "description": "An enterprise account",
   "type": "object",
   "required": [
     "id",
@@ -15,14 +16,27 @@
     "updated_at"
   ],
   "properties": {
-    "id": { "type": "integer" },
-    "slug": { "type": "string" },
-    "name": { "type": "string" },
+    "id": {
+      "description": "Unique identifier of the enterprise",
+      "type": "integer"
+    },
+    "slug": {
+      "description": "The slug url identifier for the enterprise.",
+      "type": "string"
+    },
+    "name": { "description": "The name of the enterprise.", "type": "string" },
     "node_id": { "type": "string" },
     "avatar_url": { "type": "string", "format": "uri" },
-    "description": { "type": "string" },
-    "website_url": { "type": "string" },
-    "html_url": { "type": "string" },
+    "description": {
+      "description": "A short description of the enterprise.",
+      "type": ["string", "null"]
+    },
+    "website_url": {
+      "description": "The enterprise's website URL.",
+      "type": ["string", "null"],
+      "format": "uri"
+    },
+    "html_url": { "type": "string", "format": "uri" },
     "created_at": { "type": "string", "format": "date-time" },
     "updated_at": { "type": "string", "format": "date-time" }
   },

--- a/payload-schemas/schemas/common/enterprise.schema.json
+++ b/payload-schemas/schemas/common/enterprise.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "common/enterprise.schema.json",
+  "type": "object",
+  "required": [
+    "id",
+    "slug",
+    "name",
+    "node_id",
+    "avatar_url",
+    "description",
+    "website_url",
+    "html_url",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "id": { "type": "integer" },
+    "slug": { "type": "string" },
+    "name": { "type": "string" },
+    "node_id": { "type": "string" },
+    "avatar_url": { "type": "string", "format": "uri" },
+    "description": { "type": "string" },
+    "website_url": { "type": "string" },
+    "html_url": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" }
+  },
+  "additionalProperties": false,
+  "title": "Enterprise"
+}


### PR DESCRIPTION
Taken from payload examples in #371
This is not currently in use, yet. We currently don't have any payloads specific to GHES environments currently, and #371 includes some.
