### PR TITLE
fix: remove sender property from SecretScanningAlertCreatedEvent

### DIFF
--- a/payload-schemas/schemas/secret_scanning_alert/created.schema.json
+++ b/payload-schemas/schemas/secret_scanning_alert/created.schema.json
@@ -25,8 +25,7 @@
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },
-    "installation": { "$ref": "common/installation-lite.schema.json" },
-    "sender": { "$ref": "common/user.schema.json" }
+    "installation": { "$ref": "common/installation-lite.schema.json" }
   },
   "additionalProperties": false,
   "title": "secret_scanning_alert created event"

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -4688,7 +4688,6 @@ export interface SecretScanningAlertCreatedEvent {
   repository: Repository;
   organization?: Organization;
   installation?: InstallationLite;
-  sender: User;
 }
 export interface SecretScanningAlertReopenedEvent {
   action: "reopened";


### PR DESCRIPTION
According to the docs, the sender property is empty for the `created` action