### PR TITLE
fix: cleanup properties in issues and pull_request schemas

### DIFF
--- a/payload-schemas/schemas/issues/assigned.schema.json
+++ b/payload-schemas/schemas/issues/assigned.schema.json
@@ -6,13 +6,8 @@
   "properties": {
     "action": { "type": "string", "enum": ["assigned"] },
     "issue": { "$ref": "common/issue.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
     "assignee": {
       "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/issues/closed.schema.json
+++ b/payload-schemas/schemas/issues/closed.schema.json
@@ -19,14 +19,6 @@
         }
       ]
     },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/deleted.schema.json
+++ b/payload-schemas/schemas/issues/deleted.schema.json
@@ -6,14 +6,6 @@
   "properties": {
     "action": { "type": "string", "enum": ["deleted"] },
     "issue": { "$ref": "common/issue.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/demilestoned.schema.json
+++ b/payload-schemas/schemas/issues/demilestoned.schema.json
@@ -6,14 +6,6 @@
   "properties": {
     "action": { "type": "string", "enum": ["demilestoned"] },
     "issue": { "$ref": "common/issue.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/edited.schema.json
+++ b/payload-schemas/schemas/issues/edited.schema.json
@@ -25,13 +25,6 @@
       },
       "additionalProperties": false
     },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/labeled.schema.json
+++ b/payload-schemas/schemas/issues/labeled.schema.json
@@ -7,13 +7,6 @@
     "action": { "type": "string", "enum": ["labeled"] },
     "issue": { "$ref": "common/issue.schema.json" },
     "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/locked.schema.json
+++ b/payload-schemas/schemas/issues/locked.schema.json
@@ -22,14 +22,6 @@
         }
       ]
     },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/milestoned.schema.json
+++ b/payload-schemas/schemas/issues/milestoned.schema.json
@@ -6,14 +6,6 @@
   "properties": {
     "action": { "type": "string", "enum": ["milestoned"] },
     "issue": { "$ref": "common/issue.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/opened.schema.json
+++ b/payload-schemas/schemas/issues/opened.schema.json
@@ -19,14 +19,6 @@
         }
       ]
     },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/pinned.schema.json
+++ b/payload-schemas/schemas/issues/pinned.schema.json
@@ -6,14 +6,6 @@
   "properties": {
     "action": { "type": "string", "enum": ["pinned"] },
     "issue": { "$ref": "common/issue.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/reopened.schema.json
+++ b/payload-schemas/schemas/issues/reopened.schema.json
@@ -16,14 +16,6 @@
         }
       ]
     },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/transferred.schema.json
+++ b/payload-schemas/schemas/issues/transferred.schema.json
@@ -6,14 +6,6 @@
   "properties": {
     "action": { "type": "string", "enum": ["transferred"] },
     "issue": { "$ref": "common/issue.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/unassigned.schema.json
+++ b/payload-schemas/schemas/issues/unassigned.schema.json
@@ -6,13 +6,8 @@
   "properties": {
     "action": { "type": "string", "enum": ["unassigned"] },
     "issue": { "$ref": "common/issue.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
     "assignee": {
       "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/schemas/issues/unlabeled.schema.json
+++ b/payload-schemas/schemas/issues/unlabeled.schema.json
@@ -7,13 +7,6 @@
     "action": { "type": "string", "enum": ["unlabeled"] },
     "issue": { "$ref": "common/issue.schema.json" },
     "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/unlocked.schema.json
+++ b/payload-schemas/schemas/issues/unlocked.schema.json
@@ -19,14 +19,6 @@
         }
       ]
     },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/issues/unpinned.schema.json
+++ b/payload-schemas/schemas/issues/unpinned.schema.json
@@ -6,14 +6,6 @@
   "properties": {
     "action": { "type": "string", "enum": ["unpinned"] },
     "issue": { "$ref": "common/issue.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": {
-      "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]
-    },
-    "assignees": {
-      "type": "array",
-      "items": { "$ref": "common/user.schema.json" }
-    },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/pull_request/assigned.schema.json
+++ b/payload-schemas/schemas/pull_request/assigned.schema.json
@@ -7,7 +7,6 @@
     "action": { "type": "string", "enum": ["assigned"] },
     "number": { "type": "integer" },
     "pull_request": { "$ref": "common/pull-request.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
     "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/pull_request/closed.schema.json
+++ b/payload-schemas/schemas/pull_request/closed.schema.json
@@ -25,8 +25,6 @@
         }
       ]
     },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
+++ b/payload-schemas/schemas/pull_request/converted_to_draft.schema.json
@@ -35,8 +35,6 @@
         }
       ]
     },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/payload-schemas/schemas/pull_request/edited.schema.json
+++ b/payload-schemas/schemas/pull_request/edited.schema.json
@@ -32,8 +32,6 @@
       "additionalProperties": false
     },
     "pull_request": { "$ref": "common/pull-request.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/payload-schemas/schemas/pull_request/labeled.schema.json
+++ b/payload-schemas/schemas/pull_request/labeled.schema.json
@@ -8,7 +8,6 @@
     "number": { "type": "integer" },
     "pull_request": { "$ref": "common/pull-request.schema.json" },
     "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/payload-schemas/schemas/pull_request/locked.schema.json
+++ b/payload-schemas/schemas/pull_request/locked.schema.json
@@ -7,8 +7,6 @@
     "action": { "type": "string", "enum": ["locked"] },
     "number": { "type": "integer" },
     "pull_request": { "$ref": "common/pull-request.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/payload-schemas/schemas/pull_request/opened.schema.json
+++ b/payload-schemas/schemas/pull_request/opened.schema.json
@@ -31,8 +31,6 @@
         }
       ]
     },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/payload-schemas/schemas/pull_request/ready_for_review.schema.json
+++ b/payload-schemas/schemas/pull_request/ready_for_review.schema.json
@@ -37,8 +37,6 @@
         }
       ]
     },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/payload-schemas/schemas/pull_request/reopened.schema.json
+++ b/payload-schemas/schemas/pull_request/reopened.schema.json
@@ -31,8 +31,6 @@
         }
       ]
     },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/payload-schemas/schemas/pull_request/synchronize.schema.json
+++ b/payload-schemas/schemas/pull_request/synchronize.schema.json
@@ -7,8 +7,6 @@
     "action": { "type": "string", "enum": ["synchronize"] },
     "number": { "type": "integer" },
     "pull_request": { "$ref": "common/pull-request.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/payload-schemas/schemas/pull_request/unassigned.schema.json
+++ b/payload-schemas/schemas/pull_request/unassigned.schema.json
@@ -7,7 +7,6 @@
     "action": { "type": "string", "enum": ["unassigned"] },
     "number": { "type": "integer" },
     "pull_request": { "$ref": "common/pull-request.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
     "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-schemas/schemas/pull_request/unlabeled.schema.json
+++ b/payload-schemas/schemas/pull_request/unlabeled.schema.json
@@ -8,7 +8,6 @@
     "number": { "type": "integer" },
     "pull_request": { "$ref": "common/pull-request.schema.json" },
     "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/payload-schemas/schemas/pull_request/unlocked.schema.json
+++ b/payload-schemas/schemas/pull_request/unlocked.schema.json
@@ -7,8 +7,6 @@
     "action": { "type": "string", "enum": ["unlocked"] },
     "number": { "type": "integer" },
     "pull_request": { "$ref": "common/pull-request.schema.json" },
-    "label": { "$ref": "common/label.schema.json" },
-    "assignee": { "$ref": "common/user.schema.json" },
     "repository": { "$ref": "common/repository.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },
     "organization": { "$ref": "common/organization.schema.json" },

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -2209,9 +2209,7 @@ export interface IssueCommentEditedEvent {
 export interface IssuesAssignedEvent {
   action: "assigned";
   issue: Issue;
-  label?: Label;
   assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2223,9 +2221,6 @@ export interface IssuesClosedEvent {
     state: "closed";
     closed_at: string;
   };
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2234,9 +2229,6 @@ export interface IssuesClosedEvent {
 export interface IssuesDeletedEvent {
   action: "deleted";
   issue: Issue;
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2245,9 +2237,6 @@ export interface IssuesDeletedEvent {
 export interface IssuesDemilestonedEvent {
   action: "demilestoned";
   issue: Issue;
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2265,8 +2254,6 @@ export interface IssuesEditedEvent {
       from: string;
     };
   };
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2276,8 +2263,6 @@ export interface IssuesLabeledEvent {
   action: "labeled";
   issue: Issue;
   label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2289,9 +2274,6 @@ export interface IssuesLockedEvent {
     locked: true;
     active_lock_reason: "resolved" | "off-topic" | "too heated" | "spam";
   };
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2300,9 +2282,6 @@ export interface IssuesLockedEvent {
 export interface IssuesMilestonedEvent {
   action: "milestoned";
   issue: Issue;
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2314,9 +2293,6 @@ export interface IssuesOpenedEvent {
     state: "open";
     closed_at: null;
   };
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2325,9 +2301,6 @@ export interface IssuesOpenedEvent {
 export interface IssuesPinnedEvent {
   action: "pinned";
   issue: Issue;
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2338,9 +2311,6 @@ export interface IssuesReopenedEvent {
   issue: Issue & {
     state: "open";
   };
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2349,9 +2319,6 @@ export interface IssuesReopenedEvent {
 export interface IssuesTransferredEvent {
   action: "transferred";
   issue: Issue;
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2360,9 +2327,7 @@ export interface IssuesTransferredEvent {
 export interface IssuesUnassignedEvent {
   action: "unassigned";
   issue: Issue;
-  label?: Label;
   assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2372,8 +2337,6 @@ export interface IssuesUnlabeledEvent {
   action: "unlabeled";
   issue: Issue;
   label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2385,9 +2348,6 @@ export interface IssuesUnlockedEvent {
     locked: false;
     active_lock_reason: null;
   };
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -2396,9 +2356,6 @@ export interface IssuesUnlockedEvent {
 export interface IssuesUnpinnedEvent {
   action: "unpinned";
   issue: Issue;
-  label?: Label;
-  assignee?: User | null;
-  assignees?: User[];
   repository: Repository;
   sender: User;
   installation?: InstallationLite;
@@ -3217,7 +3174,6 @@ export interface PullRequestAssignedEvent {
   action: "assigned";
   number: number;
   pull_request: PullRequest;
-  label?: Label;
   assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
@@ -3341,8 +3297,6 @@ export interface PullRequestClosedEvent {
     closed_at: string;
     merged: boolean;
   };
-  label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;
@@ -3362,8 +3316,6 @@ export interface PullRequestConvertedToDraftEvent {
     merged: boolean;
     merged_by: null;
   };
-  label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;
@@ -3381,8 +3333,6 @@ export interface PullRequestEditedEvent {
     };
   };
   pull_request: PullRequest;
-  label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;
@@ -3393,7 +3343,6 @@ export interface PullRequestLabeledEvent {
   number: number;
   pull_request: PullRequest;
   label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;
@@ -3403,8 +3352,6 @@ export interface PullRequestLockedEvent {
   action: "locked";
   number: number;
   pull_request: PullRequest;
-  label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;
@@ -3421,8 +3368,6 @@ export interface PullRequestOpenedEvent {
     active_lock_reason: null;
     merged_by: null;
   };
-  label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;
@@ -3443,8 +3388,6 @@ export interface PullRequestReadyForReviewEvent {
     merged: boolean;
     merged_by: null;
   };
-  label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;
@@ -3461,8 +3404,6 @@ export interface PullRequestReopenedEvent {
     merged: boolean;
     merged_by: null;
   };
-  label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;
@@ -3492,8 +3433,6 @@ export interface PullRequestSynchronizeEvent {
   action: "synchronize";
   number: number;
   pull_request: PullRequest;
-  label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;
@@ -3503,7 +3442,6 @@ export interface PullRequestUnassignedEvent {
   action: "unassigned";
   number: number;
   pull_request: PullRequest;
-  label?: Label;
   assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
@@ -3515,7 +3453,6 @@ export interface PullRequestUnlabeledEvent {
   number: number;
   pull_request: PullRequest;
   label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;
@@ -3525,8 +3462,6 @@ export interface PullRequestUnlockedEvent {
   action: "unlocked";
   number: number;
   pull_request: PullRequest;
-  label?: Label;
-  assignee?: User;
   repository: Repository;
   installation?: InstallationLite;
   organization?: Organization;


### PR DESCRIPTION
* Removes the `label` property from other actions then then `labeled` and `unlabeled`
* Removes the `assignees` property from all schemas, it doesn't exist at the top level
* Removes the `assignee` property from other actions then then `assigned` and `unassigned`