### PR TITLE
fix: remove `format` from `compare` property on `push` payload schema

### DIFF
--- a/index.json
+++ b/index.json
@@ -45656,7 +45656,7 @@
         "deleted": true,
         "forced": false,
         "base_ref": null,
-        "compare": "https://github.com/Codertocat/Hello-World/compare/6113728f27ae...000000000000",
+        "compare": "https://github.com/Codertocat/Hello-World/compare/d70c5c6fa638^...000000000000",
         "commits": [],
         "head_commit": null,
         "repository": {

--- a/payload-examples/api.github.com/push/1.payload.json
+++ b/payload-examples/api.github.com/push/1.payload.json
@@ -6,7 +6,7 @@
   "deleted": true,
   "forced": false,
   "base_ref": null,
-  "compare": "https://github.com/Codertocat/Hello-World/compare/6113728f27ae...000000000000",
+  "compare": "https://github.com/Codertocat/Hello-World/compare/d70c5c6fa638^...000000000000",
   "commits": [],
   "head_commit": null,
   "repository": {

--- a/payload-schemas/schemas/push/event.schema.json
+++ b/payload-schemas/schemas/push/event.schema.json
@@ -34,7 +34,7 @@
     "deleted": { "type": "boolean" },
     "forced": { "type": "boolean" },
     "base_ref": { "type": "null" },
-    "compare": { "type": "string", "format": "uri" },
+    "compare": { "type": "string" },
     "commits": {
       "type": "array",
       "description": "An array of commit objects describing the pushed commits.",


### PR DESCRIPTION
Found this when reviewing webhook calls this morning.