### PR TITLE
fix: remove `null` override on `IssueCommentEditedEvent#issue.closed_at`

### DIFF
--- a/payload-schemas/schemas/issue_comment/edited.schema.json
+++ b/payload-schemas/schemas/issue_comment/edited.schema.json
@@ -29,7 +29,7 @@
         { "$ref": "common/issue.schema.json" },
         {
           "type": "object",
-          "required": ["labels", "state", "locked", "assignee", "closed_at"],
+          "required": ["labels", "state", "locked", "assignee"],
           "properties": {
             "assignee": {
               "oneOf": [
@@ -42,7 +42,6 @@
               "enum": ["open", "closed"],
               "description": "State of the issue; either 'open' or 'closed'"
             },
-            "closed_at": { "type": "null" },
             "locked": { "type": "boolean" },
             "labels": {
               "type": "array",

--- a/schema.d.ts
+++ b/schema.d.ts
@@ -2369,7 +2369,6 @@ export interface IssueCommentEditedEvent {
      * State of the issue; either 'open' or 'closed'
      */
     state: "open" | "closed";
-    closed_at: null;
     locked: boolean;
     labels: Label[];
     pull_request?: {


### PR DESCRIPTION
An issue can be edited after it has been closed, therefore this override is unnecessary