### PR TITLE
fix: don't include `$id` property in compiled schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,30 @@ const SCHEMA = require("@octokit/webhooks-definitions/schema.json");
 import SCHEMA from "@octokit/webhooks-definitions/schema.json";
 ```
 
+### Usage with `ajv` in `strict` mode
+
+When running in `strict` mode, `ajv` will throw an "unknown keyword" error if it
+encounters any keywords that have not been defined.
+
+This schema currently uses custom keywords provided by `ajv-formats`, along with
+the custom keyword `tsAdditionalProperties`.
+
+Here is an example of how you can set this up:
+
+```ts
+import type { WebhookEvent } from "@octokit/webhooks-definitions/schema";
+import * as githubWebhookSchema from "@octokit/webhooks-definitions/schema.json";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+
+const ajv = new Ajv({ strict: true });
+
+addFormats(ajv);
+ajv.addKeyword("tsAdditionalProperties");
+
+const validate = ajv.compile<WebhookEvent>(githubWebhookSchema);
+```
+
 ## Importing types
 
 This package ships with types for the webhook events generated from the

--- a/bin/octokit-schema.ts
+++ b/bin/octokit-schema.ts
@@ -125,6 +125,10 @@ async function run() {
       "schema.json",
       format(
         JSON.stringify(schema, (key, value: unknown) => {
+          if (key === "$id") {
+            return undefined;
+          }
+
           if (typeof value === "string" && value.endsWith(".schema.json")) {
             const { base } = path.parse(value);
 

--- a/bin/validate-schema.ts
+++ b/bin/validate-schema.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env ts-node-transpile-only
+
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { parseArgv } from "./utils";
+
+const [, {}] = parseArgv(__filename, [], []);
+
+const ajv = new Ajv({ strict: true });
+
+addFormats(ajv);
+ajv.addKeyword("tsAdditionalProperties");
+
+const schema = JSON.parse(
+  readFileSync(resolve(__dirname, "../schema.json"), "utf-8")
+);
+
+// if this is invalid, an error will be thrown
+ajv.compile(schema);

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "octokit-schema": "ts-node -T bin/octokit-schema.ts",
     "octokit-webhooks": "ts-node -T bin/octokit-webhooks.ts",
     "pretest": "npm run -s lint",
-    "test": "npm run build && npm run validate -- --continue-on-error && ts-node -T test.ts",
+    "test": "npm run build && npm run build:schema && npm run validate -- --continue-on-error && ts-node -T test.ts",
     "typecheck": "tsc -p . --noEmit",
-    "validate": "ts-node -T bin/validate-payload-examples.ts"
+    "validate": "npm run -s validate:payloads && npm run -s validate:schema",
+    "validate:payloads": "ts-node -T bin/validate-payload-examples.ts",
+    "validate:schema": "ts-node -T bin/validate-schema.ts"
   },
   "prettier": {},
   "dependencies": {},


### PR DESCRIPTION
When you include `$id`, it affects how `$ref` is resolved - this is fine in some cases, but not others (I don't know the exact specifics, other than it seems to be a relative vs absolute style problem).

You can see the break with this schema:

```
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "definitions": {
    "s$1": {
      "$id": "s$1",
      "type": "object",
      "properties": { "p": { "$ref": "#/definitions/s$2" } }
    },
    "s$2": {
      "$id": "#/definitions/s$2",
      "type": "object"
    }
  },
  "oneOf": [{ "$ref": "#/definitions/s$1" }]
}
```

We don't actually need the IDs in our schema, so we can safely just drop them.

----

Fixes #429 