### PR TITLE
chore: cleanup un-needed entries in the root `package.json` and mark it as private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,14 @@
 {
   "name": "@octokit/webhooks-definitions",
   "version": "0.0.0-development",
+  "private": "true",
   "description": "machine-readable, always up-to-date GitHub Webhooks specifications",
   "keywords": [],
   "repository": "github:octokit/webhooks",
   "license": "MIT",
   "author": "Gregor Martynus (https://github.com/gr2m)",
   "main": "index.json",
-  "files": [
-    "index.d.ts",
-    "index.json",
-    "schema.d.ts",
-    "schema.json"
-  ],
+  "files": [],
   "scripts": {
     "build": "ts-node -T bin/octokit-webhooks.ts check --cached",
     "build:all": "npm run -s build:webhooks && npm run -s build:schema && npm run -s build:types",


### PR DESCRIPTION
Since we don't publish this package anymore, and it's only used to store the scripts and dependencies, I removed the `files` entry and marked the package as private