### PR TITLE
fix(types): mark `WebhookDefinition#examples` to be an `Array`

### DIFF
--- a/payload-examples/index.d.ts
+++ b/payload-examples/index.d.ts
@@ -5,7 +5,7 @@ export type WebhookDefinition<
   name: TName;
   actions: string[];
   description: string;
-  examples: WebhookEventMap[TName];
+  examples: WebhookEventMap[TName][];
   properties: Record<
     string,
     {


### PR DESCRIPTION
The examples property is an Array of `WebhookEventMap[TName]` but it wasn't marked as so