### PR TITLE
fix(readme): Definition links in README's where 404ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Download
 
 Download the latest specification at
-[octokit.github.io/webhooks/index.json](https://octokit.github.io/webhooks/payload-examples/index.json)
+[octokit.github.io/webhooks/payload-examples/index.json](https://octokit.github.io/webhooks/payload-examples/index.json)
 
 ## Example
 

--- a/payload-types/README.md
+++ b/payload-types/README.md
@@ -7,7 +7,7 @@
 ## Download
 
 Download the latest specification at
-[octokit.github.io/webhooks/index.json](https://octokit.github.io/webhooks/index.json)
+[octokit.github.io/webhooks/payload-examples/index.json](https://octokit.github.io/webhooks/payload-examples/index.json)
 
 ## Usage
 


### PR DESCRIPTION
The link to the generated `payload-examples` JSON was only updated in one
place. But the `payload-types` README still referenced the old URL. This
 commit updates that URL throughout this repositories README's.