### PR TITLE
ci(prettier): fail git commit silently

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -20,5 +20,4 @@ jobs:
             git config user.email "33075676+octokitbot@users.noreply.github.com"
             git config user.name "Octokit Bot"
             git add .
-            git commit -m "style: lint JSON files"
-            git push
+            git commit -m "style: lint JSON files" && git push || true

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -16,8 +16,10 @@ jobs:
       - run: npm ci
       - run: echo "./node_modules/.bin" >> $GITHUB_PATH
       - run: "./bin/format-with-prettier.ts"
-      - run: |
-            git config user.email "33075676+octokitbot@users.noreply.github.com"
-            git config user.name "Octokit Bot"
-            git add .
-            git commit -m "style: lint JSON files" && git push || true
+      - run: git diff-index --quiet HEAD
+      - if: failure()
+        run: |
+          git config user.email "33075676+octokitbot@users.noreply.github.com"
+          git config user.name "Octokit Bot"
+          git add .
+          git commit -m "style: lint JSON files" && git push || true


### PR DESCRIPTION
This should avoid errors like this:

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/39992/121906638-275bcb80-cce0-11eb-83c8-55feb7ed40c3.png">

Not sure if there is a more elegant way but this should work