### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          cache: npm
       - run: npm ci
       - run: echo "./node_modules/.bin" >> $GITHUB_PATH
       - run: "./bin/format-with-prettier.ts"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          cache: npm
       - run: npm ci
       - run: npm run build:schema
       - run: npx semantic-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          cache: npm
       - run: npm ci
       - run: npm test
   typecheck:
@@ -27,6 +28,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          cache: npm
       - run: npm ci
       - run: cd payload-examples && npm i && cd ..
       - run: npm run typecheck
@@ -38,6 +40,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          cache: npm
       - run: npm ci
       - run: npm run build:schema
       - run: npm run build:types

--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          cache: npm
       - run: npm ci
       - run: "npm run lint:fix"
       - uses: gr2m/create-or-update-pull-request-action@v1.x

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          cache: npm
       - run: git checkout webhooks-update || true
       - run: npm ci
       - name: update .com webhooks


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
