### PR TITLE
fix(api.github.com): update descriptions for `issues.labeled` and `issues.unlabeled` events

### DIFF
--- a/payload-schemas/api.github.com/issues/labeled.schema.json
+++ b/payload-schemas/api.github.com/issues/labeled.schema.json
@@ -8,7 +8,7 @@
     "issue": { "$ref": "common/issue.schema.json" },
     "label": {
       "$ref": "common/label.schema.json",
-      "description": "The optional label that was added to the issue."
+      "description": "The label that was added to the issue."
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/api.github.com/issues/labeled.schema.json
+++ b/payload-schemas/api.github.com/issues/labeled.schema.json
@@ -8,7 +8,7 @@
     "issue": { "$ref": "common/issue.schema.json" },
     "label": {
       "$ref": "common/label.schema.json",
-      "description": "The optional label that was added or removed from the issue."
+      "description": "The optional label that was added to the issue."
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },

--- a/payload-schemas/api.github.com/issues/unlabeled.schema.json
+++ b/payload-schemas/api.github.com/issues/unlabeled.schema.json
@@ -8,7 +8,7 @@
     "issue": { "$ref": "common/issue.schema.json" },
     "label": {
       "$ref": "common/label.schema.json",
-      "description": "The optional label that was added or removed from the issue."
+      "description": "The label that was removed from the issue."
     },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },


### PR DESCRIPTION
If I understand it correctly, the `issues.labeled` event only adds a label. If a label is removed, the action is set `unlabeled`. Or am I missing something?