### PR TITLE
fix(readme): broken links to index.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ for these scripts in `bin/docs`, which can also be accessed by passing `--help`
 ## Adding examples
 
 The
-[`index.json` file](https://github.com/octokit/webhooks/blob/master/payload-examples/index.json)
+[`index.json` file](https://github.com/octokit/webhooks/blob/master/payload-examples/api.github.com/index.json)
 is generated, please do not edit it. Instead, make changes in the
 [`payload-examples/api.github.com/` folder](https://github.com/octokit/webhooks/tree/master/payload-examples/api.github.com),
 then update `index.json` by running the following command

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Download
 
 Download the latest specification at
-[octokit.github.io/webhooks/payload-examples/index.json](https://octokit.github.io/webhooks/payload-examples/index.json)
+[octokit.github.io/webhooks/payload-examples/api.github.com/index.json](https://octokit.github.io/webhooks/payload-examples/api.github.com/index.json)
 
 ## Example
 
@@ -231,7 +231,7 @@ Example webhook definition
 You can download the latest `index.json` and `schema.json` files from
 [unpkg](https://unpkg.com/)
 
-- [`index.json`](https://unpkg.com/@octokit/webhooks-examples/index.json)
+- [`index.json`](https://unpkg.com/@octokit/webhooks-examples/api.github.com/index.json)
 - [`schema.json`](https://unpkg.com/@octokit/webhooks-schemas/schema.json)
 
 ## Usage as Node module
@@ -240,10 +240,10 @@ To get an array of all webhook definition objects, require the `@octokit/webhook
 
 ```js
 // Use Node.js require:
-const WEBHOOKS = require("@octokit/webhooks-examples/index.json");
+const WEBHOOKS = require("@octokit/webhooks-examples/api.github.com/index.json");
 
 // Or ESM/TypeScript import:
-import WEBHOOKS from "@octokit/webhooks-examples/index.json";
+import WEBHOOKS from "@octokit/webhooks-examples/api.github.com/index.json";
 ```
 
 To get the JSON schema for webhook payloads, require the `@octokit/webhooks-schemas` package.

--- a/payload-examples/README.md
+++ b/payload-examples/README.md
@@ -7,7 +7,7 @@
 ## Download
 
 Download the latest specification at
-[octokit.github.io/webhooks/payload-examples/index.json](https://octokit.github.io/webhooks/payload-examples/index.json)
+[octokit.github.io/webhooks/payload-examples/api.github.com/index.json](https://octokit.github.io/webhooks/payload-examples/api.github.com/index.json)
 
 ## Example
 
@@ -229,7 +229,7 @@ Example webhook definition
 ## Download webhook definitions and webhook payloads schema
 
 You can download the latest `index.json` file from
-[unpkg](https://unpkg.com/@octokit/webhooks-examples/index.json)
+[unpkg](https://unpkg.com/@octokit/webhooks-examples/api.github.com/index.json)
 
 ## Usage as Node module
 
@@ -237,10 +237,10 @@ To get an array of all webhook definition objects, require the `@octokit/webhook
 
 ```js
 // Use Node.js require:
-const WEBHOOKS = require("@octokit/webhooks-examples/index.json");
+const WEBHOOKS = require("@octokit/webhooks-examples/api.github.com/index.json");
 
 // Or ESM/TypeScript import:
-import WEBHOOKS from "@octokit/webhooks-examples/index.json";
+import WEBHOOKS from "@octokit/webhooks-examples/api.github.com/index.json";
 ```
 
 ## How it works

--- a/payload-types/README.md
+++ b/payload-types/README.md
@@ -7,7 +7,7 @@
 ## Download
 
 Download the latest specification at
-[octokit.github.io/webhooks/payload-examples/index.json](https://octokit.github.io/webhooks/payload-examples/index.json)
+[octokit.github.io/webhooks/payload-examples/api.github.com/index.json](https://octokit.github.io/webhooks/payload-examples/api.github.com/index.json)
 
 ## Usage
 


### PR DESCRIPTION
By #443, the path to index.json file has been changed.
But README still referenced the old path.
This PR update paths to index.json in all READMEs.