### PR TITLE
fix(schema): add `null` to `type` field where missing when present in `enum`

### DIFF
--- a/payload-schemas/api.github.com/code_scanning_alert/closed_by_user.schema.json
+++ b/payload-schemas/api.github.com/code_scanning_alert/closed_by_user.schema.json
@@ -66,7 +66,7 @@
           "description": "The time that the alert was dismissed in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "dismissed_reason": {
-          "type": "string",
+          "type": ["string", "null"],
           "enum": ["false positive", "won't fix", "used in tests", null],
           "description": "The reason for dismissing or closing the alert. Can be one of: `false positive`, `won't fix`, and `used in tests`."
         },


### PR DESCRIPTION
Type the enum array lists `null`, it's not a valid value per the `type` field. Note that this is the only instance where `enum` contains `null` and `type` does not:

```
$ git ls-files | grep schema.json | xargs -L1 jq -c '.. | select(.enum?) | select(.enum | index(null) != null) | .type' 
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
"string"
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
["string","null"]
```