### PR TITLE
fix: type override masks the props

### DIFF
--- a/payload-types/schema.d.ts
+++ b/payload-types/schema.d.ts
@@ -270,25 +270,13 @@ export type PullRequestReviewRequestRemovedEvent =
        */
       number: number;
       pull_request: PullRequest;
-      requested_reviewer: User;
+      requested_reviewer?: User;
+      requested_team?: Team;
       repository: Repository;
       installation?: InstallationLite;
       organization?: Organization;
       sender: User;
     }
-  | {
-      action: "review_request_removed";
-      /**
-       * The pull request number.
-       */
-      number: number;
-      pull_request: PullRequest;
-      requested_team: Team;
-      repository: Repository;
-      installation?: InstallationLite;
-      organization?: Organization;
-      sender: User;
-    };
 export type PullRequestReviewRequestedEvent =
   | {
       action: "review_requested";
@@ -297,25 +285,13 @@ export type PullRequestReviewRequestedEvent =
        */
       number: number;
       pull_request: PullRequest;
-      requested_reviewer: User;
+      requested_reviewer?: User;
+      requested_team?: Team;
       repository: Repository;
       installation?: InstallationLite;
       organization?: Organization;
       sender: User;
     }
-  | {
-      action: "review_requested";
-      /**
-       * The pull request number.
-       */
-      number: number;
-      pull_request: PullRequest;
-      requested_team: Team;
-      repository: Repository;
-      installation?: InstallationLite;
-      organization?: Organization;
-      sender: User;
-    };
 export type PullRequestReviewEvent =
   | PullRequestReviewDismissedEvent
   | PullRequestReviewEditedEvent


### PR DESCRIPTION
The 2nd type definition is masking the 1st one for some reason. The union doesn't seem to work and the props are rather "lost".

![image](https://user-images.githubusercontent.com/411625/151948545-de03d640-0f19-4756-9002-5be19def1019.png)

The only way to get access to `requested_reviewer` is to remove the union and reunite the types.