### PR TITLE
ci(deps): ping `gr2m/await-npm-package-version` to `1.1.7`

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -8,19 +8,19 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: gr2m/await-npm-package-version-action@v1
+      - uses: gr2m/await-npm-package-version-action@v1.1.7
         with:
           package: "@octokit/webhooks-schemas"
           version: ${{ github.event.release.tag_name }}
-      - uses: gr2m/await-npm-package-version-action@v1
+      - uses: gr2m/await-npm-package-version-action@v1.1.7
         with:
           package: "@octokit/webhooks-types"
           version: ${{ github.event.release.tag_name }}
-      - uses: gr2m/await-npm-package-version-action@v1
+      - uses: gr2m/await-npm-package-version-action@v1.1.7
         with:
           package: "@octokit/webhooks-examples"
           version: ${{ github.event.release.tag_name }}
-      - uses: gr2m/release-notifier-action@v1
+      - uses: gr2m/release-notifier-action@v1.1.7
         with:
           app_id: ${{ secrets.RELEASE_NOTIFIER_APP_ID }}
           private_key: ${{ secrets.RELEASE_NOTIFIER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Until https://github.com/gr2m/await-npm-package-version-action/issues/85 gets fixed again (https://github.com/gr2m/await-npm-package-version-action/commit/5dc2ffa59e1844d4e527ecbd4e707aae52515922), pin the version so the release notifier works