### PR TITLE
feat: Add missing date-time format to time fields

### DIFF
--- a/payload-schemas/api.github.com/check_run/completed.schema.json
+++ b/payload-schemas/api.github.com/check_run/completed.schema.json
@@ -57,10 +57,12 @@
         },
         "started_at": {
           "type": "string",
+          "format": "date-time",
           "description": "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "completed_at": {
           "type": "string",
+          "format": "date-time",
           "description": "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "output": {

--- a/payload-schemas/api.github.com/check_run/created.schema.json
+++ b/payload-schemas/api.github.com/check_run/created.schema.json
@@ -57,10 +57,14 @@
         },
         "started_at": {
           "type": "string",
+          "format": "date-time",
           "description": "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "completed_at": {
-          "type": ["string", "null"],
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ],
           "description": "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "output": {

--- a/payload-schemas/api.github.com/check_run/requested_action.schema.json
+++ b/payload-schemas/api.github.com/check_run/requested_action.schema.json
@@ -63,10 +63,14 @@
         },
         "started_at": {
           "type": "string",
+          "format": "date-time",
           "description": "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "completed_at": {
-          "type": ["string", "null"],
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ],
           "description": "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "output": {

--- a/payload-schemas/api.github.com/check_run/rerequested.schema.json
+++ b/payload-schemas/api.github.com/check_run/rerequested.schema.json
@@ -57,10 +57,12 @@
         },
         "started_at": {
           "type": "string",
+          "format": "date-time",
           "description": "The time that the check run began. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "completed_at": {
           "type": "string",
+          "format": "date-time",
           "description": "The time the check completed. This is a timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format: `YYYY-MM-DDTHH:MM:SSZ`."
         },
         "output": {

--- a/payload-schemas/api.github.com/commit_comment/created.schema.json
+++ b/payload-schemas/api.github.com/commit_comment/created.schema.json
@@ -56,8 +56,8 @@
           "type": "string",
           "description": "The SHA of the commit to which the comment applies."
         },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
         "author_association": {
           "$ref": "common/author_association.schema.json"
         },

--- a/payload-schemas/api.github.com/common/deployment.schema.json
+++ b/payload-schemas/api.github.com/common/deployment.schema.json
@@ -37,8 +37,8 @@
     "production_environment": { "type": "boolean" },
     "description": { "type": ["string", "null"] },
     "creator": { "$ref": "user.schema.json" },
-    "created_at": { "type": "string" },
-    "updated_at": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" },
     "statuses_url": { "type": "string", "format": "uri" },
     "repository_url": { "type": "string", "format": "uri" },
     "performed_via_github_app": {

--- a/payload-schemas/api.github.com/common/discussion.schema.json
+++ b/payload-schemas/api.github.com/common/discussion.schema.json
@@ -45,14 +45,16 @@
         "name": { "type": "string" },
         "description": { "type": "string" },
         "created_at": { "type": "string", "format": "date-time" },
-        "updated_at": { "type": "string" },
+        "updated_at": { "type": "string", "format": "date-time" },
         "slug": { "type": "string" },
         "is_answerable": { "type": "boolean" }
       },
       "additionalProperties": false
     },
     "answer_html_url": { "type": ["string", "null"] },
-    "answer_chosen_at": { "type": ["string", "null"] },
+    "answer_chosen_at": {
+      "oneOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }]
+    },
     "answer_chosen_by": {
       "oneOf": [{ "$ref": "user.schema.json" }, { "type": "null" }]
     },

--- a/payload-schemas/api.github.com/common/marketplace-purchase.schema.json
+++ b/payload-schemas/api.github.com/common/marketplace-purchase.schema.json
@@ -32,7 +32,9 @@
     "billing_cycle": { "type": "string" },
     "unit_count": { "type": "integer" },
     "on_free_trial": { "type": "boolean" },
-    "free_trial_ends_on": { "type": "null" },
+    "free_trial_ends_on": {
+      "oneOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }]
+    },
     "next_billing_date": { "type": "string" },
     "plan": {
       "type": "object",

--- a/payload-schemas/api.github.com/common/repository-vulnerability-alert-alert.schema.json
+++ b/payload-schemas/api.github.com/common/repository-vulnerability-alert-alert.schema.json
@@ -25,7 +25,7 @@
     "affected_package_name": { "type": "string" },
     "dismisser": { "$ref": "user.schema.json" },
     "dismiss_reason": { "type": "string" },
-    "dismissed_at": { "type": "string" },
+    "dismissed_at": { "type": "string", "format": "date-time" },
     "severity": { "type": "string" },
     "ghsa_id": { "type": "string" },
     "external_reference": { "type": "string", "format": "uri" },
@@ -33,7 +33,7 @@
     "fixed_in": { "type": "string" },
     "fixed_at": { "type": "string", "format": "date-time" },
     "fix_reason": { "type": "string" },
-    "created_at": { "type": "string" }
+    "created_at": { "type": "string", "format": "date-time" }
   },
   "additionalProperties": false,
   "description": "The security alert of the vulnerable dependency.",

--- a/payload-schemas/api.github.com/common/simple-pull-request.schema.json
+++ b/payload-schemas/api.github.com/common/simple-pull-request.schema.json
@@ -54,10 +54,14 @@
     "title": { "type": "string" },
     "user": { "$ref": "user.schema.json" },
     "body": { "type": "string" },
-    "created_at": { "type": "string" },
-    "updated_at": { "type": "string" },
-    "closed_at": { "type": ["string", "null"] },
-    "merged_at": { "type": ["string", "null"] },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" },
+    "closed_at": {
+      "oneOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }]
+    },
+    "merged_at": {
+      "oneOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }]
+    },
     "merge_commit_sha": { "type": ["string", "null"] },
     "assignee": {
       "oneOf": [{ "$ref": "user.schema.json" }, { "type": "null" }]

--- a/payload-schemas/api.github.com/common/sponsorship-tier.schema.json
+++ b/payload-schemas/api.github.com/common/sponsorship-tier.schema.json
@@ -15,7 +15,7 @@
   "type": "object",
   "properties": {
     "node_id": { "type": "string" },
-    "created_at": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
     "description": { "type": "string" },
     "monthly_price_in_cents": { "type": "integer" },
     "monthly_price_in_dollars": { "type": "integer" },

--- a/payload-schemas/api.github.com/common/workflow-job.schema.json
+++ b/payload-schemas/api.github.com/common/workflow-job.schema.json
@@ -71,8 +71,10 @@
       "type": ["string", "null"],
       "description": "The name of the runner group that is running this job. This will be `null` as long as `workflow_job[status]` is `queued`."
     },
-    "started_at": { "type": "string" },
-    "completed_at": { "type": ["string", "null"] }
+    "started_at": { "type": "string", "format": "date-time" },
+    "completed_at": {
+      "oneOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }]
+    }
   },
   "additionalProperties": false,
   "title": "Workflow Job"

--- a/payload-schemas/api.github.com/common/workflow-step-completed.schema.json
+++ b/payload-schemas/api.github.com/common/workflow-step-completed.schema.json
@@ -18,8 +18,8 @@
       "enum": ["failure", "skipped", "success"]
     },
     "number": { "type": "integer" },
-    "started_at": { "type": "string" },
-    "completed_at": { "type": "string" }
+    "started_at": { "type": "string", "format": "date-time" },
+    "completed_at": { "type": "string", "format": "date-time" }
   },
   "additionalProperties": false,
   "title": "Workflow Step (Completed)"

--- a/payload-schemas/api.github.com/common/workflow-step-in_progress.schema.json
+++ b/payload-schemas/api.github.com/common/workflow-step-in_progress.schema.json
@@ -15,7 +15,7 @@
     "status": { "type": "string", "enum": ["in_progress"] },
     "conclusion": { "type": "null" },
     "number": { "type": "integer" },
-    "started_at": { "type": "string" },
+    "started_at": { "type": "string", "format": "date-time" },
     "completed_at": { "type": "null" }
   },
   "additionalProperties": false,

--- a/payload-schemas/api.github.com/deploy_key/created.schema.json
+++ b/payload-schemas/api.github.com/deploy_key/created.schema.json
@@ -23,7 +23,7 @@
         "url": { "type": "string", "format": "uri" },
         "title": { "type": "string" },
         "verified": { "type": "boolean" },
-        "created_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
         "read_only": { "type": "boolean" }
       },
       "additionalProperties": false

--- a/payload-schemas/api.github.com/deploy_key/deleted.schema.json
+++ b/payload-schemas/api.github.com/deploy_key/deleted.schema.json
@@ -23,7 +23,7 @@
         "url": { "type": "string", "format": "uri" },
         "title": { "type": "string" },
         "verified": { "type": "boolean" },
-        "created_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
         "read_only": { "type": "boolean" }
       },
       "additionalProperties": false

--- a/payload-schemas/api.github.com/deployment_status/created.schema.json
+++ b/payload-schemas/api.github.com/deployment_status/created.schema.json
@@ -53,8 +53,8 @@
           "type": "string",
           "description": "The optional link added to the status."
         },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
         "deployment_url": { "type": "string", "format": "uri" },
         "repository_url": { "type": "string", "format": "uri" },
         "performed_via_github_app": {

--- a/payload-schemas/api.github.com/discussion/category_changed.schema.json
+++ b/payload-schemas/api.github.com/discussion/category_changed.schema.json
@@ -32,7 +32,7 @@
                 "name": { "type": "string" },
                 "description": { "type": "string" },
                 "created_at": { "type": "string", "format": "date-time" },
-                "updated_at": { "type": "string" },
+                "updated_at": { "type": "string", "format": "date-time" },
                 "slug": { "type": "string" },
                 "is_answerable": { "type": "boolean" }
               },

--- a/payload-schemas/api.github.com/discussion_comment/created.schema.json
+++ b/payload-schemas/api.github.com/discussion_comment/created.schema.json
@@ -41,8 +41,8 @@
           "$ref": "common/author_association.schema.json"
         },
         "user": { "$ref": "common/user.schema.json" },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
         "body": { "type": "string" },
         "reactions": { "$ref": "common/reactions.schema.json" }
       },

--- a/payload-schemas/api.github.com/discussion_comment/deleted.schema.json
+++ b/payload-schemas/api.github.com/discussion_comment/deleted.schema.json
@@ -41,8 +41,8 @@
           "$ref": "common/author_association.schema.json"
         },
         "user": { "$ref": "common/user.schema.json" },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
         "body": { "type": "string" },
         "reactions": { "$ref": "common/reactions.schema.json" }
       },

--- a/payload-schemas/api.github.com/discussion_comment/edited.schema.json
+++ b/payload-schemas/api.github.com/discussion_comment/edited.schema.json
@@ -55,8 +55,8 @@
           "$ref": "common/author_association.schema.json"
         },
         "user": { "$ref": "common/user.schema.json" },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
         "body": { "type": "string" },
         "reactions": { "$ref": "common/reactions.schema.json" }
       },

--- a/payload-schemas/api.github.com/marketplace_purchase/cancelled.schema.json
+++ b/payload-schemas/api.github.com/marketplace_purchase/cancelled.schema.json
@@ -5,7 +5,7 @@
   "required": ["action", "effective_date", "sender", "marketplace_purchase"],
   "properties": {
     "action": { "type": "string", "enum": ["cancelled"] },
-    "effective_date": { "type": "string" },
+    "effective_date": { "type": "string", "format": "date-time" },
     "sender": {
       "type": "object",
       "required": [
@@ -56,7 +56,9 @@
         {
           "type": "object",
           "required": ["next_billing_date"],
-          "properties": { "next_billing_date": { "type": "string" } },
+          "properties": {
+            "next_billing_date": { "type": "string", "format": "date-time" }
+          },
           "tsAdditionalProperties": false
         }
       ]

--- a/payload-schemas/api.github.com/marketplace_purchase/changed.schema.json
+++ b/payload-schemas/api.github.com/marketplace_purchase/changed.schema.json
@@ -5,7 +5,7 @@
   "required": ["action", "effective_date", "sender", "marketplace_purchase"],
   "properties": {
     "action": { "type": "string", "enum": ["changed"] },
-    "effective_date": { "type": "string" },
+    "effective_date": { "type": "string", "format": "date-time" },
     "sender": {
       "type": "object",
       "required": [
@@ -56,7 +56,9 @@
         {
           "type": "object",
           "required": ["next_billing_date"],
-          "properties": { "next_billing_date": { "type": "string" } },
+          "properties": {
+            "next_billing_date": { "type": "string", "format": "date-time" }
+          },
           "tsAdditionalProperties": false
         }
       ]

--- a/payload-schemas/api.github.com/marketplace_purchase/pending_change.schema.json
+++ b/payload-schemas/api.github.com/marketplace_purchase/pending_change.schema.json
@@ -5,7 +5,7 @@
   "required": ["action", "effective_date", "sender", "marketplace_purchase"],
   "properties": {
     "action": { "type": "string", "enum": ["pending_change"] },
-    "effective_date": { "type": "string" },
+    "effective_date": { "type": "string", "format": "date-time" },
     "sender": {
       "type": "object",
       "required": [
@@ -56,7 +56,9 @@
         {
           "type": "object",
           "required": ["next_billing_date"],
-          "properties": { "next_billing_date": { "type": "string" } },
+          "properties": {
+            "next_billing_date": { "type": "string", "format": "date-time" }
+          },
           "tsAdditionalProperties": false
         }
       ]

--- a/payload-schemas/api.github.com/marketplace_purchase/pending_change_cancelled.schema.json
+++ b/payload-schemas/api.github.com/marketplace_purchase/pending_change_cancelled.schema.json
@@ -5,7 +5,7 @@
   "required": ["action", "effective_date", "sender", "marketplace_purchase"],
   "properties": {
     "action": { "type": "string", "enum": ["pending_change_cancelled"] },
-    "effective_date": { "type": "string" },
+    "effective_date": { "type": "string", "format": "date-time" },
     "sender": {
       "type": "object",
       "required": [
@@ -56,7 +56,9 @@
         {
           "type": "object",
           "required": ["next_billing_date"],
-          "properties": { "next_billing_date": { "type": "string" } },
+          "properties": {
+            "next_billing_date": { "type": "string", "format": "date-time" }
+          },
           "tsAdditionalProperties": false
         }
       ]

--- a/payload-schemas/api.github.com/marketplace_purchase/purchased.schema.json
+++ b/payload-schemas/api.github.com/marketplace_purchase/purchased.schema.json
@@ -5,7 +5,7 @@
   "required": ["action", "effective_date", "sender", "marketplace_purchase"],
   "properties": {
     "action": { "type": "string", "enum": ["purchased"] },
-    "effective_date": { "type": "string" },
+    "effective_date": { "type": "string", "format": "date-time" },
     "sender": {
       "type": "object",
       "required": [
@@ -56,7 +56,9 @@
         {
           "type": "object",
           "required": ["next_billing_date"],
-          "properties": { "next_billing_date": { "type": "string" } },
+          "properties": {
+            "next_billing_date": { "type": "string", "format": "date-time" }
+          },
           "tsAdditionalProperties": false
         }
       ]

--- a/payload-schemas/api.github.com/meta/deleted.schema.json
+++ b/payload-schemas/api.github.com/meta/deleted.schema.json
@@ -39,8 +39,8 @@
           },
           "additionalProperties": false
         },
-        "updated_at": { "type": "string" },
-        "created_at": { "type": "string" }
+        "updated_at": { "type": "string", "format": "date-time" },
+        "created_at": { "type": "string", "format": "date-time" }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/api.github.com/package/published.schema.json
+++ b/payload-schemas/api.github.com/package/published.schema.json
@@ -30,8 +30,8 @@
         "ecosystem": { "type": "string" },
         "package_type": { "type": "string" },
         "html_url": { "type": "string", "format": "uri" },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
         "owner": { "$ref": "common/user.schema.json" },
         "package_version": {
           "type": "object",
@@ -93,8 +93,8 @@
                 "draft": { "type": "boolean" },
                 "author": { "$ref": "common/user.schema.json" },
                 "prerelease": { "type": "boolean" },
-                "created_at": { "type": "string" },
-                "published_at": { "type": "string" }
+                "created_at": { "type": "string", "format": "date-time" },
+                "published_at": { "type": "string", "format": "date-time" }
               },
               "additionalProperties": false
             },
@@ -105,8 +105,8 @@
             "target_oid": { "type": "string" },
             "draft": { "type": "boolean" },
             "prerelease": { "type": "boolean" },
-            "created_at": { "type": "string" },
-            "updated_at": { "type": "string" },
+            "created_at": { "type": "string", "format": "date-time" },
+            "updated_at": { "type": "string", "format": "date-time" },
             "metadata": { "type": "array", "items": {} },
             "docker_metadata": { "type": "array", "items": {} },
             "package_files": {
@@ -136,8 +136,8 @@
                   "content_type": { "type": "string" },
                   "state": { "type": "string" },
                   "size": { "type": "integer" },
-                  "created_at": { "type": "string" },
-                  "updated_at": { "type": "string" }
+                  "created_at": { "type": "string", "format": "date-time" },
+                  "updated_at": { "type": "string", "format": "date-time" }
                 },
                 "additionalProperties": false
               }

--- a/payload-schemas/api.github.com/package/updated.schema.json
+++ b/payload-schemas/api.github.com/package/updated.schema.json
@@ -30,8 +30,8 @@
         "ecosystem": { "type": "string" },
         "package_type": { "type": "string" },
         "html_url": { "type": "string", "format": "uri" },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
         "owner": { "$ref": "common/user.schema.json" },
         "package_version": {
           "type": "object",
@@ -93,8 +93,8 @@
                 "draft": { "type": "boolean" },
                 "author": { "$ref": "common/user.schema.json" },
                 "prerelease": { "type": "boolean" },
-                "created_at": { "type": "string" },
-                "published_at": { "type": "string" }
+                "created_at": { "type": "string", "format": "date-time" },
+                "published_at": { "type": "string", "format": "date-time" }
               },
               "additionalProperties": false
             },
@@ -105,8 +105,8 @@
             "target_oid": { "type": "string" },
             "draft": { "type": "boolean" },
             "prerelease": { "type": "boolean" },
-            "created_at": { "type": "string" },
-            "updated_at": { "type": "string" },
+            "created_at": { "type": "string", "format": "date-time" },
+            "updated_at": { "type": "string", "format": "date-time" },
             "metadata": { "type": "array", "items": {} },
             "docker_metadata": { "type": "array", "items": {} },
             "package_files": {
@@ -136,8 +136,8 @@
                   "content_type": { "type": "string" },
                   "state": { "type": "string" },
                   "size": { "type": "integer" },
-                  "created_at": { "type": "string" },
-                  "updated_at": { "type": "string" }
+                  "created_at": { "type": "string", "format": "date-time" },
+                  "updated_at": { "type": "string", "format": "date-time" }
                 },
                 "additionalProperties": false
               }

--- a/payload-schemas/api.github.com/page_build/event.schema.json
+++ b/payload-schemas/api.github.com/page_build/event.schema.json
@@ -31,8 +31,8 @@
         "pusher": { "$ref": "common/user.schema.json" },
         "commit": { "type": "string" },
         "duration": { "type": "integer" },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" }
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/api.github.com/ping/event.schema.json
+++ b/payload-schemas/api.github.com/ping/event.schema.json
@@ -46,8 +46,8 @@
           },
           "additionalProperties": false
         },
-        "updated_at": { "type": "string" },
-        "created_at": { "type": "string" },
+        "updated_at": { "type": "string", "format": "date-time" },
+        "created_at": { "type": "string", "format": "date-time" },
         "url": { "type": "string", "format": "uri" },
         "test_url": { "type": "string", "format": "uri" },
         "ping_url": { "type": "string", "format": "uri" },

--- a/payload-schemas/api.github.com/pull_request_review_comment/created.schema.json
+++ b/payload-schemas/api.github.com/pull_request_review_comment/created.schema.json
@@ -58,10 +58,20 @@
         "title": { "type": "string" },
         "user": { "$ref": "common/user.schema.json" },
         "body": { "type": "string" },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" },
-        "closed_at": { "type": ["string", "null"] },
-        "merged_at": { "type": ["string", "null"] },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
+        "closed_at": {
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ]
+        },
+        "merged_at": {
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ]
+        },
         "merge_commit_sha": { "type": ["string", "null"] },
         "assignee": {
           "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]

--- a/payload-schemas/api.github.com/pull_request_review_comment/deleted.schema.json
+++ b/payload-schemas/api.github.com/pull_request_review_comment/deleted.schema.json
@@ -58,10 +58,20 @@
         "title": { "type": "string" },
         "user": { "$ref": "common/user.schema.json" },
         "body": { "type": "string" },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" },
-        "closed_at": { "type": ["string", "null"] },
-        "merged_at": { "type": ["string", "null"] },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
+        "closed_at": {
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ]
+        },
+        "merged_at": {
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ]
+        },
         "merge_commit_sha": { "type": ["string", "null"] },
         "assignee": {
           "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]

--- a/payload-schemas/api.github.com/pull_request_review_comment/edited.schema.json
+++ b/payload-schemas/api.github.com/pull_request_review_comment/edited.schema.json
@@ -83,10 +83,20 @@
         "title": { "type": "string" },
         "user": { "$ref": "common/user.schema.json" },
         "body": { "type": "string" },
-        "created_at": { "type": "string" },
-        "updated_at": { "type": "string" },
-        "closed_at": { "type": ["string", "null"] },
-        "merged_at": { "type": ["string", "null"] },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
+        "closed_at": {
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ]
+        },
+        "merged_at": {
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ]
+        },
         "merge_commit_sha": { "type": ["string", "null"] },
         "assignee": {
           "oneOf": [{ "$ref": "common/user.schema.json" }, { "type": "null" }]

--- a/payload-schemas/api.github.com/secret_scanning_alert/resolved.schema.json
+++ b/payload-schemas/api.github.com/secret_scanning_alert/resolved.schema.json
@@ -23,7 +23,7 @@
           "enum": ["false_positive", "wontfix", "revoked", "used_in_tests"]
         },
         "resolved_by": { "$ref": "common/user.schema.json" },
-        "resolved_at": { "type": "string" }
+        "resolved_at": { "type": "string", "format": "date-time" }
       },
       "additionalProperties": false
     },

--- a/payload-schemas/api.github.com/security_advisory/performed.schema.json
+++ b/payload-schemas/api.github.com/security_advisory/performed.schema.json
@@ -69,9 +69,14 @@
             "additionalProperties": false
           }
         },
-        "published_at": { "type": "string" },
-        "updated_at": { "type": "string" },
-        "withdrawn_at": { "type": ["string", "null"] },
+        "published_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
+        "withdrawn_at": {
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ]
+        },
         "vulnerabilities": {
           "type": "array",
           "items": {

--- a/payload-schemas/api.github.com/security_advisory/published.schema.json
+++ b/payload-schemas/api.github.com/security_advisory/published.schema.json
@@ -69,9 +69,14 @@
             "additionalProperties": false
           }
         },
-        "published_at": { "type": "string" },
-        "updated_at": { "type": "string" },
-        "withdrawn_at": { "type": ["string", "null"] },
+        "published_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
+        "withdrawn_at": {
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ]
+        },
         "vulnerabilities": {
           "type": "array",
           "items": {

--- a/payload-schemas/api.github.com/security_advisory/updated.schema.json
+++ b/payload-schemas/api.github.com/security_advisory/updated.schema.json
@@ -69,9 +69,14 @@
             "additionalProperties": false
           }
         },
-        "published_at": { "type": "string" },
-        "updated_at": { "type": "string" },
-        "withdrawn_at": { "type": ["string", "null"] },
+        "published_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
+        "withdrawn_at": {
+          "oneOf": [
+            { "type": "string", "format": "date-time" },
+            { "type": "null" }
+          ]
+        },
         "vulnerabilities": {
           "type": "array",
           "items": {

--- a/payload-schemas/api.github.com/security_advisory/withdrawn.schema.json
+++ b/payload-schemas/api.github.com/security_advisory/withdrawn.schema.json
@@ -69,9 +69,9 @@
             "additionalProperties": false
           }
         },
-        "published_at": { "type": "string" },
-        "updated_at": { "type": "string" },
-        "withdrawn_at": { "type": "string" },
+        "published_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
+        "withdrawn_at": { "type": "string", "format": "date-time" },
         "vulnerabilities": {
           "type": "array",
           "items": {

--- a/payload-schemas/api.github.com/sponsorship/cancelled.schema.json
+++ b/payload-schemas/api.github.com/sponsorship/cancelled.schema.json
@@ -17,7 +17,7 @@
       ],
       "properties": {
         "node_id": { "type": "string" },
-        "created_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },

--- a/payload-schemas/api.github.com/sponsorship/created.schema.json
+++ b/payload-schemas/api.github.com/sponsorship/created.schema.json
@@ -17,7 +17,7 @@
       ],
       "properties": {
         "node_id": { "type": "string" },
-        "created_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },

--- a/payload-schemas/api.github.com/sponsorship/edited.schema.json
+++ b/payload-schemas/api.github.com/sponsorship/edited.schema.json
@@ -17,7 +17,7 @@
       ],
       "properties": {
         "node_id": { "type": "string" },
-        "created_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },

--- a/payload-schemas/api.github.com/sponsorship/pending_cancellation.schema.json
+++ b/payload-schemas/api.github.com/sponsorship/pending_cancellation.schema.json
@@ -17,7 +17,7 @@
       ],
       "properties": {
         "node_id": { "type": "string" },
-        "created_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },

--- a/payload-schemas/api.github.com/sponsorship/pending_tier_change.schema.json
+++ b/payload-schemas/api.github.com/sponsorship/pending_tier_change.schema.json
@@ -17,7 +17,7 @@
       ],
       "properties": {
         "node_id": { "type": "string" },
-        "created_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },

--- a/payload-schemas/api.github.com/sponsorship/tier_changed.schema.json
+++ b/payload-schemas/api.github.com/sponsorship/tier_changed.schema.json
@@ -17,7 +17,7 @@
       ],
       "properties": {
         "node_id": { "type": "string" },
-        "created_at": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
         "sponsorable": { "$ref": "common/user.schema.json" },
         "sponsor": { "$ref": "common/user.schema.json" },
         "privacy_level": { "type": "string" },

--- a/payload-schemas/api.github.com/star/created.schema.json
+++ b/payload-schemas/api.github.com/star/created.schema.json
@@ -7,6 +7,7 @@
     "action": { "type": "string", "enum": ["created"] },
     "starred_at": {
       "type": "string",
+      "format": "date-time",
       "description": "The time the star was created. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Will be `null` for the `deleted` action."
     },
     "repository": { "$ref": "common/repository.schema.json" },

--- a/payload-schemas/api.github.com/status/event.schema.json
+++ b/payload-schemas/api.github.com/status/event.schema.json
@@ -179,8 +179,8 @@
         "additionalProperties": false
       }
     },
-    "created_at": { "type": "string" },
-    "updated_at": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" },
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "installation": { "$ref": "common/installation-lite.schema.json" },

--- a/payload-types/schema.d.ts
+++ b/payload-types/schema.d.ts
@@ -3426,7 +3426,7 @@ export interface MarketplacePurchase {
   billing_cycle: string;
   unit_count: number;
   on_free_trial: boolean;
-  free_trial_ends_on: null;
+  free_trial_ends_on: string | null;
   next_billing_date?: string;
   plan: {
     id: number;


### PR DESCRIPTION
While doing some parsing & codegen work based on the JSON specs I realised that some time-based fields were missing the `date-time` format validation which is a very nice-to-have when dealing with unmarshalling into typed languages.

This PR's changes solely focus on adding those missing format hints.