### PR TITLE
fix: refactor `workflow_job.queued` event to use the `WorkflowJob` common shema

### DIFF
--- a/payload-schemas/api.github.com/common/workflow-job.schema.json
+++ b/payload-schemas/api.github.com/common/workflow-job.schema.json
@@ -43,8 +43,7 @@
     },
     "steps": {
       "type": "array",
-      "items": { "$ref": "workflow-step.schema.json" },
-      "minItems": 1
+      "items": { "$ref": "workflow-step.schema.json" }
     },
     "conclusion": {
       "type": ["string", "null"],

--- a/payload-schemas/api.github.com/workflow_job/queued.schema.json
+++ b/payload-schemas/api.github.com/workflow_job/queued.schema.json
@@ -10,55 +10,17 @@
     "repository": { "$ref": "common/repository.schema.json" },
     "sender": { "$ref": "common/user.schema.json" },
     "workflow_job": {
-      "type": "object",
-      "required": [
-        "id",
-        "run_id",
-        "run_url",
-        "run_attempt",
-        "node_id",
-        "head_sha",
-        "url",
-        "html_url",
-        "status",
-        "conclusion",
-        "started_at",
-        "completed_at",
-        "name",
-        "steps",
-        "check_run_url",
-        "labels",
-        "runner_id",
-        "runner_name",
-        "runner_group_id",
-        "runner_group_name"
-      ],
-      "properties": {
-        "id": { "type": "integer" },
-        "run_id": { "type": "number" },
-        "run_url": { "type": "string", "format": "uri" },
-        "run_attempt": { "type": "integer" },
-        "head_sha": { "type": "string" },
-        "node_id": { "type": "string" },
-        "name": { "type": "string" },
-        "check_run_url": { "type": "string", "format": "uri" },
-        "html_url": { "type": "string", "format": "uri" },
-        "url": { "type": "string", "format": "uri" },
-        "status": { "type": "string", "enum": ["queued"] },
-        "steps": {
-          "type": "array",
-          "items": { "$ref": "common/workflow-step.schema.json" }
-        },
-        "conclusion": { "type": "null" },
-        "labels": { "type": "array", "items": { "type": "string" } },
-        "runner_id": { "type": ["integer", "null"] },
-        "runner_name": { "type": ["string", "null"] },
-        "runner_group_id": { "type": ["integer", "null"] },
-        "runner_group_name": { "type": ["string", "null"] },
-        "started_at": { "type": "string", "format": "date-time" },
-        "completed_at": { "type": "null" }
-      },
-      "additionalProperties": false
+      "allOf": [
+        { "$ref": "common/workflow-job.schema.json" },
+        {
+          "type": "object",
+          "required": ["status"],
+          "properties": {
+            "status": { "type": "string", "enum": ["queued"] }
+          },
+          "tsAdditionalProperties": false
+        }
+      ]
     }
   },
   "additionalProperties": false,

--- a/payload-types/schema.d.ts
+++ b/payload-types/schema.d.ts
@@ -2923,6 +2923,8 @@ export interface InstallationRepositoriesAddedEvent {
   }[];
   /**
    * An array of repository objects, which were removed from the installation.
+   *
+   * @maxItems 0
    */
   repositories_removed: [];
   requester: User | null;
@@ -2937,6 +2939,8 @@ export interface InstallationRepositoriesRemovedEvent {
   repository_selection: "all" | "selected";
   /**
    * An array of repository objects, which were added to the installation.
+   *
+   * @maxItems 0
    */
   repositories_added: [];
   /**

--- a/payload-types/schema.d.ts
+++ b/payload-types/schema.d.ts
@@ -2923,8 +2923,6 @@ export interface InstallationRepositoriesAddedEvent {
   }[];
   /**
    * An array of repository objects, which were removed from the installation.
-   *
-   * @maxItems 0
    */
   repositories_removed: [];
   requester: User | null;
@@ -2939,8 +2937,6 @@ export interface InstallationRepositoriesRemovedEvent {
   repository_selection: "all" | "selected";
   /**
    * An array of repository objects, which were added to the installation.
-   *
-   * @maxItems 0
    */
   repositories_added: [];
   /**
@@ -6256,10 +6252,7 @@ export interface WorkflowJob {
    * The current status of the job. Can be `queued`, `in_progress`, or `completed`.
    */
   status: "queued" | "in_progress" | "completed";
-  /**
-   * @minItems 1
-   */
-  steps: [WorkflowStep, ...WorkflowStep[]];
+  steps: WorkflowStep[];
   conclusion: "success" | "failure" | "cancelled" | "skipped" | null;
   /**
    * Custom labels for the job. Specified by the [`"runs-on"` attribute](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on) in the workflow YAML.
@@ -6316,27 +6309,8 @@ export interface WorkflowJobQueuedEvent {
   installation?: InstallationLite;
   repository: Repository;
   sender: User;
-  workflow_job: {
-    id: number;
-    run_id: number;
-    run_url: string;
-    run_attempt: number;
-    head_sha: string;
-    node_id: string;
-    name: string;
-    check_run_url: string;
-    html_url: string;
-    url: string;
+  workflow_job: WorkflowJob & {
     status: "queued";
-    steps: WorkflowStep[];
-    conclusion: null;
-    labels: string[];
-    runner_id: number | null;
-    runner_name: string | null;
-    runner_group_id: number | null;
-    runner_group_name: string | null;
-    started_at: string;
-    completed_at: null;
   };
 }
 export interface WorkflowRunCompletedEvent {


### PR DESCRIPTION
My personal code generation tool led me to notice a missing refactor for the `queued` variant of the `workflow_job` event. Am refactoring it here along the same lines as what is used for other variants of the same event.

This does require the relaxation of the `minItems` constraints on the `steps` field in the refactored Workflow Job spec and hence results in a slight alteration of the validation semantics of the other event variants, without it being a breaking change.

If someone could point out a way to forgo this constraint relaxation I am all ears but I did try to add an override for `steps` alongside the `status` one within the `queued` spec but this resulted in test failures.

Example, adding the following in `queued.schema.json`:
```json
        {
          "type": "object",
          "required": ["status"],
          "properties": {
            "status": { "type": "string", "enum": ["queued"] },
            "steps": {
              "type": "array",
              "items": { "$ref": "common/workflow-step.schema.json" }
            }
          },
          "tsAdditionalProperties": false
        }
```
results on `npm run test` in:
```text
✅ Payload 'workflow_job/completed.failure.with-organization.payload.json' matches schema
✅ Payload 'workflow_job/completed.success.with-organization.payload.json' matches schema
✅ Payload 'workflow_job/in_progress.payload.json' matches schema
❌ Payload 'workflow_job/queued.payload.json' does not match schema
[
  {
    instancePath: '/action',
    schemaPath: '#/properties/action/enum',
    keyword: 'enum',
    params: { allowedValues: [ 'completed', 'in_progress' ] },
    message: 'must be equal to one of the allowed values'
  },
  {
    instancePath: '/workflow_job/steps',
    schemaPath: '#/properties/steps/minItems',
    keyword: 'minItems',
    params: { limit: 1 },
    message: 'must NOT have fewer than 1 items'
  },
  {
    instancePath: '',
    schemaPath: '#/oneOf',
    keyword: 'oneOf',
    params: { passingSchemas: null },
    message: 'must match exactly one schema in oneOf'
  }
]
```