### PR TITLE
build(deps): upgrade lock file to v2

### DIFF
--- a/payload-examples/package-lock.json
+++ b/payload-examples/package-lock.json
@@ -1,8 +1,24 @@
 {
   "name": "@octokit/webhooks-examples",
   "version": "0.0.0-development",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@octokit/webhooks-examples",
+      "version": "0.0.0-development",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/webhooks-types": "^6.0.0"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/@octokit/webhooks-types": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-6.2.2.tgz",
+      "integrity": "sha512-CUxPFTKtGq13ja9PC+DoOMpeuWOlLWcfzWSOH29TjI1LHU7p+6Ppb0KH5weCV0tXvdfZdeZrg7UMenGsVOcFGA=="
+    }
+  },
   "dependencies": {
     "@octokit/webhooks-types": {
       "version": "6.2.2",


### PR DESCRIPTION
This is to help with renovate downgrading the lockfile to v1 when it is v2
https://github.com/renovatebot/renovate/discussions/16515#discussioncomment-3118836