### PR TITLE
ci(renovate): move configuaration out of `package.json`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "enabled": true,
+  "extends": ["github>octokit/.github"]
+}

--- a/package.json
+++ b/package.json
@@ -94,11 +94,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "renovate": {
-    "enabled": true,
-    "extends": [
-      "github>octokit/.github"
-    ]
   }
 }


### PR DESCRIPTION
Putting the configuration in the `package.json` is deprecated