### PR TITLE
fix: update schema descriptions for `added`, `removed` and `modified` files in `commits`

### DIFF
--- a/payload-schemas/api.github.com/common/commit.schema.json
+++ b/payload-schemas/api.github.com/common/commit.schema.json
@@ -38,17 +38,17 @@
     "added": {
       "type": "array",
       "items": { "type": "string" },
-      "description": "An array of files added in the commit."
+      "description": "An array of files added in the commit. For extremely large commits where GitHub is unable to calculate this list in a timely manner, this may be empty even if files were added."
     },
     "modified": {
       "type": "array",
       "items": { "type": "string" },
-      "description": "An array of files modified by the commit."
+      "description": "An array of files modified by the commit. For extremely large commits where GitHub is unable to calculate this list in a timely manner, this may be empty even if files were modified."
     },
     "removed": {
       "type": "array",
       "items": { "type": "string" },
-      "description": "An array of files removed in the commit."
+      "description": "An array of files removed in the commit. For extremely large commits where GitHub is unable to calculate this list in a timely manner, this may be empty even if files were removed."
     }
   },
   "additionalProperties": false,

--- a/payload-types/schema.d.ts
+++ b/payload-types/schema.d.ts
@@ -5780,15 +5780,15 @@ export interface Commit {
   author: Committer;
   committer: Committer;
   /**
-   * An array of files added in the commit.
+   * An array of files added in the commit. For extremely large commits where GitHub is unable to calculate this list in a timely manner, this may be empty even if files were added.
    */
   added: string[];
   /**
-   * An array of files modified by the commit.
+   * An array of files modified by the commit. For extremely large commits where GitHub is unable to calculate this list in a timely manner, this may be empty even if files were modified.
    */
   modified: string[];
   /**
-   * An array of files removed in the commit.
+   * An array of files removed in the commit. For extremely large commits where GitHub is unable to calculate this list in a timely manner, this may be empty even if files were removed.
    */
   removed: string[];
 }


### PR DESCRIPTION
This PR applies the description changes detected in #691 to the schemas. They were automatically applied to the examples, but I forgot to make the manual schema changes.