### PR TITLE
fix: refactor `BranchProtectionRule` to have a common schema for the different rule types

### DIFF
--- a/payload-schemas/api.github.com/branch_protection_rule/edited.schema.json
+++ b/payload-schemas/api.github.com/branch_protection_rule/edited.schema.json
@@ -14,7 +14,11 @@
         "admin_enforced": {
           "type": "object",
           "required": ["from"],
-          "properties": { "from": { "type": "boolean" } },
+          "properties": {
+            "from": {
+              "$ref": "common/branch-protection-rule-boolean.schema.json"
+            }
+          },
           "additionalProperties": false
         },
         "allow_deletions_enforcement_level": {
@@ -22,8 +26,12 @@
           "required": ["from"],
           "properties": {
             "from": {
-              "type": ["string", "null"],
-              "enum": ["off", "non_admins", "everyone"]
+              "oneOf": [
+                {
+                  "$ref": "common/branch-protection-rule-enforcement-level.schema.json"
+                },
+                { "type": "null" }
+              ]
             }
           },
           "additionalProperties": false
@@ -33,8 +41,7 @@
           "required": ["from"],
           "properties": {
             "from": {
-              "type": "string",
-              "enum": ["off", "non_admins", "everyone"]
+              "$ref": "common/branch-protection-rule-enforcement-level.schema.json"
             }
           },
           "additionalProperties": false
@@ -42,27 +49,44 @@
         "authorized_actors_only": {
           "type": "object",
           "required": ["from"],
-          "properties": { "from": { "type": "boolean" } },
+          "properties": {
+            "from": {
+              "$ref": "common/branch-protection-rule-boolean.schema.json"
+            }
+          },
           "additionalProperties": false
         },
         "authorized_actor_names": {
           "type": "object",
           "required": ["from"],
           "properties": {
-            "from": { "type": "array", "items": { "type": "string" } }
+            "from": {
+              "$ref": "common/branch-protection-rule-array.schema.json"
+            }
           },
           "additionalProperties": false
         },
         "authorized_dismissal_actors_only": {
           "type": "object",
           "required": ["from"],
-          "properties": { "from": { "type": ["boolean", "null"] } },
+          "properties": {
+            "from": {
+              "oneOf": [
+                { "$ref": "common/branch-protection-rule-boolean.schema.json" },
+                { "type": "null" }
+              ]
+            }
+          },
           "additionalProperties": false
         },
         "dismiss_stale_reviews_on_push": {
           "type": "object",
           "required": ["from"],
-          "properties": { "from": { "type": "boolean" } },
+          "properties": {
+            "from": {
+              "$ref": "common/branch-protection-rule-boolean.schema.json"
+            }
+          },
           "additionalProperties": false
         },
         "pull_request_reviews_enforcement_level": {
@@ -70,8 +94,7 @@
           "required": ["from"],
           "properties": {
             "from": {
-              "type": "string",
-              "enum": ["off", "non_admins", "everyone"]
+              "$ref": "common/branch-protection-rule-enforcement-level.schema.json"
             }
           },
           "additionalProperties": false
@@ -79,13 +102,17 @@
         "require_code_owner_review": {
           "type": "object",
           "required": ["from"],
-          "properties": { "from": { "type": ["boolean"] } },
+          "properties": {
+            "from": {
+              "$ref": "common/branch-protection-rule-boolean.schema.json"
+            }
+          },
           "additionalProperties": false
         },
         "required_approving_review_count": {
           "type": "object",
           "required": ["from"],
-          "properties": { "from": { "type": "integer" } },
+          "properties": { "from": { "$ref": "common/branch-protection-rule-number.schema.json" } },
           "additionalProperties": false
         },
         "required_conversation_resolution_level": {
@@ -93,8 +120,7 @@
           "required": ["from"],
           "properties": {
             "from": {
-              "type": "string",
-              "enum": ["off", "non_admins", "everyone"]
+              "$ref": "common/branch-protection-rule-enforcement-level.schema.json"
             }
           },
           "additionalProperties": false
@@ -104,8 +130,7 @@
           "required": ["from"],
           "properties": {
             "from": {
-              "type": "string",
-              "enum": ["off", "non_admins", "everyone"]
+              "$ref": "common/branch-protection-rule-enforcement-level.schema.json"
             }
           },
           "additionalProperties": false
@@ -114,7 +139,9 @@
           "type": "object",
           "required": ["from"],
           "properties": {
-            "from": { "type": "array", "items": { "type": "string" } }
+            "from": {
+              "$ref": "common/branch-protection-rule-array.schema.json"
+            }
           },
           "additionalProperties": false
         },
@@ -123,8 +150,7 @@
           "required": ["from"],
           "properties": {
             "from": {
-              "type": "string",
-              "enum": ["off", "non_admins", "everyone"]
+              "$ref": "common/branch-protection-rule-enforcement-level.schema.json"
             }
           },
           "additionalProperties": false
@@ -134,8 +160,7 @@
           "required": ["from"],
           "properties": {
             "from": {
-              "type": "string",
-              "enum": ["off", "non_admins", "everyone"]
+              "$ref": "common/branch-protection-rule-enforcement-level.schema.json"
             }
           },
           "additionalProperties": false
@@ -145,8 +170,7 @@
           "required": ["from"],
           "properties": {
             "from": {
-              "type": "string",
-              "enum": ["off", "non_admins", "everyone"]
+              "$ref": "common/branch-protection-rule-enforcement-level.schema.json"
             }
           },
           "additionalProperties": false

--- a/payload-schemas/api.github.com/branch_protection_rule/edited.schema.json
+++ b/payload-schemas/api.github.com/branch_protection_rule/edited.schema.json
@@ -112,7 +112,11 @@
         "required_approving_review_count": {
           "type": "object",
           "required": ["from"],
-          "properties": { "from": { "$ref": "common/branch-protection-rule-number.schema.json" } },
+          "properties": {
+            "from": {
+              "$ref": "common/branch-protection-rule-number.schema.json"
+            }
+          },
           "additionalProperties": false
         },
         "required_conversation_resolution_level": {

--- a/payload-schemas/api.github.com/common/branch-protection-rule-array.schema.json
+++ b/payload-schemas/api.github.com/common/branch-protection-rule-array.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "common/branch-protection-rule-array.schema.json",
+  "type": "array",
+  "items": { "type": "string" },
+  "title": "Branch Protection Rule Array"
+}

--- a/payload-schemas/api.github.com/common/branch-protection-rule-boolean.schema.json
+++ b/payload-schemas/api.github.com/common/branch-protection-rule-boolean.schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "common/branch-protection-rule-boolean.schema.json",
+  "type": "boolean",
+  "title": "Branch protection rule boolean"
+}

--- a/payload-schemas/api.github.com/common/branch-protection-rule-enforcement-level.schema.json
+++ b/payload-schemas/api.github.com/common/branch-protection-rule-enforcement-level.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "common/branch-protection-rule-enforcement-level.schema.json",
+  "type": "string",
+  "enum": ["off", "non_admins", "everyone"],
+  "title": "Branch protection rule enforcement level"
+}

--- a/payload-schemas/api.github.com/common/branch-protection-rule-number.schema.json
+++ b/payload-schemas/api.github.com/common/branch-protection-rule-number.schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "common/branch-protection-rule-number.schema.json",
+  "type": "integer",
+  "title": "Branch protection rule number"
+}

--- a/payload-schemas/api.github.com/common/branch-protection-rule.schema.json
+++ b/payload-schemas/api.github.com/common/branch-protection-rule.schema.json
@@ -38,7 +38,9 @@
     "pull_request_reviews_enforcement_level": {
       "$ref": "branch-protection-rule-enforcement-level.schema.json"
     },
-    "required_approving_review_count": { "$ref": "branch-protection-rule-number.schema.json" },
+    "required_approving_review_count": {
+      "$ref": "branch-protection-rule-number.schema.json"
+    },
     "dismiss_stale_reviews_on_push": {
       "$ref": "branch-protection-rule-boolean.schema.json"
     },

--- a/payload-schemas/api.github.com/common/branch-protection-rule.schema.json
+++ b/payload-schemas/api.github.com/common/branch-protection-rule.schema.json
@@ -36,55 +36,63 @@
     "created_at": { "type": "string", "format": "date-time" },
     "updated_at": { "type": "string", "format": "date-time" },
     "pull_request_reviews_enforcement_level": {
-      "type": "string",
-      "enum": ["off", "non_admins", "everyone"]
+      "$ref": "branch-protection-rule-enforcement-level.schema.json"
     },
-    "required_approving_review_count": { "type": "integer" },
-    "dismiss_stale_reviews_on_push": { "type": "boolean" },
-    "require_code_owner_review": { "type": "boolean" },
-    "authorized_dismissal_actors_only": { "type": "boolean" },
-    "ignore_approvals_from_contributors": { "type": "boolean" },
+    "required_approving_review_count": { "$ref": "branch-protection-rule-number.schema.json" },
+    "dismiss_stale_reviews_on_push": {
+      "$ref": "branch-protection-rule-boolean.schema.json"
+    },
+    "require_code_owner_review": {
+      "$ref": "branch-protection-rule-boolean.schema.json"
+    },
+    "authorized_dismissal_actors_only": {
+      "$ref": "branch-protection-rule-boolean.schema.json"
+    },
+    "ignore_approvals_from_contributors": {
+      "$ref": "branch-protection-rule-boolean.schema.json"
+    },
     "required_status_checks": {
-      "type": "array",
-      "items": { "type": "string" }
+      "$ref": "branch-protection-rule-array.schema.json"
     },
     "required_status_checks_enforcement_level": {
-      "type": "string",
-      "enum": ["off", "non_admins", "everyone"]
+      "$ref": "branch-protection-rule-enforcement-level.schema.json"
     },
-    "strict_required_status_checks_policy": { "type": "boolean" },
+    "strict_required_status_checks_policy": {
+      "$ref": "branch-protection-rule-boolean.schema.json"
+    },
     "signature_requirement_enforcement_level": {
-      "type": "string",
-      "enum": ["off", "non_admins", "everyone"]
+      "$ref": "branch-protection-rule-enforcement-level.schema.json"
     },
     "linear_history_requirement_enforcement_level": {
-      "type": "string",
-      "enum": ["off", "non_admins", "everyone"]
+      "$ref": "branch-protection-rule-enforcement-level.schema.json"
     },
-    "admin_enforced": { "type": "boolean" },
-    "create_protected": { "type": "boolean" },
+    "admin_enforced": {
+      "$ref": "branch-protection-rule-boolean.schema.json"
+    },
+    "create_protected": {
+      "$ref": "branch-protection-rule-boolean.schema.json"
+    },
     "allow_force_pushes_enforcement_level": {
-      "type": "string",
-      "enum": ["off", "non_admins", "everyone"]
+      "$ref": "branch-protection-rule-enforcement-level.schema.json"
     },
     "allow_deletions_enforcement_level": {
-      "type": "string",
-      "enum": ["off", "non_admins", "everyone"]
+      "$ref": "branch-protection-rule-enforcement-level.schema.json"
     },
     "merge_queue_enforcement_level": {
-      "type": "string",
-      "enum": ["off", "non_admins", "everyone"]
+      "$ref": "branch-protection-rule-enforcement-level.schema.json"
     },
     "required_deployments_enforcement_level": {
-      "type": "string",
-      "enum": ["off", "non_admins", "everyone"]
+      "$ref": "branch-protection-rule-enforcement-level.schema.json"
     },
     "required_conversation_resolution_level": {
-      "type": "string",
-      "enum": ["off", "non_admins", "everyone"]
+      "$ref": "branch-protection-rule-enforcement-level.schema.json"
     },
-    "authorized_actors_only": { "type": "boolean" },
-    "authorized_actor_names": { "type": "array", "items": { "type": "string" } }
+    "authorized_actors_only": {
+      "$ref": "branch-protection-rule-boolean.schema.json"
+    },
+    "authorized_actor_names": {
+      "$ref": "branch-protection-rule-array.schema.json"
+    }
   },
   "additionalProperties": false,
   "title": "branch protection rule"

--- a/payload-types/schema.d.ts
+++ b/payload-types/schema.d.ts
@@ -67,6 +67,13 @@ export type BranchProtectionRuleEvent =
   | BranchProtectionRuleCreatedEvent
   | BranchProtectionRuleDeletedEvent
   | BranchProtectionRuleEditedEvent;
+export type BranchProtectionRuleEnforcementLevel =
+  | "off"
+  | "non_admins"
+  | "everyone";
+export type BranchProtectionRuleNumber = number;
+export type BranchProtectionRuleBoolean = boolean;
+export type BranchProtectionRuleArray = string[];
 export type CheckRunEvent =
   | CheckRunCompletedEvent
   | CheckRunCreatedEvent
@@ -417,29 +424,26 @@ export interface BranchProtectionRule {
   name: string;
   created_at: string;
   updated_at: string;
-  pull_request_reviews_enforcement_level: "off" | "non_admins" | "everyone";
-  required_approving_review_count: number;
-  dismiss_stale_reviews_on_push: boolean;
-  require_code_owner_review: boolean;
-  authorized_dismissal_actors_only: boolean;
-  ignore_approvals_from_contributors: boolean;
-  required_status_checks: string[];
-  required_status_checks_enforcement_level: "off" | "non_admins" | "everyone";
-  strict_required_status_checks_policy: boolean;
-  signature_requirement_enforcement_level: "off" | "non_admins" | "everyone";
-  linear_history_requirement_enforcement_level:
-    | "off"
-    | "non_admins"
-    | "everyone";
-  admin_enforced: boolean;
-  create_protected?: boolean;
-  allow_force_pushes_enforcement_level: "off" | "non_admins" | "everyone";
-  allow_deletions_enforcement_level: "off" | "non_admins" | "everyone";
-  merge_queue_enforcement_level: "off" | "non_admins" | "everyone";
-  required_deployments_enforcement_level: "off" | "non_admins" | "everyone";
-  required_conversation_resolution_level: "off" | "non_admins" | "everyone";
-  authorized_actors_only: boolean;
-  authorized_actor_names: string[];
+  pull_request_reviews_enforcement_level: BranchProtectionRuleEnforcementLevel;
+  required_approving_review_count: BranchProtectionRuleNumber;
+  dismiss_stale_reviews_on_push: BranchProtectionRuleBoolean;
+  require_code_owner_review: BranchProtectionRuleBoolean;
+  authorized_dismissal_actors_only: BranchProtectionRuleBoolean;
+  ignore_approvals_from_contributors: BranchProtectionRuleBoolean;
+  required_status_checks: BranchProtectionRuleArray;
+  required_status_checks_enforcement_level: BranchProtectionRuleEnforcementLevel;
+  strict_required_status_checks_policy: BranchProtectionRuleBoolean;
+  signature_requirement_enforcement_level: BranchProtectionRuleEnforcementLevel;
+  linear_history_requirement_enforcement_level: BranchProtectionRuleEnforcementLevel;
+  admin_enforced: BranchProtectionRuleBoolean;
+  create_protected?: BranchProtectionRuleBoolean;
+  allow_force_pushes_enforcement_level: BranchProtectionRuleEnforcementLevel;
+  allow_deletions_enforcement_level: BranchProtectionRuleEnforcementLevel;
+  merge_queue_enforcement_level: BranchProtectionRuleEnforcementLevel;
+  required_deployments_enforcement_level: BranchProtectionRuleEnforcementLevel;
+  required_conversation_resolution_level: BranchProtectionRuleEnforcementLevel;
+  authorized_actors_only: BranchProtectionRuleBoolean;
+  authorized_actor_names: BranchProtectionRuleArray;
 }
 /**
  * A git repository
@@ -792,52 +796,52 @@ export interface BranchProtectionRuleEditedEvent {
    */
   changes?: {
     admin_enforced?: {
-      from: boolean;
+      from: BranchProtectionRuleBoolean;
     };
     allow_deletions_enforcement_level?: {
-      from: ("off" | "non_admins" | "everyone") | null;
+      from: BranchProtectionRuleEnforcementLevel | null;
     };
     allow_force_pushes_enforcement_level?: {
-      from: "off" | "non_admins" | "everyone";
+      from: BranchProtectionRuleEnforcementLevel;
     };
     authorized_actors_only?: {
-      from: boolean;
+      from: BranchProtectionRuleBoolean;
     };
     authorized_actor_names?: {
-      from: string[];
+      from: BranchProtectionRuleArray;
     };
     authorized_dismissal_actors_only?: {
-      from: boolean | null;
+      from: BranchProtectionRuleBoolean | null;
     };
     dismiss_stale_reviews_on_push?: {
-      from: boolean;
+      from: BranchProtectionRuleBoolean;
     };
     pull_request_reviews_enforcement_level?: {
-      from: "off" | "non_admins" | "everyone";
+      from: BranchProtectionRuleEnforcementLevel;
     };
     require_code_owner_review?: {
-      from: boolean;
+      from: BranchProtectionRuleBoolean;
     };
     required_approving_review_count?: {
-      from: number;
+      from: BranchProtectionRuleNumber;
     };
     required_conversation_resolution_level?: {
-      from: "off" | "non_admins" | "everyone";
+      from: BranchProtectionRuleEnforcementLevel;
     };
     required_deployments_enforcement_level?: {
-      from: "off" | "non_admins" | "everyone";
+      from: BranchProtectionRuleEnforcementLevel;
     };
     required_status_checks?: {
-      from: string[];
+      from: BranchProtectionRuleArray;
     };
     required_status_checks_enforcement_level?: {
-      from: "off" | "non_admins" | "everyone";
+      from: BranchProtectionRuleEnforcementLevel;
     };
     signature_requirement_enforcement_level?: {
-      from: "off" | "non_admins" | "everyone";
+      from: BranchProtectionRuleEnforcementLevel;
     };
     linear_history_requirement_enforcement_level?: {
-      from: "off" | "non_admins" | "everyone";
+      from: BranchProtectionRuleEnforcementLevel;
     };
   };
   repository: Repository;


### PR DESCRIPTION
https://github.com/octokit/webhooks/issues/689#issuecomment-1211422677