### PR TITLE
Update wont_fix typo in secret_scanning_alert

### DIFF
--- a/payload-schemas/api.github.com/secret_scanning_alert/resolved.schema.json
+++ b/payload-schemas/api.github.com/secret_scanning_alert/resolved.schema.json
@@ -14,7 +14,7 @@
           "properties": {
             "resolution": {
               "type": "string",
-              "enum": ["false_positive", "wontfix", "revoked", "used_in_tests"]
+              "enum": ["false_positive", "wont_fix", "revoked", "used_in_tests"]
             },
             "resolved_by": { "$ref": "common/user.schema.json" },
             "resolved_at": { "type": "string", "format": "date-time" }

--- a/payload-types/schema.d.ts
+++ b/payload-types/schema.d.ts
@@ -7199,7 +7199,7 @@ export interface SecretScanningAlertReopenedEvent {
 export interface SecretScanningAlertResolvedEvent {
   action: "resolved";
   alert: SecretScanningAlert & {
-    resolution: "false_positive" | "wontfix" | "revoked" | "used_in_tests";
+    resolution: "false_positive" | "wont_fix" | "revoked" | "used_in_tests";
     resolved_by: User;
     resolved_at: string;
   };


### PR DESCRIPTION
Resolves #806 

Makes the resolved schema consistent with the schema it inherits from ( https://github.com/octokit/webhooks/blob/a5c455c39903cfc033d4c7a0ee0dc6476aa60a2d/payload-schemas/api.github.com/common/secret-scanning-alert.schema.json#L61 ) 

Bugfix: Type: Bug