### PR TITLE
fix: declare pull_request auto_merge properties as string|null

### DIFF
--- a/payload-schemas/api.github.com/common/auto-merge.schema.json
+++ b/payload-schemas/api.github.com/common/auto-merge.schema.json
@@ -4,18 +4,18 @@
   "type": "object",
   "required": ["enabled_by", "merge_method", "commit_title", "commit_message"],
   "properties": {
-    "enabled_by": { "$ref": "user.schema.json" },
+    "enabled_by": { "oneOf": [{ "$ref": "user.schema.json" }, { "type": "null" }] },
     "merge_method": {
       "type": "string",
       "enum": ["merge", "squash", "rebase"],
       "description": "The merge method to use."
     },
     "commit_title": {
-      "type": "string",
+      "type": ["string", "null"],
       "description": "Title for the merge commit message."
     },
     "commit_message": {
-      "type": "string",
+      "type": ["string", "null"],
       "description": "Commit message for the merge commit."
     }
   },

--- a/payload-schemas/api.github.com/common/auto-merge.schema.json
+++ b/payload-schemas/api.github.com/common/auto-merge.schema.json
@@ -4,7 +4,9 @@
   "type": "object",
   "required": ["enabled_by", "merge_method", "commit_title", "commit_message"],
   "properties": {
-    "enabled_by": { "oneOf": [{ "$ref": "user.schema.json" }, { "type": "null" }] },
+    "enabled_by": {
+      "oneOf": [{ "$ref": "user.schema.json" }, { "type": "null" }]
+    },
     "merge_method": {
       "type": "string",
       "enum": ["merge", "squash", "rebase"],

--- a/payload-types/schema.d.ts
+++ b/payload-types/schema.d.ts
@@ -3008,7 +3008,7 @@ export interface Link {
  * The status of auto merging a pull request.
  */
 export interface PullRequestAutoMerge {
-  enabled_by: User;
+  enabled_by: User | null;
   /**
    * The merge method to use.
    */
@@ -3016,11 +3016,11 @@ export interface PullRequestAutoMerge {
   /**
    * Title for the merge commit message.
    */
-  commit_title: string;
+  commit_title: string | null;
   /**
    * Commit message for the merge commit.
    */
-  commit_message: string;
+  commit_message: string | null;
 }
 export interface DeploymentReviewApprovedEvent {
   action: "approved";


### PR DESCRIPTION
See: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #828

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The properties `enabled_by`, `commit_title` and `commit_message` did not allow null

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The properties `enabled_by`, `commit_title` and `commit_message` are nullable

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

