### PR TITLE
Update opened.schema.json

### DIFF
--- a/payload-schemas/api.github.com/issues/opened.schema.json
+++ b/payload-schemas/api.github.com/issues/opened.schema.json
@@ -22,7 +22,7 @@
           "required": ["state", "closed_at"],
           "properties": {
             "state": { "type": "string", "enum": ["open"] },
-            "closed_at": { "type": "null" }
+            "closed_at": { "type": ["string", "null"] }
           },
           "tsAdditionalProperties": false
         }


### PR DESCRIPTION
Fix congruence with:


https://github.com/octokit/webhooks/blob/7e61eaa06955106f224b90a5eccbd1f9ecf9c721/payload-schemas/api.github.com/issues/opened.schema.json#L25C36-L25C37

"type": ["string", "null"] VS "type": "null"

error TS2339: Property 'title' does not exist on type 'never'.
  The intersection 'Issue & { state: "open"; closed_at: null; }' was reduced to 'never' because property 'closed_at' has conflicting types in some constituents.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #879

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

![Captura desde 2024-01-10 03-56-11](https://github.com/octokit/webhooks/assets/2866454/23260e58-737c-499f-be2c-ef36b1f7ed45)

