### PR TITLE
feat(schemas): added schema for the `merge_group` destroyed event

### DIFF
--- a/payload-schemas/api.github.com/merge_group/destroyed.schema.json
+++ b/payload-schemas/api.github.com/merge_group/destroyed.schema.json
@@ -1,83 +1,86 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "merge_group$destroyed",
-    "type": "object",
-    "required": ["action", "merge_group", "reason", "repository", "sender"],
-    "properties": {
-      "action": { "type": "string", "enum": ["destroyed"] },
-      "merge_group": {
-        "type": "object",
-        "description": "The merge group.",
-        "required": [
-          "head_sha",
-          "head_ref",
-          "base_ref",
-          "base_sha",
-          "head_commit"
-        ],
-        "properties": {
-          "head_sha": {
-            "type": "string",
-            "description": "The SHA of the merge group."
-          },
-          "head_ref": {
-            "type": "string",
-            "description": "The full ref of the merge group."
-          },
-          "base_ref": {
-            "type": "string",
-            "description": "The full ref of the branch the merge group will be merged into."
-          },
-          "base_sha": {
-            "type": "string",
-            "description": "The SHA of the merge group's parent commit."
-          },
-          "head_commit": {
-            "type": "object",
-            "description": "An expanded representation of the `head_sha` commit.",
-            "required": [
-              "id",
-              "tree_id",
-              "message",
-              "timestamp",
-              "author",
-              "committer"
-            ],
-            "properties": {
-              "id": { "type": "string" },
-              "tree_id": { "type": "string" },
-              "message": { "type": "string" },
-              "timestamp": { "type": "string", "format": "date-time" },
-              "author": {
-                "type": "object",
-                "required": ["name", "email"],
-                "properties": {
-                  "name": { "type": "string" },
-                  "email": { "type": "string" }
-                },
-                "additionalProperties": false
-              },
-              "committer": {
-                "type": "object",
-                "required": ["name", "email"],
-                "properties": {
-                  "name": { "type": "string" },
-                  "email": { "type": "string" }
-                },
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "merge_group$destroyed",
+  "type": "object",
+  "required": ["action", "merge_group", "reason", "repository", "sender"],
+  "properties": {
+    "action": { "type": "string", "enum": ["destroyed"] },
+    "merge_group": {
+      "type": "object",
+      "description": "The merge group.",
+      "required": [
+        "head_sha",
+        "head_ref",
+        "base_ref",
+        "base_sha",
+        "head_commit"
+      ],
+      "properties": {
+        "head_sha": {
+          "type": "string",
+          "description": "The SHA of the merge group."
         },
-        "additionalProperties": false
+        "head_ref": {
+          "type": "string",
+          "description": "The full ref of the merge group."
+        },
+        "base_ref": {
+          "type": "string",
+          "description": "The full ref of the branch the merge group will be merged into."
+        },
+        "base_sha": {
+          "type": "string",
+          "description": "The SHA of the merge group's parent commit."
+        },
+        "head_commit": {
+          "type": "object",
+          "description": "An expanded representation of the `head_sha` commit.",
+          "required": [
+            "id",
+            "tree_id",
+            "message",
+            "timestamp",
+            "author",
+            "committer"
+          ],
+          "properties": {
+            "id": { "type": "string" },
+            "tree_id": { "type": "string" },
+            "message": { "type": "string" },
+            "timestamp": { "type": "string", "format": "date-time" },
+            "author": {
+              "type": "object",
+              "required": ["name", "email"],
+              "properties": {
+                "name": { "type": "string" },
+                "email": { "type": "string" }
+              },
+              "additionalProperties": false
+            },
+            "committer": {
+              "type": "object",
+              "required": ["name", "email"],
+              "properties": {
+                "name": { "type": "string" },
+                "email": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
       },
-      "reason": { "type": "string", "enum": ["dequeued", "invalidated", "merged"] },
-      "repository": { "$ref": "common/repository.schema.json" },
-      "sender": { "$ref": "common/user.schema.json" },
-      "installation": { "$ref": "common/installation-lite.schema.json" },
-      "organization": { "$ref": "common/organization.schema.json" }
+      "additionalProperties": false
     },
-    "additionalProperties": false,
-    "title": "merge group destroyed event"
-  }
+    "reason": {
+      "type": "string",
+      "enum": ["dequeued", "invalidated", "merged"]
+    },
+    "repository": { "$ref": "common/repository.schema.json" },
+    "sender": { "$ref": "common/user.schema.json" },
+    "installation": { "$ref": "common/installation-lite.schema.json" },
+    "organization": { "$ref": "common/organization.schema.json" }
+  },
+  "additionalProperties": false,
+  "title": "merge group destroyed event"
+}

--- a/payload-schemas/api.github.com/merge_group/destroyed.schema.json
+++ b/payload-schemas/api.github.com/merge_group/destroyed.schema.json
@@ -1,0 +1,83 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "merge_group$destroyed",
+    "type": "object",
+    "required": ["action", "merge_group", "repository", "sender"],
+    "properties": {
+      "action": { "type": "string", "enum": ["destroyed"] },
+      "merge_group": {
+        "type": "object",
+        "description": "The merge group.",
+        "required": [
+          "head_sha",
+          "head_ref",
+          "base_ref",
+          "base_sha",
+          "head_commit"
+        ],
+        "properties": {
+          "head_sha": {
+            "type": "string",
+            "description": "The SHA of the merge group."
+          },
+          "head_ref": {
+            "type": "string",
+            "description": "The full ref of the merge group."
+          },
+          "base_ref": {
+            "type": "string",
+            "description": "The full ref of the branch the merge group will be merged into."
+          },
+          "base_sha": {
+            "type": "string",
+            "description": "The SHA of the merge group's parent commit."
+          },
+          "head_commit": {
+            "type": "object",
+            "description": "An expanded representation of the `head_sha` commit.",
+            "required": [
+              "id",
+              "tree_id",
+              "message",
+              "timestamp",
+              "author",
+              "committer"
+            ],
+            "properties": {
+              "id": { "type": "string" },
+              "tree_id": { "type": "string" },
+              "message": { "type": "string" },
+              "timestamp": { "type": "string", "format": "date-time" },
+              "author": {
+                "type": "object",
+                "required": ["name", "email"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "email": { "type": "string" }
+                },
+                "additionalProperties": false
+              },
+              "committer": {
+                "type": "object",
+                "required": ["name", "email"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "email": { "type": "string" }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "reason": { "type": "string", "enum": ["dequeued", "invalidated", "merged"] },
+      "repository": { "$ref": "common/repository.schema.json" },
+      "sender": { "$ref": "common/user.schema.json" },
+      "installation": { "$ref": "common/installation-lite.schema.json" },
+      "organization": { "$ref": "common/organization.schema.json" }
+    },
+    "additionalProperties": false,
+    "title": "merge group destroyed event"
+  }

--- a/payload-schemas/api.github.com/merge_group/destroyed.schema.json
+++ b/payload-schemas/api.github.com/merge_group/destroyed.schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "merge_group$destroyed",
     "type": "object",
-    "required": ["action", "merge_group", "repository", "sender"],
+    "required": ["action", "merge_group", "reason", "repository", "sender"],
     "properties": {
       "action": { "type": "string", "enum": ["destroyed"] },
       "merge_group": {

--- a/payload-types/schema.d.ts
+++ b/payload-types/schema.d.ts
@@ -199,7 +199,9 @@ export type MemberEvent =
   | MemberEditedEvent
   | MemberRemovedEvent;
 export type MembershipEvent = MembershipAddedEvent | MembershipRemovedEvent;
-export type MergeGroupEvent = MergeGroupChecksRequestedEvent;
+export type MergeGroupEvent =
+  | MergeGroupChecksRequestedEvent
+  | MergeGroupDestroyedEvent;
 export type MetaEvent = MetaDeletedEvent;
 export type WebhookEvents =
   | (
@@ -5156,6 +5158,52 @@ export interface MergeGroupChecksRequestedEvent {
       };
     };
   };
+  repository: Repository;
+  sender: User;
+  installation?: InstallationLite;
+  organization?: Organization;
+}
+export interface MergeGroupDestroyedEvent {
+  action: "destroyed";
+  /**
+   * The merge group.
+   */
+  merge_group: {
+    /**
+     * The SHA of the merge group.
+     */
+    head_sha: string;
+    /**
+     * The full ref of the merge group.
+     */
+    head_ref: string;
+    /**
+     * The full ref of the branch the merge group will be merged into.
+     */
+    base_ref: string;
+    /**
+     * The SHA of the merge group's parent commit.
+     */
+    base_sha: string;
+    /**
+     * An expanded representation of the `head_sha` commit.
+     */
+    head_commit: {
+      id: string;
+      tree_id: string;
+      message: string;
+      timestamp: string;
+      author: {
+        name: string;
+        email: string;
+      };
+      committer: {
+        name: string;
+        email: string;
+      };
+    };
+  };
+  reason: "dequeued" | "invalidated" | "merged";
   repository: Repository;
   sender: User;
   installation?: InstallationLite;


### PR DESCRIPTION
### Before the change?

* The schema for the `merge_group` [destroyed](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=destroyed#merge_group) event was not present.

### After the change?

* The schema for the `merge_group` destroyed event is present.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

