### PR TITLE
fix: remove custom_properties from required fields in repository schema

### DIFF
--- a/payload-schemas/api.github.com/common/repository.schema.json
+++ b/payload-schemas/api.github.com/common/repository.schema.json
@@ -79,8 +79,7 @@
     "is_template",
     "web_commit_signoff_required",
     "topics",
-    "visibility",
-    "custom_properties"
+    "visibility"
   ],
   "properties": {
     "id": {


### PR DESCRIPTION
## Summary

Removes `custom_properties` from the `required` array in the repository JSON schema.

## Problem

The `repository.schema.json` marks `custom_properties` as a required field, but GitHub webhook payloads for pull_request events don't always include it. This causes validation errors with strict JSON schema validators:

```
Error("missing field `custom_properties`", line: 195, column: 17)
```

The field is still defined in `properties` (as optional), just no longer required.

## Changes

- `payload-schemas/api.github.com/common/repository.schema.json`: Removed `custom_properties` from the `required` array

## Testing

- Existing tests pass
- The field remains available in `properties` for when it is present

Fixes #911